### PR TITLE
docs(philosophy): clarify moat's scope and design principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,16 @@
 # Moat
 
-> **Early Release:** This project is in active development. APIs and configuration formats may change. Feedback and contributions welcome.
+> **Early Release:** This project is in active development. APIs and configuration formats may change.
 
-Run AI agents locally with one command. Zero Docker knowledge. Zero secret copying. Full visibility.
+Run agents in containers with credential injection and full observability.
 
-## Philosophy
-
-**Moat is the execution substrate. Orchestration lives above it.**
-
-Moat is a single-run execution environment for agents or processes. One command runs one agent against one workspace.
-
-The primary use case is **local execution**: exploring new codebases, packaging dependencies easily, and running agents with full observability. By default, you stay attached and monitor the process in real-time—detaching to background is optional.
-
-```
-moat claude ./path/to/workspace
+```bash
+moat claude ./workspace
 ```
 
-What happens when you run this:
-- An isolated container is created with your code mounted
-- Claude Code is pre-installed and ready to go
-- Credentials are injected at the network layer (the agent never sees your tokens)
-- Every API call, log line, and network request is captured
-- You see output in real-time (attached by default)
-- When it's done, the workspace is disposable—or you can keep the artifacts
+This starts Claude Code in an isolated container with your workspace mounted. Credentials are injected at runtime—Claude authenticates normally but never sees your tokens. Every API call, log line, and network request is captured.
 
-### Scope and Non-Goals
-
-**Moat does:**
-- Run a single agent in an isolated environment (attached by default)
-- Package dependencies automatically based on runtime detection
-- Inject credentials securely at the network layer
-- Capture full observability (logs, network, audit trail)
-- Support detach/reattach for background execution
-
-**Moat does not:**
-- Orchestrate multiple agents
-- Coordinate parallel runs
-- Perform task planning or delegation
-- Manage shared state across runs
-
-### Composition Philosophy
-
-Moat is designed to be composed with:
-- Shell scripting (loops, `parallel`, etc.)
-- External orchestrators
-- Agent frameworks
-
-Parallel execution and workflow coordination are intentionally left to the shell or higher-level tools.
-
-### Design Principles
-
-- **Small surface area**: One command, one run, clear semantics
-- **Predictable behavior**: Runs are independent and self-contained
-- **Unix composability**: Compose moat with existing tools
-- **Clear trust boundaries**: Explicit about what has access to credentials
-
-For more on design philosophy and decision rationale, see [VISION.md](VISION.md).
+For design rationale and principles, see [VISION.md](VISION.md).
 
 ## Installation
 
@@ -189,16 +144,6 @@ moat claude
 ```
 
 The API key is injected at the network layer—Claude Code never sees it directly.
-
-## Why This Matters
-
-| Traditional approach | With Moat |
-|---------------------|---------------|
-| `GITHUB_TOKEN=xxx` in env | Token never in container |
-| Agent could log/exfiltrate credentials | Token injected at network layer only |
-| No visibility into API calls | Full network trace for auditing |
-| Runs directly on your machine | Isolated container sandbox |
-| Manage Docker, volumes, networks | Just run the agent |
 
 ## Configuration
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,381 +1,68 @@
-# Vision and Design Philosophy
+# Vision
 
-## Positioning
+## Principles
 
-**Moat is the execution substrate. Orchestration lives above it.**
+### Narrow Scope
 
-Moat provides a single, well-defined primitive: the isolated run. Higher-level concerns—parallel execution, multi-agent coordination, task planning—are intentionally left to other tools. This creates a clear separation of responsibilities and enables composition.
+Moat runs one agent in one container against one workspace.
 
-## Core Purpose
+- `moat run` starts a run
+- `moat grant` stores credentials
+- `moat logs`, `moat trace`, `moat audit` show what happened
 
-Moat is a **single-run execution environment** for agents or processes, designed primarily for **local execution**.
+Configuration is YAML. Orchestration is shell. Workflow primitives (loops, retries, dependencies) belong in the calling environment.
 
-The typical workflow:
-- You're exploring a new codebase or starting a project
-- You want to run an agent with proper isolation and credential security
-- Dependencies are packaged automatically—no manual Docker configuration
-- You run `moat claude ./workspace` and stay attached, watching output in real-time
-- Full observability is captured: logs, network requests, audit trail
+### Safe Defaults
 
-**One command. One agent. One workspace.**
+Agents are untrusted code. Moat's defaults reflect that:
 
-- Each run is isolated, auditable, and reproducible
-- Credentials are injected securely without exposure to the agent
-- By default, you're attached and monitoring—detach is optional for background work
+- **Credentials are injected at runtime.** The agent authenticates normally, but tokens never enter the container environment—they're added at the network layer by a TLS-intercepting proxy.
+- **Runs execute in containers.** The workspace is mounted, but the host filesystem is otherwise inaccessible. Each run has its own container instance.
+- **Network access is auditable.** Every HTTP request through the proxy is logged with method, URL, status, and timing.
+- **Destruction requires intent.** `moat stop` halts execution but preserves artifacts. `moat destroy` removes them.
 
-This focus on the single-run primitive keeps moat simple, predictable, and composable.
+### Composition
 
-## Execution Model
+Moat exits with the container's exit code. Standard streams work as expected. Combine runs with shell, Make, CI pipelines, or any tool that can invoke a command.
 
-### Runs are First-Class
+### Progressive Enhancement
 
-Each invocation of `moat run` or `moat claude` creates a **run**—an isolated execution environment with:
-
-- A unique run ID
-- Mounted workspace (your code)
-- Injected credentials (if granted)
-- Captured logs, network requests, and audit trail
-- Independent lifecycle (running, stopped, destroyed)
-
-Runs are independent and self-contained. They do not share state, communicate with each other, or depend on external coordination.
-
-### Default Behavior: Attached Monitoring
-
-By default, `moat run` and `moat claude` **attach** to the container—you see output in real-time and can interact if needed.
+Start with a command:
 
 ```bash
-moat claude ./workspace  # Attached by default, you see everything
+moat run -- npm test
 ```
 
-This is the primary workflow for local development. You stay connected, monitor progress, and see exactly what's happening.
-
-### Optional: Detach for Background Execution
-
-Use `-d` to start detached and let the run continue in the background:
+Add credentials when needed:
 
 ```bash
-moat claude -d ./workspace  # Runs in background
-moat attach <run-id>         # Reattach later to see output
+moat grant github
+moat run --grant github -- npm test
 ```
 
-### Lifecycle Operations
+Add configuration when complexity grows:
 
-Runs support these operations:
+```yaml
+# agent.yaml
+dependencies:
+  - node@20
+grants:
+  - github
+network:
+  policy: strict
+  allow:
+    - "api.github.com"
+```
 
-- **Attach** (default): Stay connected to see output in real-time
-- **Detach**: Disconnect without stopping (run continues in background)
-- **Stop**: Halt execution (container stopped, artifacts preserved)
-- **Destroy**: Remove the run and its artifacts
-- **Replay**: Re-run with the same configuration (future capability)
+Each layer is optional. A run with no `agent.yaml` uses sensible defaults (ubuntu:22.04, permissive network). Configuration captures what you'd otherwise pass as flags.
 
-Critically: **Detach ≠ Stop**. Detaching leaves the run active. This enables background execution and reattachment when needed.
-
-## Explicit Non-Goals
-
-### Moat Does Not Orchestrate
+## Non-Goals
 
 Moat does not:
 
-- **Coordinate multiple agents**: No built-in multi-agent workflows
-- **Manage parallel runs**: No job scheduler or work queue
-- **Plan or delegate tasks**: No task decomposition or routing
-- **Share state across runs**: Each run is isolated
-
-**Rationale**: These are higher-level concerns that vary by use case. A shell script needs different orchestration than a Kubernetes operator. By staying focused on the single-run primitive, moat remains flexible enough to support any orchestration model.
-
-### Moat Does Not Provide Workflow Primitives
-
-No loops, conditionals, retries, or dependencies between runs. These belong in the orchestration layer.
-
-**Example of what moat does not do:**
-
-```yaml
-# This is NOT moat's job
-workflow:
-  - run: agent-1
-    depends_on: []
-  - run: agent-2
-    depends_on: [agent-1]
-    when: agent-1.status == "success"
-```
-
-Instead, orchestrate with shell, Make, or a proper workflow engine:
-
-```bash
-# Shell orchestration
-moat run ./agent-1 && moat run ./agent-2
-```
-
-```makefile
-# Make orchestration
-agent-2: agent-1
-	moat run ./agent-2
-```
-
-## Composition Philosophy
-
-Moat is designed to be **composed**, not extended.
-
-### With Shell Scripts
-
-```bash
-# Run multiple agents in parallel
-moat run ./agent-1 &
-moat run ./agent-2 &
-wait
-
-# Fan-out execution across workspaces
-for workspace in projects/*; do
-  moat claude "$workspace" -p "run tests" &
-done
-wait
-
-# Retry on failure
-until moat run ./flaky-agent; do
-  echo "Retrying..."
-  sleep 5
-done
-```
-
-### With External Orchestrators
-
-- **GitHub Actions**: Each workflow step runs `moat run` or `moat claude`
-- **Jenkins/CircleCI**: Build pipeline stages invoke moat
-- **Kubernetes CronJobs**: Scheduled jobs execute moat commands
-- **Temporal/Airflow**: Workflow tasks shell out to moat
-
-### With Agent Frameworks
-
-Agent frameworks can use moat as their execution backend:
-
-```python
-# Hypothetical agent framework
-framework.run_agent(
-    agent_config="./my-agent",
-    executor=lambda: subprocess.run(["moat", "run", "./my-agent"])
-)
-```
-
-The framework handles planning, delegation, and state. Moat handles isolation, credentials, and observability.
-
-## Design Principles
-
-### Small Surface Area
-
-**One command, one run, clear semantics.**
-
-Moat provides a minimal set of primitives:
-- Run an agent (`moat run`, `moat claude`)
-- Manage credentials (`moat grant`, `moat revoke`)
-- Observe runs (`moat logs`, `moat trace`, `moat audit`)
-- Control lifecycle (`moat attach`, `moat stop`, `moat destroy`)
-
-No plugins, no extensions, no templating language. The scope is intentionally constrained.
-
-**Why**: A small surface area is easier to understand, test, and maintain. It reduces the chance of surprising interactions or edge cases.
-
-### Predictable Behavior
-
-**Runs are independent and self-contained.**
-
-Each run has:
-- Isolated filesystem (container)
-- No shared state with other runs
-- Deterministic configuration (from `agent.yaml` or flags)
-- Reproducible environment (same image, same mounts, same credentials)
-
-**Why**: Predictability builds trust. You should be able to reason about what a run will do without consulting documentation or inspecting global state.
-
-### Unix Composability
-
-**Compose moat with existing tools.**
-
-Moat follows Unix philosophy:
-- Do one thing well (isolated runs)
-- Plain text output (JSON logs, parseable traces)
-- Zero-configuration defaults
-- Composable via shell pipelines and scripts
-
-**Why**: Reinventing orchestration, scripting, or workflow engines adds complexity and limits adoption. Moat integrates into existing toolchains instead of replacing them.
-
-### Clear Trust Boundaries
-
-**Explicit about what has access to credentials.**
-
-Moat's security model:
-- Credentials stored encrypted on host
-- Injected at network layer via TLS-intercepting proxy
-- Never exposed as environment variables
-- Scoped per-run (binding discarded when run ends)
-- Full audit trail of usage
-
-**Why**: Agents are untrusted. Credentials must never enter the container environment where they could be logged, exfiltrated, or misused.
-
-## CLI Contract
-
-### Canonical Usage
-
-```bash
-moat claude ./path/to/workspace
-moat run ./path/to/workspace
-```
-
-One command, one workspace, one run.
-
-### Re-Running and Fan-Out
-
-Re-running or executing across multiple workspaces is done **externally**:
-
-```bash
-# Re-run the same workspace
-moat run ./workspace  # First run
-moat run ./workspace  # Second run (new run ID)
-
-# Fan-out across workspaces
-for ws in workspaces/*; do
-  moat run "$ws"
-done
-```
-
-**Why**: Shell scripting is universal, well-understood, and powerful. Moat doesn't need to reimplement `for` loops.
-
-### Flags vs. Configuration
-
-- **Common options**: Available as CLI flags (`--grant`, `--name`, `-d`)
-- **Complex configuration**: Use `agent.yaml` for dependencies, mounts, network policy
-- **Precedence**: CLI flags override `agent.yaml`
-
-**Why**: Flags are convenient for ad-hoc runs. `agent.yaml` is better for repeatable, versioned configurations.
-
-## Examples: What Moat Enables
-
-### Exploring a New Codebase
-
-You clone a repository and want to understand it:
-
-```bash
-git clone https://github.com/example/new-project
-cd new-project
-
-# Run Claude Code with GitHub access, stay attached, see everything
-moat claude --grant github
-```
-
-Moat automatically:
-- Detects dependencies (Node, Python, Go, etc.)
-- Pulls the appropriate base image
-- Injects your GitHub credentials securely
-- Captures all API calls for audit
-
-You see Claude's work in real-time. No Docker configuration needed.
-
-### Packaging Dependencies Easily
-
-You have a Python project with complex dependencies:
-
-```bash
-# Create agent.yaml
-cat > agent.yaml <<EOF
-dependencies:
-  - python@3.11
-grants:
-  - github
-EOF
-
-# Run with automatic dependency packaging
-moat claude
-```
-
-Moat handles the container setup. You focus on the task.
-
-### Isolated Development Environments
-
-```bash
-# Work on authentication feature
-moat claude ./app --name auth-work
-
-# Separately, work on checkout flow (same repo, different container)
-moat claude ./app --name checkout-work
-```
-
-No conflicts, no shared state. Each run is independent.
-
-### Credential Isolation for Security Testing
-
-```bash
-# Grant limited GitHub access
-moat grant github:repo
-
-# Run an untrusted agent with scoped credentials
-moat run ./untrusted-agent --grant github
-
-# After completion, audit exactly what it accessed
-moat audit
-moat trace --network
-```
-
-The agent gets scoped access. Full observability shows exactly what it did.
-
-### Parallel Testing (Optional Advanced Use)
-
-For users who need it, moat composes with shell for parallel execution:
-
-```bash
-# Fan out across branches (detached for parallel execution)
-for branch in feature-1 feature-2 feature-3; do
-  git worktree add /tmp/$branch $branch
-  moat run /tmp/$branch --name "test-$branch" -d -- npm test
-done
-
-moat list  # See all tests running
-```
-
-This is advanced usage—most users stay attached for interactive, local work.
-
-## Comparison to Other Tools
-
-| Tool | Scope | Orchestration | Moat's Position |
-|------|-------|---------------|-----------------|
-| **Docker** | Container runtime | None | Moat uses Docker (or Apple containers) as its runtime |
-| **Docker Compose** | Multi-container apps | Declarative service coordination | Moat runs one container per invocation; compose with shell |
-| **Kubernetes** | Container orchestration | Cluster-scale orchestration | Moat is for local, single-run execution |
-| **Agent frameworks** | Agent logic | Task planning, delegation | Moat provides the execution substrate |
-| **CI/CD systems** | Build/test automation | Workflow pipelines | Moat runs as a step in CI/CD pipelines |
-
-Moat occupies the layer **between** container runtimes and orchestration systems. It makes running a single agent simple, secure, and observable. Higher-level tools compose moat to build workflows.
-
-## Future Direction
-
-Moat's scope is intentionally constrained. Future development will focus on:
-
-- **Replay**: Re-run a previous run with the same configuration
-- **Snapshots**: Capture workspace state for reproducibility
-- **Network simulation**: Test agents under different network conditions
-- **Enhanced audit**: Richer cryptographic proofs and verification
-
-We will **not** add:
-- Multi-agent orchestration
-- Workflow engines
-- Task planning
-- Shared state management
-
-These belong in the orchestration layer, not the execution substrate.
-
-## Summary
-
-Moat is a **single-run execution environment** designed for **local development**:
-
-**Primary use case:**
-- Exploring new codebases
-- Easy dependency packaging
-- Running agents with full observability
-- Attached by default—you see output in real-time
-
-**Clear scope:**
-- ✅ Single-run isolation, auditability, reproducibility, safe credentials
-- ✅ Composable with shell, orchestrators, and frameworks
-- ❌ No orchestration, coordination, or planning
-
-**One command. One agent. One workspace.**
-
-Detach to background if needed. Compose with shell for parallel execution. The rest is composition.
+- **Orchestrate multiple agents.** No job scheduler, work queue, or multi-agent coordination.
+- **Manage state across runs.** Each run is independent. Shared state belongs in external storage.
+- **Plan or delegate tasks.** No task decomposition, routing, or agent-to-agent communication.
+- **Provide workflow primitives.** No loops, conditionals, retries, or dependencies between runs.
+
+These concerns vary by use case and belong in the orchestration layer—shell scripts, CI systems, agent frameworks, or workflow engines. Moat provides the execution primitive they compose.


### PR DESCRIPTION
Update README philosophy section to emphasize moat as a single-run
execution substrate rather than an orchestration tool. Add explicit
non-goals, composition philosophy, and design principles.

Create VISION.md with detailed rationale for design decisions,
including execution model, comparison to other tools, and examples
of how moat composes with shell scripts and orchestrators.

Key changes:
- Position moat as "execution substrate" not orchestrator
- Clarify one command = one run = one workspace
- Document explicit non-goals (no multi-agent coordination, no planning)
- Emphasize Unix composability and small surface area
- Add VISION.md for deeper philosophy and design rationale