### PR TITLE
fix(security): harden audit storage and improve docker:dind warnings

### DIFF
--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1412,9 +1412,19 @@ region = %s
 	var privileged bool
 	if dockerConfig != nil && dockerConfig.Privileged {
 		privileged = true
-		log.Warn("creating privileged container - full host kernel access granted",
-			"mode", "docker:dind",
-			"security_docs", "https://majorcontext.com/moat/concepts/sandboxing#docker-modes")
+		if goruntime.GOOS == "darwin" {
+			log.Warn("creating privileged container for docker:dind",
+				"platform", "macOS",
+				"isolation", "Docker Desktop VM boundary provides host protection",
+				"risk", "Can compromise Docker engine in VM, cannot access macOS host",
+				"docs", "https://majorcontext.com/moat/concepts/sandboxing#docker-modes")
+		} else {
+			log.Warn("creating privileged container for docker:dind",
+				"platform", "Linux",
+				"risk", "CRITICAL - privileged mode grants direct host kernel access",
+				"impact", "Container can escape to host system",
+				"docs", "https://majorcontext.com/moat/concepts/sandboxing#docker-modes")
+		}
 	}
 
 	// Create network and start BuildKit sidecar if enabled

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -45,7 +45,7 @@ type RunStore struct {
 // It creates the run directory under baseDir if it doesn't exist.
 func NewRunStore(baseDir, runID string) (*RunStore, error) {
 	runDir := filepath.Join(baseDir, runID)
-	if err := os.MkdirAll(runDir, 0755); err != nil {
+	if err := os.MkdirAll(runDir, 0700); err != nil {
 		return nil, err
 	}
 	return &RunStore{
@@ -80,7 +80,7 @@ func (s *RunStore) SaveMetadata(m Metadata) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(s.dir, "metadata.json"), data, 0644)
+	return os.WriteFile(filepath.Join(s.dir, "metadata.json"), data, 0600)
 }
 
 // LoadMetadata reads the metadata from metadata.json in the run directory.


### PR DESCRIPTION
1. Audit directory permissions (storage.go)
   - Change run directory permissions from 0755 to 0700
   - Change metadata.json permissions from 0644 to 0600
   - Rationale: Audit data contains sensitive information (credentials used, network requests, commands executed) that should only be readable by the user who created the run

2. Platform-aware docker:dind warnings (manager.go)
   - Add platform-specific warning messages for privileged containers
   - macOS: Clarify Docker Desktop VM provides isolation layer
   - Linux: Emphasize CRITICAL risk of direct kernel access
   - Rationale: Current warning doesn't distinguish between macOS (where Docker Desktop VM mitigates risk) and Linux (where privileged containers have direct host kernel access)
