### PR TITLE
chore(ci): use flexible pattern matching for Claude review detection

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -56,12 +56,8 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            IMPORTANT: Your review comment MUST start with a title in exactly this format:
-            ## Pull Request Review: <brief title>
-
-            For example: "## Pull Request Review: AWS Credential Support"
-
-            This title format is used to identify your reviews so previous ones can be collapsed when superseded.
+            Start your review comment with a markdown heading containing "Review" (e.g., "## Code Review" or "### Pull Request Review: <title>").
+            Previous reviews are automatically collapsed when new ones are posted.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 


### PR DESCRIPTION
Detect Claude reviews by checking comment author (github-actions[bot]) and matching heading pattern (##+ .*Review) instead of exact title. This handles Claude's varying formats like "### Code Review" and "## Pull Request Review".