### PR TITLE
fix(tui): fix Docker multiplexed stream headers leaking into non-interactive output

### DIFF
--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/majorcontext/moat/internal/audit"
 	"github.com/majorcontext/moat/internal/claude"
 	"github.com/majorcontext/moat/internal/codex"
@@ -2041,7 +2042,18 @@ func (m *Manager) streamLogs(ctx context.Context, r *Run) {
 
 	// Stream to stdout only for real-time feedback
 	// Storage is handled by Wait() after container exits
-	_, _ = io.Copy(os.Stdout, logs)
+	//
+	// Note: streamLogs is only called for non-interactive runs (see exec.go).
+	// Interactive runs use StartAttached which handles I/O directly.
+	// Non-interactive Docker containers use multiplexed streams (no TTY),
+	// so we must demultiplex to avoid 8-byte headers leaking into output.
+	if m.runtime.Type() == container.RuntimeDocker {
+		// Docker non-interactive container: demultiplex the stream
+		_, _ = stdcopy.StdCopy(os.Stdout, os.Stderr, logs)
+	} else {
+		// Apple container: output is already raw
+		_, _ = io.Copy(os.Stdout, logs)
+	}
 }
 
 // Stop terminates a running run.


### PR DESCRIPTION
## Summary

Fixes #100 - Docker multiplexed stream header bytes were leaking into non-interactive container output, causing stray characters (e.g., `3`, `4`, `z`) to appear at the beginning of output lines.

## Changes

- Updated `streamLogs()` in `internal/run/manager.go` to detect Docker runtime and use `stdcopy.StdCopy()` for proper demultiplexing
- Added import for `github.com/docker/docker/pkg/stdcopy`
- Added explanatory comments about when multiplexing occurs (non-interactive Docker containers only)

## Root Cause

Docker's attach API uses a multiplexed stream protocol when `TTY: false`. Each frame has an 8-byte header indicating stream type (stdout/stderr) and payload size. The `streamLogs()` function was copying the raw stream directly to stdout without stripping these headers.

## Solution

The fix mirrors the approach already used in `ContainerLogsAll()` - check if the runtime is Docker and use `stdcopy.StdCopy()` to demultiplex the stream. Since `streamLogs()` is only called for non-interactive runs (interactive runs use `StartAttached()`), and non-interactive Docker containers always use multiplexed streams (no TTY), the fix unconditionally demultiplexes for Docker runtime.

## Test Plan

- Builds successfully with `go build ./...`
- All existing unit tests pass
- Manual testing would verify clean output when running `moat run examples/service-postgres` (requires Docker)

🤖 Generated with Claude Code