### PR TITLE
perf(deps): optimize generated Dockerfiles for faster builds

### DIFF
--- a/internal/claude/dockerfile_test.go
+++ b/internal/claude/dockerfile_test.go
@@ -15,7 +15,8 @@ func TestGenerateDockerfileSnippet(t *testing.T) {
 		"aws-agent-skills@aws-agent-skills",
 	}
 
-	result := GenerateDockerfileSnippet(marketplaces, plugins, "moatuser")
+	// Test with needsRootAfter = true
+	result := GenerateDockerfileSnippet(marketplaces, plugins, "moatuser", true)
 
 	// Should have section header
 	if !strings.Contains(result, "# Claude Code plugins") {
@@ -43,19 +44,26 @@ func TestGenerateDockerfileSnippet(t *testing.T) {
 		t.Error("should install claude-md-management plugin")
 	}
 
-	// Should switch back to root
+	// Should switch back to root when needsRootAfter = true
 	if !strings.Contains(result, "USER root") {
-		t.Error("should switch back to USER root")
+		t.Error("should switch back to USER root when needsRootAfter = true")
+	}
+
+	// Test with needsRootAfter = false
+	result = GenerateDockerfileSnippet(marketplaces, plugins, "moatuser", false)
+	// Should NOT switch back to root when needsRootAfter = false
+	if strings.Contains(result, "USER root") {
+		t.Error("should NOT switch to USER root when needsRootAfter = false")
 	}
 }
 
 func TestGenerateDockerfileSnippetEmpty(t *testing.T) {
-	result := GenerateDockerfileSnippet(nil, nil, "moatuser")
+	result := GenerateDockerfileSnippet(nil, nil, "moatuser", false)
 	if result != "" {
 		t.Error("empty input should return empty string")
 	}
 
-	result = GenerateDockerfileSnippet([]MarketplaceConfig{}, []string{}, "moatuser")
+	result = GenerateDockerfileSnippet([]MarketplaceConfig{}, []string{}, "moatuser", true)
 	if result != "" {
 		t.Error("empty slices should return empty string")
 	}
@@ -68,7 +76,7 @@ func TestGenerateDockerfileSnippetValidation(t *testing.T) {
 			{Name: "evil", Source: "github", Repo: "; rm -rf /"},
 		}
 
-		result := GenerateDockerfileSnippet(marketplaces, nil, "moatuser")
+		result := GenerateDockerfileSnippet(marketplaces, nil, "moatuser", false)
 
 		// Valid repo should be included
 		if !strings.Contains(result, "marketplace add valid/repo") {
@@ -90,7 +98,7 @@ func TestGenerateDockerfileSnippetValidation(t *testing.T) {
 			"bad;rm -rf /@market",
 		}
 
-		result := GenerateDockerfileSnippet(nil, plugins, "moatuser")
+		result := GenerateDockerfileSnippet(nil, plugins, "moatuser", false)
 
 		// Valid plugin should be included
 		if !strings.Contains(result, "plugin install valid-plugin@valid-market") {

--- a/internal/deps/dockerfile_test.go
+++ b/internal/deps/dockerfile_test.go
@@ -64,16 +64,25 @@ func TestGenerateDockerfileEmpty(t *testing.T) {
 }
 
 func TestGenerateDockerfileHasIptables(t *testing.T) {
-	// Verify iptables is installed in base packages for firewall support
+	// Verify iptables is installed when NeedsIptables is true (for transparent proxy redirect)
 	deps := []Dependency{
 		{Name: "python", Version: "3.11"},
 	}
-	result, err := GenerateDockerfile(deps, nil)
+	result, err := GenerateDockerfile(deps, &DockerfileOptions{NeedsIptables: true})
 	if err != nil {
 		t.Fatalf("GenerateDockerfile error: %v", err)
 	}
 	if !strings.Contains(result.Dockerfile, "iptables") {
-		t.Errorf("Dockerfile should install iptables for firewall support.\nGenerated Dockerfile:\n%s", result.Dockerfile)
+		t.Errorf("Dockerfile should install iptables when NeedsIptables is true.\nGenerated Dockerfile:\n%s", result.Dockerfile)
+	}
+
+	// Verify iptables is NOT installed when NeedsIptables is false
+	result, err = GenerateDockerfile(deps, &DockerfileOptions{NeedsIptables: false})
+	if err != nil {
+		t.Fatalf("GenerateDockerfile error: %v", err)
+	}
+	if strings.Contains(result.Dockerfile, "iptables") {
+		t.Errorf("Dockerfile should NOT install iptables when NeedsIptables is false.\nGenerated Dockerfile:\n%s", result.Dockerfile)
 	}
 }
 

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1078,6 +1078,8 @@ region = %s
 		useBuildKit := os.Getenv("MOAT_DISABLE_BUILDKIT") != "1"
 
 		// Always generate the Dockerfile so we can save it to the run directory
+		// iptables is needed for: (1) proxy when grants are present, (2) firewall when network policy is strict
+		needsIptables := len(opts.Grants) > 0 || (opts.Config != nil && opts.Config.Network.Policy == "strict")
 		result, err := deps.GenerateDockerfile(installableDeps, &deps.DockerfileOptions{
 			NeedsSSH:           hasSSHGrants,
 			SSHHosts:           sshGrants,
@@ -1086,6 +1088,7 @@ region = %s
 			UseBuildKit:        &useBuildKit,
 			ClaudeMarketplaces: claudeMarketplaces,
 			ClaudePlugins:      claudePlugins,
+			NeedsIptables:      needsIptables,
 		})
 		if err != nil {
 			cleanupProxy(proxyServer)


### PR DESCRIPTION
## Summary

Optimizes Dockerfile generation for better build performance and clarity, addressing all optimization opportunities in #103.

## Changes

### Performance improvements

1. **Combine Claude plugin layers** (9+ → 2 layers)
   - Merge all marketplace adds into a single RUN command
   - Merge all plugin installs into a single RUN command
   - Biggest performance win - reduces Docker snapshot/commit overhead significantly

2. **Merge base + user apt packages** (2 layers → 1 layer)
   - Single `apt-get update` instead of two
   - Combines base packages (curl, gnupg, etc.) with user-specified apt deps
   - Faster builds, fewer layers, cleaner output

3. **Make iptables conditional**
   - Only install iptables when grants are present (`NeedsIptables` flag)
   - Simple runs without proxy don't need it
   - Reduces package count for basic images

### Clarity improvements

4. **Remove redundant USER transitions**
   - Claude plugin block only switches to root when needed
   - Checks if dynamic deps or SSH hosts follow
   - Eliminates pointless `USER root` → `USER moatuser` when nothing follows

5. **Clean up apt list cleanup**
   - Only run `rm -rf /var/lib/apt/lists/*` for non-BuildKit builds
   - BuildKit uses cache mounts, so cleanup is a no-op
   - Cleanup removed when BuildKit is enabled

## Testing

- ✅ All unit tests pass (`internal/claude`, `internal/deps`)
- ✅ Updated tests to verify conditional iptables installation
- ✅ Updated tests to verify USER transition behavior
- ✅ Full build succeeds

## Breaking Changes

None - all changes are internal to Dockerfile generation.

Fixes #103