### PR TITLE
feat(cli): resolve runs by name or ID prefix

### DIFF
--- a/cmd/moat/cli/destroy.go
+++ b/cmd/moat/cli/destroy.go
@@ -9,11 +9,12 @@ import (
 )
 
 var destroyCmd = &cobra.Command{
-	Use:   "destroy [run-id]",
+	Use:   "destroy [run]",
 	Short: "Destroy a run and its resources",
 	Long: `Remove a run and clean up its container and resources.
 
-The run must be stopped before it can be destroyed.`,
+Accepts a run ID or name. The run must be stopped before it can be destroyed.
+If a name matches multiple runs, you'll be prompted to confirm.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: destroyRun,
 }
@@ -29,37 +30,43 @@ func destroyRun(cmd *cobra.Command, args []string) error {
 	}
 	defer manager.Close()
 
-	var runID string
+	var runIDs []string
 	if len(args) > 0 {
-		runID = args[0]
+		var resolveErr error
+		runIDs, resolveErr = resolveRunArg(manager, args[0], "Destroy")
+		if resolveErr != nil {
+			return resolveErr
+		}
 	} else {
 		// Find the most recent stopped run
 		runs := manager.List()
 		for _, r := range runs {
 			if r.State == run.StateStopped {
-				runID = r.ID
+				runIDs = []string{r.ID}
 				break
 			}
 		}
-		if runID == "" {
+		if len(runIDs) == 0 {
 			return fmt.Errorf("no stopped runs found to destroy")
 		}
 	}
 
-	if verbose {
-		fmt.Printf("Destroying run %s...\n", runID)
-	}
-
-	if dryRun {
-		fmt.Printf("Dry run - would destroy run %s\n", runID)
-		return nil
-	}
-
 	ctx := context.Background()
-	if err := manager.Destroy(ctx, runID); err != nil {
-		return fmt.Errorf("destroying run: %w", err)
-	}
+	for _, runID := range runIDs {
+		if verbose {
+			fmt.Printf("Destroying run %s...\n", runID)
+		}
 
-	fmt.Printf("Run %s destroyed\n", runID)
+		if dryRun {
+			fmt.Printf("Dry run - would destroy run %s\n", runID)
+			continue
+		}
+
+		if err := manager.Destroy(ctx, runID); err != nil {
+			return fmt.Errorf("destroying run %s: %w", runID, err)
+		}
+
+		fmt.Printf("Run %s destroyed\n", runID)
+	}
 	return nil
 }

--- a/cmd/moat/cli/resolve.go
+++ b/cmd/moat/cli/resolve.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/majorcontext/moat/internal/run"
+	"github.com/majorcontext/moat/internal/term"
+)
+
+// resolveRunArg resolves a user-provided argument (name or ID) to one or more
+// run IDs using the manager's Resolve method.
+//
+// When multiple runs match (e.g., multiple runs share the same name):
+//   - For TTY sessions: prints matching runs and prompts "Act on all N runs? [y/N]"
+//   - For non-TTY (piped/scripted): returns an error asking the user to specify a run ID
+//
+// The action parameter is used in the prompt (e.g., "Stop", "Destroy").
+func resolveRunArg(manager *run.Manager, arg string, action string) ([]string, error) {
+	matches, err := manager.Resolve(arg)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(matches) == 1 {
+		return []string{matches[0].ID}, nil
+	}
+
+	// Multiple matches — need disambiguation
+	return disambiguateRuns(matches, arg, action)
+}
+
+// resolveRunArgSingle resolves a user-provided argument to exactly one run ID.
+// If multiple runs match, it prints them and returns an error telling the user
+// to specify a run ID. This is used by commands that only operate on a single
+// run (e.g., logs, trace, audit, attach).
+func resolveRunArgSingle(manager *run.Manager, arg string) (string, error) {
+	matches, err := manager.Resolve(arg)
+	if err != nil {
+		return "", err
+	}
+
+	if len(matches) == 1 {
+		return matches[0].ID, nil
+	}
+
+	// Multiple matches — print them and error
+	printMatchingRuns(matches, arg)
+	return "", fmt.Errorf("name %q matches %d runs; specify a run ID to disambiguate", arg, len(matches))
+}
+
+// disambiguateRuns handles the multi-match case for batch commands.
+func disambiguateRuns(matches []*run.Run, arg string, action string) ([]string, error) {
+	printMatchingRuns(matches, arg)
+
+	// Non-TTY: error out instead of prompting
+	if !term.IsTerminal(os.Stdin) {
+		return nil, fmt.Errorf("name %q matches %d runs; specify a run ID (non-interactive mode)", arg, len(matches))
+	}
+
+	// Prompt user
+	fmt.Fprintf(os.Stderr, "%s all %d runs? [y/N]: ", action, len(matches))
+
+	reader := bufio.NewReader(os.Stdin)
+	answer, _ := reader.ReadString('\n')
+	answer = strings.TrimSpace(strings.ToLower(answer))
+
+	if answer != "y" && answer != "yes" {
+		return nil, fmt.Errorf("aborted")
+	}
+
+	ids := make([]string, len(matches))
+	for i, m := range matches {
+		ids[i] = m.ID
+	}
+	return ids, nil
+}
+
+// printMatchingRuns prints a table of matching runs to stderr.
+func printMatchingRuns(matches []*run.Run, arg string) {
+	fmt.Fprintf(os.Stderr, "Multiple runs match %q:\n", arg)
+	w := tabwriter.NewWriter(os.Stderr, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "  NAME\tRUN ID\tSTATE\tAGE")
+	for _, r := range matches {
+		fmt.Fprintf(w, "  %s\t%s\t%s\t%s\n",
+			r.Name,
+			r.ID,
+			r.State,
+			formatTimeAgo(r.CreatedAt),
+		)
+	}
+	w.Flush()
+	fmt.Fprintln(os.Stderr)
+}

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -20,6 +20,20 @@ These flags apply to all commands:
 | `--json` | Output in JSON format |
 | `-h`, `--help` | Show help for command |
 
+## Run identification
+
+Commands that operate on a run (`stop`, `destroy`, `attach`, `logs`, `trace`, `audit`, `snapshot`) accept a run ID or a run name:
+
+```bash
+moat stop run_a1b2c3d4e5f6   # by full ID
+moat stop run_a1b2                # by ID prefix
+moat stop my-agent                # by name
+```
+
+Resolution priority: exact ID > ID prefix > exact name.
+
+If a name matches multiple runs, batch commands (`stop`, `destroy`) prompt for confirmation while single-target commands (`logs`, `attach`) list the matches and ask you to specify a run ID.
+
 ## Common agent flags
 
 The agent commands (`moat claude`, `moat codex`, `moat gemini`) share the following flags. These flags work identically across `moat claude`, `moat codex`, and `moat gemini`.
@@ -414,14 +428,14 @@ moat wt clean dark-mode
 Attach to a running container.
 
 ```
-moat attach [flags] <run-id>
+moat attach [flags] <run>
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `run-id` | Run ID to attach to |
+| `run` | Run ID or name |
 
 ### Flags
 
@@ -435,7 +449,10 @@ By default, uses the run's original mode (interactive or not).
 ### Examples
 
 ```bash
-# Attach with original mode
+# Attach by name
+moat attach my-agent
+
+# Attach by ID
 moat attach run_a1b2c3d4e5f6
 
 # Force interactive
@@ -659,14 +676,14 @@ moat revoke ssh:github.com
 View container logs.
 
 ```
-moat logs [flags] [run-id]
+moat logs [flags] [run]
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `run-id` | Run ID (default: most recent) |
+| `run` | Run ID or name (default: most recent) |
 
 ### Flags
 
@@ -680,7 +697,10 @@ moat logs [flags] [run-id]
 # Most recent run
 moat logs
 
-# Specific run
+# By name
+moat logs my-agent
+
+# By ID
 moat logs run_a1b2c3d4e5f6
 
 # Last 50 lines
@@ -694,14 +714,14 @@ moat logs -n 50
 View execution traces and network requests.
 
 ```
-moat trace [flags] [run-id]
+moat trace [flags] [run]
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `run-id` | Run ID (default: most recent) |
+| `run` | Run ID or name (default: most recent) |
 
 ### Flags
 
@@ -722,7 +742,8 @@ moat trace --network
 # Network with details
 moat trace --network -v
 
-# Specific run
+# By name or ID
+moat trace --network my-agent
 moat trace --network run_a1b2c3d4e5f6
 ```
 
@@ -733,14 +754,14 @@ moat trace --network run_a1b2c3d4e5f6
 Verify audit log integrity.
 
 ```
-moat audit [flags] <run-id>
+moat audit [flags] <run>
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `run-id` | Run ID to audit |
+| `run` | Run ID or name |
 
 ### Flags
 
@@ -751,7 +772,8 @@ moat audit [flags] <run-id>
 ### Examples
 
 ```bash
-# Verify audit log
+# Verify by name or ID
+moat audit my-agent
 moat audit run_a1b2c3d4e5f6
 
 # Export proof bundle
@@ -820,14 +842,16 @@ For image details, use `moat system images`
 Stop a running container.
 
 ```
-moat stop [run-id]
+moat stop [run]
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `run-id` | Run ID (default: most recent running) |
+| `run` | Run ID or name (default: most recent running) |
+
+If a name matches multiple runs, you'll be prompted to confirm stopping all of them.
 
 ### Flags
 
@@ -841,7 +865,10 @@ moat stop [run-id]
 # Stop most recent
 moat stop
 
-# Stop specific run
+# Stop by name
+moat stop my-agent
+
+# Stop by ID
 moat stop run_a1b2c3d4e5f6
 
 # Stop all
@@ -855,12 +882,24 @@ moat stop --all
 Remove a stopped run and its artifacts.
 
 ```
-moat destroy [run-id]
+moat destroy [run]
 ```
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `run` | Run ID or name (default: most recent stopped) |
+
+If a name matches multiple runs, you'll be prompted to confirm destroying all of them.
 
 ### Examples
 
 ```bash
+# Destroy by name
+moat destroy my-agent
+
+# Destroy by ID
 moat destroy run_a1b2c3d4e5f6
 ```
 
@@ -900,10 +939,10 @@ moat clean --dry-run
 
 Create and manage workspace snapshots.
 
-When called with a run ID, creates a manual snapshot. Use subcommands to list, prune, or restore snapshots.
+When called with a run argument, creates a manual snapshot. Use subcommands to list, prune, or restore snapshots. All snapshot commands accept a run ID or name.
 
 ```
-moat snapshot <run-id> [flags]
+moat snapshot <run> [flags]
 ```
 
 ### Flags
@@ -915,6 +954,7 @@ moat snapshot <run-id> [flags]
 ### Examples
 
 ```bash
+moat snapshot my-agent
 moat snapshot run_a1b2c3d4e5f6
 moat snapshot run_a1b2c3d4e5f6 --label "before refactor"
 ```
@@ -924,13 +964,13 @@ moat snapshot run_a1b2c3d4e5f6 --label "before refactor"
 List snapshots for a run.
 
 ```
-moat snapshot list <run-id>
+moat snapshot list <run>
 ```
 
 #### Examples
 
 ```bash
-moat snapshot list run_a1b2c3d4e5f6
+moat snapshot list my-agent
 moat snapshot list run_a1b2c3d4e5f6 --json
 ```
 
@@ -939,7 +979,7 @@ moat snapshot list run_a1b2c3d4e5f6 --json
 Remove old snapshots, keeping the newest N. The pre-run snapshot is always preserved.
 
 ```
-moat snapshot prune <run-id> [flags]
+moat snapshot prune <run> [flags]
 ```
 
 #### Flags
@@ -952,7 +992,7 @@ moat snapshot prune <run-id> [flags]
 #### Examples
 
 ```bash
-moat snapshot prune run_a1b2c3d4e5f6 --keep 3
+moat snapshot prune my-agent --keep 3
 moat snapshot prune run_a1b2c3d4e5f6 --dry-run
 ```
 
@@ -961,7 +1001,7 @@ moat snapshot prune run_a1b2c3d4e5f6 --dry-run
 Restore workspace from a snapshot. If no snapshot ID is given, restores the most recent. A safety snapshot is created before in-place restores.
 
 ```
-moat snapshot restore <run-id> [snapshot-id] [flags]
+moat snapshot restore <run> [snapshot-id] [flags]
 ```
 
 #### Flags
@@ -973,7 +1013,7 @@ moat snapshot restore <run-id> [snapshot-id] [flags]
 #### Examples
 
 ```bash
-moat snapshot restore run_a1b2c3d4e5f6
+moat snapshot restore my-agent
 moat snapshot restore run_a1b2c3d4e5f6 snap_abc123
 moat snapshot restore run_a1b2c3d4e5f6 --to /tmp/recovery
 ```

--- a/internal/run/resolve.go
+++ b/internal/run/resolve.go
@@ -1,0 +1,71 @@
+package run
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/majorcontext/moat/internal/id"
+)
+
+// Resolve takes a user-provided argument (a run ID, ID prefix, or run name)
+// and returns the matching run(s).
+//
+// Resolution priority:
+//  1. Exact ID match — if arg is a valid full run ID, look it up directly.
+//  2. ID prefix match — if arg starts with "run_", scan for runs whose ID
+//     starts with arg. Useful for typing abbreviated IDs.
+//  3. Exact name match — scan all runs for those whose Name field equals arg.
+//
+// Returns an error if no runs match. The caller is responsible for handling
+// the case where multiple runs match (e.g., prompting the user).
+func (m *Manager) Resolve(arg string) ([]*Run, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// 1. Exact ID match
+	if id.IsValid(arg, "run") {
+		r, ok := m.runs[arg]
+		if !ok {
+			return nil, fmt.Errorf("run %s not found", arg)
+		}
+		return []*Run{r}, nil
+	}
+
+	// 2. ID prefix match (arg starts with "run_" but isn't a full ID)
+	if strings.HasPrefix(arg, "run_") {
+		var matches []*Run
+		for _, r := range m.runs {
+			if strings.HasPrefix(r.ID, arg) {
+				matches = append(matches, r)
+			}
+		}
+		if len(matches) > 0 {
+			sortRunsByCreatedAt(matches)
+			return matches, nil
+		}
+		// Fall through to name match
+	}
+
+	// 3. Exact name match
+	var matches []*Run
+	for _, r := range m.runs {
+		if r.Name == arg {
+			matches = append(matches, r)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no run found matching %q\n\nRun 'moat list' to see available runs.", arg)
+	}
+
+	sortRunsByCreatedAt(matches)
+	return matches, nil
+}
+
+// sortRunsByCreatedAt sorts runs newest first.
+func sortRunsByCreatedAt(runs []*Run) {
+	sort.Slice(runs, func(i, j int) bool {
+		return runs[i].CreatedAt.After(runs[j].CreatedAt)
+	})
+}

--- a/internal/run/resolve_test.go
+++ b/internal/run/resolve_test.go
@@ -1,0 +1,132 @@
+package run
+
+import (
+	"testing"
+	"time"
+)
+
+// newTestManager creates a Manager with pre-populated runs for testing.
+// No container runtime is needed since Resolve only reads the in-memory map.
+func newTestManager(runs map[string]*Run) *Manager {
+	return &Manager{
+		runs: runs,
+	}
+}
+
+func TestResolve_ExactID(t *testing.T) {
+	r := &Run{ID: "run_aabbccddeeff", Name: "my-agent", CreatedAt: time.Now()}
+	m := newTestManager(map[string]*Run{r.ID: r})
+
+	matches, err := m.Resolve("run_aabbccddeeff")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].ID != "run_aabbccddeeff" {
+		t.Errorf("expected ID run_aabbccddeeff, got %s", matches[0].ID)
+	}
+}
+
+func TestResolve_ExactID_NotFound(t *testing.T) {
+	m := newTestManager(map[string]*Run{})
+
+	_, err := m.Resolve("run_aabbccddeeff")
+	if err == nil {
+		t.Fatal("expected error for non-existent ID")
+	}
+}
+
+func TestResolve_IDPrefix(t *testing.T) {
+	r := &Run{ID: "run_aabbccddeeff", Name: "my-agent", CreatedAt: time.Now()}
+	m := newTestManager(map[string]*Run{r.ID: r})
+
+	matches, err := m.Resolve("run_aabb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].ID != "run_aabbccddeeff" {
+		t.Errorf("expected ID run_aabbccddeeff, got %s", matches[0].ID)
+	}
+}
+
+func TestResolve_IDPrefix_MultipleMatches(t *testing.T) {
+	r1 := &Run{ID: "run_aabb11223344", Name: "agent-1", CreatedAt: time.Now()}
+	r2 := &Run{ID: "run_aabb55667788", Name: "agent-2", CreatedAt: time.Now().Add(-time.Hour)}
+	m := newTestManager(map[string]*Run{r1.ID: r1, r2.ID: r2})
+
+	matches, err := m.Resolve("run_aabb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+	// Should be sorted newest first
+	if matches[0].CreatedAt.Before(matches[1].CreatedAt) {
+		t.Error("expected matches sorted newest first")
+	}
+}
+
+func TestResolve_ExactName(t *testing.T) {
+	r := &Run{ID: "run_aabbccddeeff", Name: "my-agent", CreatedAt: time.Now()}
+	m := newTestManager(map[string]*Run{r.ID: r})
+
+	matches, err := m.Resolve("my-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(matches))
+	}
+	if matches[0].Name != "my-agent" {
+		t.Errorf("expected name my-agent, got %s", matches[0].Name)
+	}
+}
+
+func TestResolve_NameMultipleMatches(t *testing.T) {
+	r1 := &Run{ID: "run_111111111111", Name: "my-agent", CreatedAt: time.Now()}
+	r2 := &Run{ID: "run_222222222222", Name: "my-agent", CreatedAt: time.Now().Add(-time.Hour)}
+	r3 := &Run{ID: "run_333333333333", Name: "other-agent", CreatedAt: time.Now()}
+	m := newTestManager(map[string]*Run{r1.ID: r1, r2.ID: r2, r3.ID: r3})
+
+	matches, err := m.Resolve("my-agent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d", len(matches))
+	}
+	// Should be sorted newest first
+	if matches[0].ID != "run_111111111111" {
+		t.Errorf("expected newest run first, got %s", matches[0].ID)
+	}
+}
+
+func TestResolve_NoMatch(t *testing.T) {
+	r := &Run{ID: "run_aabbccddeeff", Name: "my-agent", CreatedAt: time.Now()}
+	m := newTestManager(map[string]*Run{r.ID: r})
+
+	_, err := m.Resolve("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for non-existent name")
+	}
+}
+
+func TestResolve_IDPrefixFallsToName(t *testing.T) {
+	// A run whose name starts with "run_" (unlikely but should work)
+	r := &Run{ID: "run_aabbccddeeff", Name: "run_my_custom", CreatedAt: time.Now()}
+	m := newTestManager(map[string]*Run{r.ID: r})
+
+	// "run_my" doesn't prefix-match any ID, so should fall through to name match
+	// But "run_my_custom" isn't a valid ID, so name match won't trigger either
+	// This should match nothing via prefix, then try name "run_my" which also matches nothing
+	_, err := m.Resolve("run_my")
+	if err == nil {
+		t.Fatal("expected error for no match")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Manager.Resolve()` for centralized run argument resolution with priority: exact ID → ID prefix → exact name match
- Batch commands (`stop`, `destroy`) prompt `[y/N]` when a name matches multiple runs; single-target commands (`logs`, `attach`, etc.) error with a table of matches
- Updates all 7 run commands: `stop`, `destroy`, `attach`, `logs`, `trace`, `audit`, `snapshot`

Closes #119

## Test plan

- [x] Unit tests for all resolution paths (exact ID, ID not found, ID prefix, prefix multi-match, exact name, name multi-match, no match)
- [x] `go vet` and `golangci-lint` pass with 0 issues
- [x] Manual: `moat stop <name>` stops the matching run
- [x] Manual: `moat logs <name>` shows logs for the matching run
- [x] Manual: `moat stop <name>` with multiple matches prompts for confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)