### PR TITLE
docs(readme): add early release notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Moat
 
+> **Early Release:** This project is in active development. APIs and configuration formats may change. Feedback and contributions welcome.
+
 Run AI agents locally with one command. Zero Docker knowledge. Zero secret copying. Full visibility.
 
 ## Philosophy


### PR DESCRIPTION
## Summary
- Adds an early release notice at the top of the README
- Sets expectations that APIs and configuration formats may change
- Invites feedback and contributions

Preparing for public release.

## Test plan
- [x] Verify notice renders correctly in GitHub markdown preview