### PR TITLE
chore(ci): collapse old Claude reviews when posting new ones

### DIFF
--- a/.github/scripts/collapse-previous-reviews.sh
+++ b/.github/scripts/collapse-previous-reviews.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Collapses previous Claude Code review comments on a PR by wrapping them
+# in a <details> block. This keeps the PR timeline clean when new reviews
+# supersede old ones.
+#
+# Required environment variables:
+#   GH_TOKEN    - GitHub token with pull-requests:write permission
+#   REPO        - Repository in owner/repo format
+#   PR_NUMBER   - Pull request number
+#
+set -euo pipefail
+
+# Markers used to identify and track Claude Code review comments
+MARKER="<!-- claude-code-review -->"
+COLLAPSED_MARKER="<!-- claude-code-review-collapsed -->"
+
+# Get all comments that have the review marker but haven't been collapsed yet
+comments=$(gh api "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+  --jq ".[] | select(.body | contains(\"${MARKER}\")) | select(.body | contains(\"${COLLAPSED_MARKER}\") | not) | {id: .id, body: .body}")
+
+if [ -z "$comments" ]; then
+  echo "No previous Claude reviews to collapse"
+  exit 0
+fi
+
+# Process each comment
+echo "$comments" | jq -c '.' | while read -r comment; do
+  if [ -z "$comment" ] || [ "$comment" = "null" ]; then
+    continue
+  fi
+
+  comment_id=$(echo "$comment" | jq -r '.id')
+  original_body=$(echo "$comment" | jq -r '.body')
+
+  # Create collapsed version with the original content inside a details block
+  collapsed_body="${COLLAPSED_MARKER}
+<details>
+<summary>📦 <strong>Previous Review</strong> (superseded by newer review)</summary>
+
+${original_body}
+
+</details>"
+
+  echo "Collapsing previous review comment: $comment_id"
+  gh api \
+    --method PATCH \
+    "/repos/${REPO}/issues/comments/${comment_id}" \
+    -f body="$collapsed_body"
+done
+
+echo "Done collapsing previous reviews"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write  # Required to update previous review comments
       issues: read
       id-token: write
 
@@ -30,6 +30,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Collapse previous Claude reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./.github/scripts/collapse-previous-reviews.sh
 
       - name: Run Claude Code Review
         id: claude-review
@@ -48,6 +55,8 @@ jobs:
             - Test coverage
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+
+            IMPORTANT: When posting your review comment, you MUST include the marker `<!-- claude-code-review -->` at the very beginning of your comment body. This marker is used to identify your reviews so they can be collapsed when superseded by newer reviews.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 


### PR DESCRIPTION
Add a step to the code review workflow that wraps previous Claude review comments in a collapsible `<details>` section before posting a new review. This saves scroll space on PRs with multiple review cycles and clearly indicates which review is current.

- Add collapse-previous-reviews.sh script to .github/scripts/
- Update workflow to call script before running new review
- Instruct Claude to include marker comment for identification
- Bump pull-requests permission to write for comment updates