### PR TITLE
fix(ci): restore Claude review posting and collapse previous reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -31,6 +31,13 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Collapse previous Claude reviews
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: ./.github/scripts/collapse-previous-reviews.sh
+
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
@@ -39,6 +46,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          claude_args: '--allowed-tools "Bash(gh pr comment:*)" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh api:*)"'
 


### PR DESCRIPTION
## Summary

- Restores `pull-requests: write` permission so the workflow token can post comments
- Adds `claude_args` with allowed bash tools (`gh pr comment`, `gh pr diff`, `gh pr view`, `gh api`) so the code-review plugin can post its review to the PR
- Restores the collapse-previous-reviews step that wraps old Claude reviews in `<details>` blocks

## What broke

The workflow update in #127 switched to the `code-review@claude-code-plugins` plugin approach but inadvertently removed the mechanisms Claude needs to post reviews:

1. **Permissions** — `pull-requests: write` was downgraded to `read`
2. **Allowed tools** — `claude_args` with `--allowed-tools` for `gh pr comment` etc. was removed
3. **The action's agent mode** doesn't include MCP posting servers by default — they require explicit tool references in `claude_args`

Claude was generating reviews (~$1/run, 15 turns) but the output only went to the Actions step summary, never to the PR. Every run since PR #155 (Feb 11) has been affected.

## Test plan

- [ ] Verify this PR itself gets a Claude review comment posted
- [ ] Push a follow-up commit to verify collapse of the first review