### PR TITLE
release: Add Homebrew tap support and update install docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,7 +25,8 @@ builds:
       - -X github.com/majorcontext/moat/cmd/moat/cli.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     name_template: >-
       {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     files:
@@ -66,6 +67,25 @@ changelog:
       order: 4
     - title: Others
       order: 999
+
+brews:
+  - name: moat
+    repository:
+      owner: majorcontext
+      name: homebrew-moat
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    commit_author:
+      name: moat-bot
+      email: bot@majorcontext.com
+    commit_msg_template: "brew: update {{ .ProjectName }} to {{ .Tag }}"
+    homepage: "https://majorcontext.com/moat"
+    description: "Run AI agents in isolated containers with credential injection and full observability"
+    license: "MIT"
+    test: |
+      system "#{bin}/moat", "version"
+    install: |
+      bin.install "moat"
 
 release:
   github:

--- a/README.md
+++ b/README.md
@@ -15,15 +15,14 @@ For design rationale and principles, see [VISION.md](VISION.md), for pretty vers
 ## Installation
 
 ```bash
-go install github.com/majorcontext/moat/cmd/moat@latest
+brew tap majorcontext/moat
+brew install moat
 ```
 
-Or build from source:
+Or with Go:
 
 ```bash
-git clone https://github.com/majorcontext/moat.git
-cd moat
-go build -o moat ./cmd/moat
+go install github.com/majorcontext/moat/cmd/moat@latest
 ```
 
 **Requirements:** Docker or Apple containers (macOS 15+ with Apple Silicon—auto-detected).

--- a/docs/content/getting-started/01-introduction.md
+++ b/docs/content/getting-started/01-introduction.md
@@ -9,8 +9,11 @@ keywords: ["moat", "ai agents", "containers", "credentials", "observability"]
 Run AI agents in isolated containers with credential injection and observability.
 
 ```bash
-go install github.com/majorcontext/moat/cmd/moat@latest
+brew tap majorcontext/moat
+brew install moat
 ```
+
+See [Installation](./02-installation.md) for other platforms and methods.
 
 ## What Moat does
 

--- a/docs/content/getting-started/02-installation.md
+++ b/docs/content/getting-started/02-installation.md
@@ -1,19 +1,38 @@
 ---
 title: "Installation"
 description: "Install Moat on macOS, Linux, or Windows with Docker or Apple containers."
-keywords: ["moat", "installation", "docker", "apple containers", "setup"]
+keywords: ["moat", "installation", "docker", "apple containers", "setup", "homebrew"]
 ---
 
 # Installation
 
 ## Requirements
 
-- **Go 1.21 or later** — For building from source
 - **Container runtime** — Docker or Apple containers (macOS 26+ with Apple Silicon)
 
 ## Install Moat
 
+### Homebrew (recommended)
+
+```bash
+brew tap majorcontext/moat
+brew install moat
+```
+
+### Download binary
+
+Download a prebuilt binary from the [GitHub releases](https://github.com/majorcontext/moat/releases) page. Archives are available for macOS (arm64, amd64) and Linux (arm64, amd64).
+
+Extract the archive and move the binary to a directory in your `PATH`:
+
+```bash
+tar xzf moat_*.tar.gz
+mv moat /usr/local/bin/
+```
+
 ### Using `go install`
+
+Requires Go 1.21 or later.
 
 ```bash
 go install github.com/majorcontext/moat/cmd/moat@latest


### PR DESCRIPTION
## Summary

- Configure GoReleaser to auto-publish a Homebrew formula to `majorcontext/homebrew-moat` on each release
- Add `HOMEBREW_TAP_TOKEN` env var to the release workflow for cross-repo push
- Fix deprecated `archives.format` → `archives.formats` in GoReleaser config
- Update README, introduction, and installation docs to show `brew install` as the recommended method
- Add binary download option to installation docs

## Setup required

A GitHub PAT (classic) with `repo` scope must be added as `HOMEBREW_TAP_TOKEN` in Actions secrets (already done).

## Test plan

- [ ] Verify GoReleaser config parses: `goreleaser check`
- [ ] Tag a release and confirm the formula in `homebrew-moat` gets updated
- [ ] `brew tap majorcontext/moat && brew install moat` works after first release
