### PR TITLE
fix(tui): resolve cursor rendering issues and initial terminal sizing

### DIFF
--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -114,6 +114,12 @@ type AttachOptions struct {
 	Stdout io.Writer // If non-nil, receive stdout from container
 	Stderr io.Writer // If non-nil, receive stderr from container (may be same as Stdout)
 	TTY    bool      // If true, use TTY mode (raw terminal)
+
+	// InitialWidth and InitialHeight set the initial terminal size for TTY mode.
+	// If both are > 0, the TTY is resized immediately after the container starts,
+	// before the process has a chance to query terminal dimensions.
+	InitialWidth  uint
+	InitialHeight uint
 }
 
 // Config holds configuration for creating a container.

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1577,6 +1577,17 @@ func (m *Manager) StartAttached(ctx context.Context, runID string, stdin io.Read
 		TTY:    useTTY,
 	}
 
+	// Pass initial terminal size so the container can be resized immediately
+	// after starting, before the process queries terminal dimensions.
+	if useTTY && term.IsTerminal(os.Stdout) {
+		width, height := term.GetSize(os.Stdout)
+		if width > 0 && height > 0 {
+			// #nosec G115 -- width/height are validated positive above
+			attachOpts.InitialWidth = uint(width)
+			attachOpts.InitialHeight = uint(height)
+		}
+	}
+
 	// Channel to receive the attach result
 	attachDone := make(chan error, 1)
 

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -32,12 +32,15 @@ func (s *StatusBar) SetDimensions(width, height int) {
 }
 
 // Render returns the full status bar with ANSI escapes for positioning.
+// The caller is responsible for cursor positioning after calling Render.
 func (s *StatusBar) Render() string {
 	if s.height <= 0 {
 		return ""
 	}
-	// Save cursor, move to bottom row, clear line, draw bar, restore cursor
-	return fmt.Sprintf("\x1b[s\x1b[%d;1H\x1b[2K%s\x1b[u", s.height, s.Content())
+	// Move to bottom row, clear line, draw bar.
+	// Note: No save/restore cursor here - Writer.renderLocked() handles cursor
+	// positioning explicitly to avoid double cursor artifacts.
+	return fmt.Sprintf("\x1b[%d;1H\x1b[2K%s", s.height, s.Content())
 }
 
 // Content returns the status bar content string (with ANSI styling).

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -64,13 +64,13 @@ func TestStatusBar_RenderEscaped(t *testing.T) {
 	if !strings.Contains(rendered, "\x1b[2K") {
 		t.Errorf("expected clear line escape, got %q", rendered)
 	}
-	// Should contain save cursor
-	if !strings.Contains(rendered, "\x1b[s") {
-		t.Errorf("expected save cursor escape, got %q", rendered)
+	// Should NOT contain save/restore cursor - the caller (Writer.renderLocked)
+	// handles cursor positioning explicitly to avoid double cursor artifacts
+	if strings.Contains(rendered, "\x1b[s") {
+		t.Errorf("unexpected save cursor escape (caller handles cursor), got %q", rendered)
 	}
-	// Should contain restore cursor
-	if !strings.Contains(rendered, "\x1b[u") {
-		t.Errorf("expected restore cursor escape, got %q", rendered)
+	if strings.Contains(rendered, "\x1b[u") {
+		t.Errorf("unexpected restore cursor escape (caller handles cursor), got %q", rendered)
 	}
 	// Should contain the actual status bar content
 	if !strings.Contains(rendered, "moat") {


### PR DESCRIPTION
## Summary

- Fix double cursor artifact when running Claude in interactive mode
- Forward cursor visibility (show/hide) sequences from Claude to terminal
- Eliminate initial terminal size race condition that caused Claude to render with wrong dimensions

## Details

**Double cursor fix:** `StatusBar.Render()` was emitting save/restore cursor sequences (`\x1b[s`/`\x1b[u`) that conflicted with `Writer.renderLocked()` also positioning the cursor explicitly. Removed the redundant save/restore from StatusBar.

**Cursor visibility forwarding:** The charmbracelet vt emulator parses DECTCEM sequences (`\x1b[?25l`/`\x1b[?25h`) but doesn't expose cursor visibility state. Added tracking in Writer to detect these sequences and include the appropriate show/hide in each render output.

**Initial terminal size:** Container started with Docker's default PTY size (~80x24), Claude queried terminal dimensions immediately on startup and cached the wrong value, then our resize came 200ms later. Added `InitialWidth`/`InitialHeight` to `AttachOptions` so both Docker and Apple runtimes resize the TTY immediately after the container starts.

## Test plan

- [x] All existing tests pass
- [x] New tests for cursor visibility tracking
- [x] Manual testing in Docker runtime with Claude Code
- [ ] Manual testing in Apple container runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)