### PR TITLE
feat(tui): Update footer after ctrl-/ to show escape squences

### DIFF
--- a/cmd/moat/cli/attach.go
+++ b/cmd/moat/cli/attach.go
@@ -241,6 +241,11 @@ func attachInteractiveMode(ctx context.Context, manager *run.Manager, r *run.Run
 	// Wrap stdin with escape proxy to detect detach/stop sequences
 	escapeProxy := term.NewEscapeProxy(os.Stdin)
 
+	// Set up callback to update footer when escape sequence is in progress
+	if statusWriter != nil {
+		statusWriter.SetupEscapeHints(escapeProxy)
+	}
+
 	// Wrap stdin with tracer if tracing is enabled
 	stdin := io.Reader(escapeProxy)
 	if tracer != nil {

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -491,6 +491,11 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	// Wrap stdin with escape proxy to detect detach/stop sequences
 	escapeProxy := term.NewEscapeProxy(os.Stdin)
 
+	// Set up callback to update footer when escape sequence is in progress
+	if statusWriter != nil {
+		statusWriter.SetupEscapeHints(escapeProxy)
+	}
+
 	// Wrap stdin with tracer if tracing is enabled
 	stdin := io.Reader(escapeProxy)
 	if tracer != nil {

--- a/internal/term/escape_test.go
+++ b/internal/term/escape_test.go
@@ -196,3 +196,99 @@ func TestGetEscapeAction_NonEscapeError(t *testing.T) {
 		t.Errorf("GetEscapeAction(io.EOF) = %v, want EscapeNone", got)
 	}
 }
+
+func TestEscapeProxy_OnPrefixChange(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          []byte
+		wantCallbacks  []bool // sequence of callback invocations expected
+		wantFinalState bool
+	}{
+		{
+			name:           "prefix detected then completed with detach",
+			input:          []byte{EscapePrefix, 'd'},
+			wantCallbacks:  []bool{true, false},
+			wantFinalState: false,
+		},
+		{
+			name:           "prefix detected then completed with stop",
+			input:          []byte{EscapePrefix, 'k'},
+			wantCallbacks:  []bool{true, false},
+			wantFinalState: false,
+		},
+		{
+			name:           "prefix canceled with literal",
+			input:          []byte{EscapePrefix, 'x'},
+			wantCallbacks:  []bool{true, false},
+			wantFinalState: false,
+		},
+		{
+			name:           "prefix canceled with double ctrl-/",
+			input:          []byte{EscapePrefix, EscapePrefix},
+			wantCallbacks:  []bool{true, false},
+			wantFinalState: false,
+		},
+		{
+			name:           "normal data no callbacks",
+			input:          []byte("hello"),
+			wantCallbacks:  []bool{},
+			wantFinalState: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var callbacks []bool
+			r := NewEscapeProxy(bytes.NewReader(tt.input))
+			r.OnPrefixChange(func(active bool) {
+				callbacks = append(callbacks, active)
+			})
+
+			// Read all data
+			buf := make([]byte, 100)
+			for {
+				_, err := r.Read(buf)
+				if err != nil {
+					break
+				}
+			}
+
+			// Check callback sequence
+			if len(callbacks) != len(tt.wantCallbacks) {
+				t.Errorf("got %d callbacks, want %d: %v", len(callbacks), len(tt.wantCallbacks), callbacks)
+			} else {
+				for i, want := range tt.wantCallbacks {
+					if callbacks[i] != want {
+						t.Errorf("callback %d: got %v, want %v", i, callbacks[i], want)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEscapeProxy_OnPrefixChange_SplitReads(t *testing.T) {
+	// Test that prefix state is correctly tracked when EOF occurs after prefix.
+	// When prefix is followed by EOF, it's treated as a literal and state is cleared.
+	input := []byte{EscapePrefix}
+	r := NewEscapeProxy(bytes.NewReader(input))
+
+	var callbacks []bool
+	r.OnPrefixChange(func(active bool) {
+		callbacks = append(callbacks, active)
+	})
+
+	// First read gets the prefix, but EOF cancels it
+	buf := make([]byte, 10)
+	_, err := r.Read(buf)
+	if err != io.EOF {
+		t.Fatalf("expected EOF after reading prefix, got: %v", err)
+	}
+
+	// Should have callbacks for: true (prefix seen), false (canceled by EOF)
+	if len(callbacks) != 2 {
+		t.Errorf("after prefix read: got %d callbacks %v, want 2 callbacks [true, false]", len(callbacks), callbacks)
+	} else if callbacks[0] != true || callbacks[1] != false {
+		t.Errorf("after prefix read: got callbacks %v, want [true, false]", callbacks)
+	}
+}

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -197,3 +197,153 @@ func TestStatusBar_TruncationCascade(t *testing.T) {
 		t.Errorf("expected 5 runes at width 5, got %d", len([]rune(stripped)))
 	}
 }
+
+func TestStatusBar_MessageOverlay(t *testing.T) {
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetGrants([]string{"github"})
+	bar.SetDimensions(80, 24)
+
+	// Normal content should show run info
+	normal := bar.Content()
+	if !strings.Contains(normal, "run_abc123") {
+		t.Errorf("expected run ID in normal content, got %q", normal)
+	}
+	if !strings.Contains(normal, "my-agent") {
+		t.Errorf("expected agent name in normal content, got %q", normal)
+	}
+
+	// Set message overlay
+	bar.SetMessage("Escape: d (detach) · k (stop)")
+	message := bar.Content()
+
+	// Should show message, not normal content
+	if !strings.Contains(message, "Escape") {
+		t.Errorf("expected message text in overlay, got %q", message)
+	}
+	if !strings.Contains(message, "detach") {
+		t.Errorf("expected 'detach' in message, got %q", message)
+	}
+	if strings.Contains(message, "run_abc123") {
+		t.Errorf("expected run ID hidden when message is set, got %q", message)
+	}
+	if strings.Contains(message, "my-agent") {
+		t.Errorf("expected agent name hidden when message is set, got %q", message)
+	}
+
+	// Clear message
+	bar.ClearMessage()
+	restored := bar.Content()
+
+	// Should restore normal content
+	if !strings.Contains(restored, "run_abc123") {
+		t.Errorf("expected run ID restored after clearing message, got %q", restored)
+	}
+	if strings.Contains(restored, "Escape") {
+		t.Errorf("expected message cleared, got %q", restored)
+	}
+}
+
+func TestStatusBar_MessageOverlay_Width(t *testing.T) {
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetDimensions(40, 24)
+
+	// Set a message
+	bar.SetMessage("Press d to detach or k to stop")
+	content := bar.Content()
+
+	// Message should be centered and fit width
+	stripped := stripANSI(content)
+	runeCount := len([]rune(stripped))
+	if runeCount != 40 {
+		t.Errorf("expected message width = 40 runes, got %d: %q", runeCount, stripped)
+	}
+}
+
+func TestStatusBar_MessageOverlay_LongMessage(t *testing.T) {
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetDimensions(30, 24)
+
+	// Set a message longer than width
+	longMsg := "This is a very long message that should be truncated to fit"
+	bar.SetMessage(longMsg)
+	content := bar.Content()
+
+	// Should be truncated to fit
+	stripped := stripANSI(content)
+	runeCount := len([]rune(stripped))
+	if runeCount != 30 {
+		t.Errorf("expected truncated message width = 30 runes, got %d: %q", runeCount, stripped)
+	}
+}
+
+func TestStatusBar_CtrlSlashHint(t *testing.T) {
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetGrants([]string{"github"})
+	bar.SetDimensions(80, 24)
+
+	content := bar.Content()
+	stripped := stripANSI(content)
+
+	// Should show ctrl+/ hint
+	if !strings.Contains(stripped, "(ctrl+/)") {
+		t.Errorf("expected (ctrl+/) hint in content, got: %q", stripped)
+	}
+
+	// Should still show all the normal content
+	if !strings.Contains(content, "run_abc123") {
+		t.Errorf("expected run ID, got: %q", stripped)
+	}
+	if !strings.Contains(content, "my-agent") {
+		t.Errorf("expected agent name, got: %q", stripped)
+	}
+	if !strings.Contains(content, "github") {
+		t.Errorf("expected grants, got: %q", stripped)
+	}
+
+	// Hint should be dimmed
+	if !strings.Contains(content, "\x1b[2m") {
+		t.Errorf("expected dim style for hint, got: %q", content)
+	}
+
+	// Print for visual inspection
+	t.Logf("Full width (80): %q", stripped)
+}
+
+func TestStatusBar_CtrlSlashHint_TruncationCascade(t *testing.T) {
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetGrants([]string{"github", "aws"})
+
+	tests := []struct {
+		width    int
+		wantHint bool
+		name     string
+	}{
+		{80, true, "wide: hint visible"},
+		{60, true, "medium: hint visible"},
+		{45, false, "narrow: hint dropped"},
+		{35, false, "narrower: hint and grants dropped"},
+		{30, false, "very narrow: only run ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bar.SetDimensions(tt.width, 24)
+			content := bar.Content()
+			stripped := stripANSI(content)
+
+			hasHint := strings.Contains(stripped, "(ctrl+/)")
+			if hasHint != tt.wantHint {
+				t.Errorf("width %d: hasHint=%v, want %v. Content: %q",
+					tt.width, hasHint, tt.wantHint, stripped)
+			}
+
+			// Verify width constraint
+			runeCount := len([]rune(stripped))
+			if runeCount != tt.width {
+				t.Errorf("width %d: got %d runes, want %d", tt.width, runeCount, tt.width)
+			}
+
+			t.Logf("Width %d: %q", tt.width, stripped)
+		})
+	}
+}


### PR DESCRIPTION
Shows `(ctrl+/)` in the footer if there's space. Then shows escape sequences when escape shortcuts are active.