### PR TITLE
fix(deps): use native installer for Claude Code

### DIFF
--- a/docs/content/concepts/06-dependencies.md
+++ b/docs/content/concepts/06-dependencies.md
@@ -32,7 +32,7 @@ dependencies:
   - node@20        # Runtime with version
   - python         # Runtime with default version
   - git            # System package
-  - claude-code    # npm package
+  - claude-code    # Custom installer
   - golangci-lint  # GitHub binary
 ```
 
@@ -260,7 +260,7 @@ Or use `moat codex` which includes these automatically.
 | `typescript` | npm | TypeScript compiler |
 | `prettier` | npm | Code formatter |
 | `eslint` | npm | Linter |
-| `claude-code` | npm | Claude Code CLI |
+| `claude-code` | custom | Claude Code CLI (user-space install) |
 | `codex-cli` | npm | OpenAI Codex CLI |
 
 ### CLI tools

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -352,6 +352,16 @@ func getCustomCommands(name, version string) InstallCommands {
 				"PATH": "/root/.cargo/bin:$PATH",
 			},
 		}
+	case "claude-code":
+		// Native installer - avoids Claude startup warnings from npm-based installs.
+		return InstallCommands{
+			Commands: []string{
+				`curl -fsSL https://claude.ai/install.sh | bash`,
+			},
+			EnvVars: map[string]string{
+				"PATH": "$HOME/.local/bin:$PATH",
+			},
+		}
 	case "kubectl":
 		// Install kubectl - detects architecture
 		return InstallCommands{

--- a/internal/deps/registry.yaml
+++ b/internal/deps/registry.yaml
@@ -71,9 +71,8 @@ pnpm:
 
 claude-code:
   description: Claude Code CLI
-  type: npm
-  package: "@anthropic-ai/claude-code"
-  requires: [node]
+  type: custom
+  user-install: true
 
 codex-cli:
   description: OpenAI Codex CLI

--- a/internal/deps/types.go
+++ b/internal/deps/types.go
@@ -83,6 +83,11 @@ type DepSpec struct {
 
 	// For go-install type
 	GoPackage string `yaml:"go-package,omitempty"`
+
+	// UserInstall indicates the dependency should be installed as the container
+	// user (moatuser) instead of root. This is needed for tools whose installers
+	// write to $HOME (e.g., claude-code's native installer).
+	UserInstall bool `yaml:"user-install,omitempty"`
 }
 
 // Dependency represents a parsed dependency from agent.yaml.


### PR DESCRIPTION
Switch claude-code from npm global install to the native installer (claude.ai/install.sh). The npm-based install caused Claude startup warnings. The native installer runs as moatuser since it writes to $HOME.

Add install-as: user support to the dependency registry so any custom dependency can opt into user-space installation. Dependencies with this flag are batched into a USER moatuser block in the generated Dockerfile.