### PR TITLE
fix(buildkit): connect to Docker Desktop's embedded BuildKit via DialHijack

### DIFF
--- a/internal/buildkit/client_test.go
+++ b/internal/buildkit/client_test.go
@@ -2,6 +2,7 @@ package buildkit
 
 import (
 	"context"
+	"net"
 	"os"
 	"testing"
 )
@@ -48,6 +49,27 @@ func TestNewClient(t *testing.T) {
 				t.Errorf("addr = %v, want %v", client.addr, tt.envVal)
 			}
 		})
+	}
+}
+
+func TestNewEmbeddedClient(t *testing.T) {
+	contextDialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		return nil, nil
+	}
+	sessionDialer := func(ctx context.Context, proto string, meta map[string][]string) (net.Conn, error) {
+		return nil, nil
+	}
+
+	c := NewEmbeddedClient(contextDialer, sessionDialer)
+
+	if !c.embedded {
+		t.Error("expected embedded to be true")
+	}
+	if c.addr != "" {
+		t.Errorf("expected empty addr, got %q", c.addr)
+	}
+	if len(c.clientOpts) != 2 {
+		t.Errorf("expected 2 clientOpts (context dialer + session dialer), got %d", len(c.clientOpts))
 	}
 }
 


### PR DESCRIPTION
The Docker SDK's ImageBuild with BuilderBuildKit is architecturally broken — it tells the daemon to use BuildKit but never establishes the gRPC session BuildKit requires for pulling images and auth. This causes "no active sessions" errors on fresh Docker Desktop installs.

Connect to Docker Desktop's embedded BuildKit properly using DialHijack on /grpc and /session — the same mechanism docker buildx uses.

Build routing is now:
```
1. BUILDKIT_HOST set       → standalone BuildKit (dind sidecar)
2. MOAT_DISABLE_BUILDKIT=1 → legacy builder directly
3. Default                 → try embedded BuildKit, fall back to legacy
```