### PR TITLE
fix(apple): simplify builder DNS configuration

### DIFF
--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -247,8 +247,12 @@ type Info struct {
 // BuildOptions configures image building.
 type BuildOptions struct {
 	// DNS servers to use during build (Apple containers only).
-	// If empty, host DNS is auto-detected.
+	// If empty, defaults to Google public DNS (8.8.8.8, 8.8.4.4).
 	DNS []string
+
+	// ContextFiles are additional files to write into the build context directory.
+	// Keys are relative paths, values are file contents.
+	ContextFiles map[string][]byte
 
 	// NoCache disables build cache, forcing a fresh build of all layers.
 	NoCache bool


### PR DESCRIPTION
## Summary

- Fixes Apple container builder DNS configuration that could hang or fail due to gRPC transport corruption
- Uses `printf` with escaped newlines instead of `cat` with stdin piping
- Removes file locking (no longer needed with simpler approach)
- Removes DNS auto-detection complexity, defaults to Google DNS (8.8.8.8, 8.8.4.4)
- Adds `ContextFiles` support for build operations
- Refactors `ensureBuilderRunning` into `waitForBuilder` helper

## Test plan

- [ ] Test Apple container build with default DNS
- [ ] Test Apple container build with custom DNS in agent.yaml
- [ ] Verify builds no longer hang during DNS configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)