### PR TITLE
feat(proxy): Add HTTPS support to routing proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,27 @@ agent run --name myapp ./project
 
 ### Accessing Services
 
-Services are available via hostname routing:
+Services are available via HTTPS hostname routing:
 
 ```
-http://web.myapp.localhost:8080  → container port 3000
-http://api.myapp.localhost:8080  → container port 8080
-http://myapp.localhost:8080      → default service (first in config)
+https://web.myapp.localhost:8080  → container port 3000
+https://api.myapp.localhost:8080  → container port 8080
+https://myapp.localhost:8080      → default service (first in config)
+```
+
+The proxy supports both HTTP and HTTPS on the same port, with HTTPS enabled by default using a locally-generated CA certificate.
+
+**Trusting the CA certificate** (to avoid browser/curl warnings):
+
+```bash
+# macOS
+sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ~/.agentops/proxy/ca/ca.crt
+
+# Linux
+sudo cp ~/.agentops/proxy/ca/ca.crt /usr/local/share/ca-certificates/agentops.crt && sudo update-ca-certificates
+
+# Or use curl with --cacert
+curl --cacert ~/.agentops/proxy/ca/ca.crt https://web.myapp.localhost:8080
 ```
 
 The proxy binds to port 8080 by default. Configure globally in `~/.agentops/config.yaml`:
@@ -340,7 +355,7 @@ agent destroy [run-id]
 
 ### `agent proxy`
 
-Manage the hostname-based routing proxy. By default, the proxy starts automatically when needed and stops when the last agent exits. Use these commands to run it as a standalone daemon.
+Manage the hostname-based routing proxy. The proxy supports both HTTP and HTTPS on a single port, using auto-generated certificates signed by a local CA. By default, the proxy starts automatically when needed and stops when the last agent exits. Use these commands to run it as a standalone daemon.
 
 ```bash
 # Start proxy on default port (8080)
@@ -355,6 +370,8 @@ agent proxy status
 # Stop proxy
 agent proxy stop
 ```
+
+On first start, the proxy generates a CA certificate at `~/.agentops/proxy/ca/ca.crt`. Trust this certificate to avoid browser warnings (see "Accessing Services" above).
 
 Running the proxy separately is useful when you need privileged ports (like 80) since agents can then run without sudo.
 

--- a/cmd/agent/cli/run.go
+++ b/cmd/agent/cli/run.go
@@ -204,7 +204,7 @@ func runAgent(cmd *cobra.Command, args []string) error {
 
 		fmt.Println("Services:")
 		for serviceName, containerPort := range r.Ports {
-			url := fmt.Sprintf("http://%s.%s.localhost:%d", serviceName, r.Name, proxyPort)
+			url := fmt.Sprintf("https://%s.%s.localhost:%d", serviceName, r.Name, proxyPort)
 			fmt.Printf("  %s: %s (container :%d)\n", serviceName, url, containerPort)
 		}
 	}

--- a/internal/routing/conn.go
+++ b/internal/routing/conn.go
@@ -1,0 +1,31 @@
+package routing
+
+import (
+	"bufio"
+	"net"
+)
+
+// bufferedConn wraps a net.Conn with a bufio.Reader to allow peeking
+// at the initial bytes without consuming them.
+type bufferedConn struct {
+	net.Conn
+	r *bufio.Reader
+}
+
+// newBufferedConn wraps a connection with buffering for peeking.
+func newBufferedConn(c net.Conn) *bufferedConn {
+	return &bufferedConn{
+		Conn: c,
+		r:    bufio.NewReader(c),
+	}
+}
+
+// Peek returns the next n bytes without advancing the reader.
+func (bc *bufferedConn) Peek(n int) ([]byte, error) {
+	return bc.r.Peek(n)
+}
+
+// Read reads data from the connection, including any buffered bytes.
+func (bc *bufferedConn) Read(b []byte) (int, error) {
+	return bc.r.Read(b)
+}

--- a/internal/routing/conn_test.go
+++ b/internal/routing/conn_test.go
@@ -1,0 +1,80 @@
+package routing
+
+import (
+	"bytes"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// mockConn implements net.Conn for testing
+type mockConn struct {
+	readBuf  *bytes.Buffer
+	writeBuf *bytes.Buffer
+}
+
+func newMockConn(data []byte) *mockConn {
+	return &mockConn{
+		readBuf:  bytes.NewBuffer(data),
+		writeBuf: &bytes.Buffer{},
+	}
+}
+
+func (m *mockConn) Read(b []byte) (int, error)         { return m.readBuf.Read(b) }
+func (m *mockConn) Write(b []byte) (int, error)        { return m.writeBuf.Write(b) }
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) LocalAddr() net.Addr                { return nil }
+func (m *mockConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func TestBufferedConn(t *testing.T) {
+	data := []byte("hello world")
+	mock := newMockConn(data)
+
+	bc := newBufferedConn(mock)
+
+	// Peek first byte
+	peeked, err := bc.Peek(1)
+	if err != nil {
+		t.Fatalf("Peek: %v", err)
+	}
+	if peeked[0] != 'h' {
+		t.Errorf("Peeked = %q, want 'h'", peeked[0])
+	}
+
+	// Read all - should include the peeked byte
+	all, err := io.ReadAll(bc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if string(all) != "hello world" {
+		t.Errorf("ReadAll = %q, want 'hello world'", all)
+	}
+}
+
+func TestBufferedConnDetectTLS(t *testing.T) {
+	// TLS handshake starts with 0x16 (handshake record type)
+	tlsData := []byte{0x16, 0x03, 0x01, 0x00, 0x05}
+	mock := newMockConn(tlsData)
+	bc := newBufferedConn(mock)
+
+	peeked, _ := bc.Peek(1)
+	if peeked[0] != 0x16 {
+		t.Errorf("TLS detection failed: got %x, want 0x16", peeked[0])
+	}
+}
+
+func TestBufferedConnDetectHTTP(t *testing.T) {
+	// HTTP request starts with method (GET, POST, etc.)
+	httpData := []byte("GET / HTTP/1.1\r\n")
+	mock := newMockConn(httpData)
+	bc := newBufferedConn(mock)
+
+	peeked, _ := bc.Peek(1)
+	if peeked[0] != 'G' {
+		t.Errorf("HTTP detection failed: got %c, want 'G'", peeked[0])
+	}
+}

--- a/internal/routing/mux.go
+++ b/internal/routing/mux.go
@@ -1,0 +1,103 @@
+package routing
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/andybons/agentops/internal/log"
+)
+
+const (
+	protoTLS  = "tls"
+	protoHTTP = "http"
+)
+
+// detectProtocol peeks at the first byte to determine TLS vs HTTP.
+// TLS handshake records start with 0x16 (ContentType handshake).
+func detectProtocol(bc *bufferedConn) string {
+	// Set a deadline for the peek to avoid hanging on slow clients
+	_ = bc.SetReadDeadline(time.Now().Add(5 * time.Second))
+	defer func() { _ = bc.SetReadDeadline(time.Time{}) }()
+
+	b, err := bc.Peek(1)
+	if err != nil || len(b) == 0 {
+		// Default to HTTP on error (will fail gracefully)
+		return protoHTTP
+	}
+
+	if b[0] == 0x16 {
+		return protoTLS
+	}
+	return protoHTTP
+}
+
+// muxListener wraps a net.Listener to multiplex TLS and HTTP connections.
+type muxListener struct {
+	net.Listener
+	tlsConfig *tls.Config
+	handler   http.Handler
+}
+
+// newMuxListener creates a multiplexing listener.
+func newMuxListener(ln net.Listener, tlsConfig *tls.Config, handler http.Handler) *muxListener {
+	return &muxListener{
+		Listener:  ln,
+		tlsConfig: tlsConfig,
+		handler:   handler,
+	}
+}
+
+// serve accepts connections and handles them based on detected protocol.
+func (ml *muxListener) serve() error {
+	for {
+		conn, err := ml.Accept()
+		if err != nil {
+			return err
+		}
+		go ml.handleConn(conn)
+	}
+}
+
+func (ml *muxListener) handleConn(conn net.Conn) {
+	bc := newBufferedConn(conn)
+	proto := detectProtocol(bc)
+
+	var netConn net.Conn = bc
+
+	if proto == protoTLS {
+		tlsConn := tls.Server(bc, ml.tlsConfig)
+		if err := tlsConn.Handshake(); err != nil {
+			log.Debug("TLS handshake failed", "remote", conn.RemoteAddr(), "error", err)
+			conn.Close()
+			return
+		}
+		netConn = tlsConn
+	}
+
+	// Create a single-connection listener to use with http.Serve
+	scl := &singleConnListener{conn: netConn}
+	server := &http.Server{
+		Handler:           ml.handler,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	_ = server.Serve(scl)
+}
+
+// singleConnListener is a net.Listener that returns a single connection then closes.
+type singleConnListener struct {
+	conn net.Conn
+	done bool
+}
+
+func (scl *singleConnListener) Accept() (net.Conn, error) {
+	if scl.done {
+		return nil, net.ErrClosed
+	}
+	scl.done = true
+	return scl.conn, nil
+}
+
+func (scl *singleConnListener) Close() error   { return nil }
+func (scl *singleConnListener) Addr() net.Addr { return scl.conn.LocalAddr() }

--- a/internal/routing/mux_test.go
+++ b/internal/routing/mux_test.go
@@ -1,0 +1,98 @@
+package routing
+
+import (
+	"net"
+	"sync"
+	"testing"
+)
+
+func TestMuxDetectsTLS(t *testing.T) {
+	// Create a listener
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	var detected string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Accept one connection and detect protocol
+	go func() {
+		defer wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		bc := newBufferedConn(conn)
+		proto := detectProtocol(bc)
+
+		mu.Lock()
+		detected = proto
+		mu.Unlock()
+	}()
+
+	// Connect and send TLS handshake byte
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	conn.Write([]byte{0x16, 0x03, 0x01}) // TLS handshake
+	conn.Close()
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if detected != "tls" {
+		t.Errorf("Protocol = %q, want 'tls'", detected)
+	}
+}
+
+func TestMuxDetectsHTTP(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+
+	var detected string
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		bc := newBufferedConn(conn)
+		proto := detectProtocol(bc)
+
+		mu.Lock()
+		detected = proto
+		mu.Unlock()
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	conn.Write([]byte("GET / HTTP/1.1\r\n"))
+	conn.Close()
+
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if detected != "http" {
+		t.Errorf("Protocol = %q, want 'http'", detected)
+	}
+}

--- a/internal/routing/proxy_test.go
+++ b/internal/routing/proxy_test.go
@@ -1,10 +1,16 @@
 package routing
 
 import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/andybons/agentops/internal/proxy"
 )
 
 func TestReverseProxy(t *testing.T) {
@@ -80,5 +86,180 @@ func TestReverseProxyDefaultService(t *testing.T) {
 
 	if rec.Code != http.StatusOK {
 		t.Errorf("Status = %d, want 200", rec.Code)
+	}
+}
+
+func TestProxyServerWithTLS(t *testing.T) {
+	// Create a backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("secure backend"))
+	}))
+	defer backend.Close()
+
+	// Create route table with backend
+	dir := t.TempDir()
+	routes, _ := NewRouteTable(dir)
+	routes.Add("myapp", map[string]string{
+		"web": backend.Listener.Addr().String(),
+	})
+
+	// Create CA for TLS
+	caDir := t.TempDir()
+	ca, err := proxy.NewCA(caDir)
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+
+	// Create proxy server with TLS enabled
+	ps := NewProxyServer(routes)
+	ps.EnableTLS(ca)
+	if err := ps.Start(0); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer ps.Stop(context.Background())
+
+	// Create HTTPS client that trusts our CA
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(ca.CertPEM())
+	tlsClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certPool,
+				ServerName: "web.myapp.localhost", // SNI for cert generation
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+
+	// Test HTTPS request
+	url := fmt.Sprintf("https://127.0.0.1:%d/", ps.Port())
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Host = "web.myapp.localhost"
+	resp, err := tlsClient.Do(req)
+	if err != nil {
+		t.Fatalf("HTTPS request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "secure backend" {
+		t.Errorf("Body = %q, want 'secure backend'", body)
+	}
+}
+
+func TestProxyServerWithTLSAndHTTP(t *testing.T) {
+	// Create a backend server
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend response"))
+	}))
+	defer backend.Close()
+
+	// Create route table with backend
+	dir := t.TempDir()
+	routes, _ := NewRouteTable(dir)
+	routes.Add("myapp", map[string]string{
+		"web": backend.Listener.Addr().String(),
+	})
+
+	// Create CA for TLS
+	caDir := t.TempDir()
+	ca, err := proxy.NewCA(caDir)
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+
+	// Create proxy server with TLS enabled
+	ps := NewProxyServer(routes)
+	ps.EnableTLS(ca)
+	if err := ps.Start(0); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer ps.Stop(context.Background())
+
+	// Test HTTPS request
+	certPool := x509.NewCertPool()
+	certPool.AppendCertsFromPEM(ca.CertPEM())
+	tlsClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				RootCAs:    certPool,
+				ServerName: "web.myapp.localhost", // SNI for cert generation
+				MinVersion: tls.VersionTLS12,
+			},
+		},
+	}
+
+	httpsURL := fmt.Sprintf("https://127.0.0.1:%d/", ps.Port())
+	req, _ := http.NewRequest("GET", httpsURL, nil)
+	req.Host = "web.myapp.localhost"
+	resp, err := tlsClient.Do(req)
+	if err != nil {
+		t.Fatalf("HTTPS request: %v", err)
+	}
+	resp.Body.Close()
+
+	// Test plain HTTP request on same port
+	httpClient := &http.Client{}
+	httpURL := fmt.Sprintf("http://127.0.0.1:%d/", ps.Port())
+	req, _ = http.NewRequest("GET", httpURL, nil)
+	req.Host = "web.myapp.localhost"
+	resp, err = httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "backend response" {
+		t.Errorf("Body = %q, want 'backend response'", body)
+	}
+}
+
+func TestEnableTLSValidation(t *testing.T) {
+	dir := t.TempDir()
+	routes, _ := NewRouteTable(dir)
+	ps := NewProxyServer(routes)
+
+	caDir := t.TempDir()
+	ca, err := proxy.NewCA(caDir)
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+
+	// First call should succeed
+	if err := ps.EnableTLS(ca); err != nil {
+		t.Errorf("First EnableTLS call failed: %v", err)
+	}
+
+	// Second call should fail
+	if err := ps.EnableTLS(ca); err == nil {
+		t.Error("Expected error when calling EnableTLS twice, got nil")
+	} else if err.Error() != "TLS already enabled" {
+		t.Errorf("Expected 'TLS already enabled' error, got: %v", err)
+	}
+}
+
+func TestEnableTLSAfterStart(t *testing.T) {
+	dir := t.TempDir()
+	routes, _ := NewRouteTable(dir)
+	ps := NewProxyServer(routes)
+
+	// Start the server first
+	if err := ps.Start(0); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer ps.Stop(context.Background())
+
+	caDir := t.TempDir()
+	ca, err := proxy.NewCA(caDir)
+	if err != nil {
+		t.Fatalf("NewCA: %v", err)
+	}
+
+	// EnableTLS after Start should fail
+	if err := ps.EnableTLS(ca); err == nil {
+		t.Error("Expected error when calling EnableTLS after Start, got nil")
+	} else if err.Error() != "cannot enable TLS after Start()" {
+		t.Errorf("Expected 'cannot enable TLS after Start()' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
Add TLS support to the hostname-based routing proxy:
- Auto-detect HTTP vs HTTPS on single port (peek first byte for 0x16)
- Generate certificates on-demand using SNI (Server Name Indication)
- Certificates signed by auto-created CA at ~/.agentops/proxy/ca/ca.crt
- Add retry loop for Docker port binding race condition

Usage:

    curl --cacert ~/.agentops/proxy/ca/ca.crt https://web.demo.localhost:8080