### PR TITLE
chore(hooks): add Claude Code hook to prevent unsafe git pushes during development

### DIFF
--- a/.claude/hooks/prevent-unsafe-push.bats
+++ b/.claude/hooks/prevent-unsafe-push.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+setup() {
+  HOOK="$BATS_TEST_DIRNAME/prevent-unsafe-push.py"
+}
+
+# Helper: pipe JSON to hook, capture exit code and stderr
+run_hook() {
+  local output
+  output="$(echo "$1" | "$HOOK" 2>&1)" && status=0 || status=$?
+  echo "$output"
+  return "$status"
+}
+
+# --- Allowed commands ---
+
+@test "allows push to feature branch" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push origin my-feature"}}')" || status=$?
+  [ "${status:-0}" -eq 0 ]
+}
+
+@test "allows non-git commands" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"echo hello"}}')" || status=$?
+  [ "${status:-0}" -eq 0 ]
+}
+
+@test "allows non-Bash tools" {
+  result="$(run_hook '{"tool_name":"Write","tool_input":{"command":"git push origin main"}}')" || status=$?
+  [ "${status:-0}" -eq 0 ]
+}
+
+@test "allows push with --force-with-lease" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin my-feature"}}')" || status=$?
+  [ "${status:-0}" -eq 0 ]
+}
+
+# --- Blocked: push to main ---
+
+@test "blocks push to main" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push origin main"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+  [[ "$result" == *"Direct push to main is not allowed"* ]]
+}
+
+@test "blocks push to main without explicit remote" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push main"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+}
+
+@test "blocks push to main in chained command" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"echo foo && git push origin main"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+  [[ "$result" == *"Direct push to main is not allowed"* ]]
+}
+
+@test "blocks --force-with-lease to main" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push --force-with-lease origin main"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+  [[ "$result" == *"Direct push to main is not allowed"* ]]
+}
+
+# --- Blocked: force push ---
+
+@test "blocks git push -f" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push -f origin my-feature"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+  [[ "$result" == *"Force push is not allowed"* ]]
+}
+
+@test "blocks git push --force" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"git push --force origin my-feature"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+  [[ "$result" == *"Force push is not allowed"* ]]
+}
+
+@test "blocks force push in chained command" {
+  result="$(run_hook '{"tool_name":"Bash","tool_input":{"command":"echo foo && git push --force origin my-feature"}}')" || status=$?
+  [ "${status:-0}" -eq 2 ]
+  [[ "$result" == *"Force push is not allowed"* ]]
+}

--- a/.claude/hooks/prevent-unsafe-push.py
+++ b/.claude/hooks/prevent-unsafe-push.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Claude Code PreToolUse hook: blocks git push to main and force pushes."""
+
+import json
+import re
+import sys
+
+def main():
+    data = json.load(sys.stdin)
+
+    if data.get("tool_name") != "Bash":
+        sys.exit(0)
+
+    command = data.get("tool_input", {}).get("command", "")
+    if not command:
+        sys.exit(0)
+
+    # Check for git push anywhere in the command (handles && and ; chains)
+    if not re.search(r"\bgit\s+push\b", command):
+        sys.exit(0)
+
+    # Block force push (--force or -f, but not --force-with-lease)
+    if re.search(r"\bgit\s+push\b.*(\s+--force(?!-with-lease)\b|\s+-f\b)", command):
+        print("Force push is not allowed. Use --force-with-lease if necessary.", file=sys.stderr)
+        sys.exit(2)
+
+    # Block push to main
+    if re.search(r"\bgit\s+push\b.*\s+main\b", command):
+        print("Direct push to main is not allowed. Create a pull request instead.", file=sys.stderr)
+        sys.exit(2)
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/prevent-unsafe-push.py"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up bats
+        uses: bats-core/bats-action@3.0.1
+
       - name: Run tests
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Run hook tests
+        run: bats .claude/hooks/
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all help build test test-unit test-e2e lint clean coverage
+.PHONY: all help build test test-unit test-e2e test-bats lint clean coverage
 
 # Default target - running "make" shows help
 all: help
@@ -21,13 +21,17 @@ build: ## Build the project
 build-cli: ## Build the CLI binary ./moat
 	go build -o moat ./cmd/moat
 
-test: test-unit test-e2e ## Run all tests (unit + E2E)
+test: test-unit test-e2e test-bats ## Run all tests (unit + E2E + hooks)
 
 test-unit: ## Run unit tests (use ARGS for filtering, e.g., ARGS='-run TestName')
 	go test $(ARGS) ./...
 
 test-e2e: ## Run E2E tests (use ARGS for filtering, e.g., ARGS='-run TestName')
 	go test -tags=e2e -v $(ARGS) ./internal/e2e/
+
+test-bats: ## Run bats tests for Claude Code hooks
+	@which bats > /dev/null || (echo "bats not installed. Install from https://github.com/bats-core/bats-core" && exit 1)
+	bats .claude/hooks/
 
 lint: ## Run linter (requires golangci-lint)
 	@which golangci-lint > /dev/null || (echo "golangci-lint not installed. Install from https://golangci-lint.run/usage/install/" && exit 1)

--- a/agent.yaml
+++ b/agent.yaml
@@ -11,6 +11,7 @@ dependencies:
   - make
   - claude-code
   - node@20
+  - bats
   - docker:dind
 
 grants:

--- a/internal/deps/registry.yaml
+++ b/internal/deps/registry.yaml
@@ -149,6 +149,11 @@ make:
   type: apt
   package: make
 
+bats:
+  description: Bash Automated Testing System
+  type: apt
+  package: bats
+
 # Custom installers (complex logic)
 playwright:
   description: Browser testing framework


### PR DESCRIPTION
Add a PreToolUse hook that blocks git push to main and force pushes, keeping the main branch safe from accidental direct pushes. Includes bats-core tests, CI integration via bats-core/bats-action, and adds bats to moat's dependency registry.