### PR TITLE
perf(deps): optimize generated Dockerfile layers and conditionals

### DIFF
--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1194,6 +1194,7 @@ region = %s
 			NeedsClaudeInit:    needsClaudeInit,
 			NeedsCodexInit:     needsCodexInit,
 			NeedsGeminiInit:    needsGeminiInit,
+			NeedsFirewall:      needsProxyForFirewall,
 			UseBuildKit:        &useBuildKit,
 			ClaudeMarketplaces: claudeMarketplaces,
 			ClaudePlugins:      claudePlugins,


### PR DESCRIPTION
## Summary

Addresses #103 — optimizes Dockerfiles generated by `internal/deps/dockerfile.go`:

- **Merge apt layers**: Combined `writeBasePackages` and `writeAptPackages` into a single `writeAllAptPackages`, eliminating a duplicate `apt-get update` and reducing image layers
- **Conditional iptables**: Added `NeedsFirewall` field to `DockerfileOptions`, threaded from `manager.go`'s existing `needsProxyForFirewall`. Saves ~15MB when strict network policy isn't used
- **Drop misleading apt cleanup with BuildKit**: `rm -rf /var/lib/apt/lists/*` is now only emitted when BuildKit is disabled — with cache mounts it was a no-op running against a transient overlay

Items from the issue that were already resolved or not applicable:
- Plugin RUN layers (item 1): Already batched into a single script by `GenerateDockerfileSnippet`
- Dead USER root transition (item 4): Not actually dead — needed to restore root context for subsequent sections (dynamic deps, SSH known hosts, build hooks)

## Test plan

- [x] All existing Dockerfile tests pass
- [x] New test: `TestGenerateDockerfileNoIptablesWithoutFirewall` — iptables absent by default
- [x] New test: `TestGenerateDockerfileHasIptables` — iptables present with `NeedsFirewall: true`
- [x] New test: `TestGenerateDockerfileMergedAptPackages` — single `apt-get update`, both base and user packages present
- [x] New test: `TestGenerateDockerfileBuildKitNoAptCleanup` — no `rm -rf` with BuildKit
- [x] New test: `TestGenerateDockerfileNoBuildKitHasAptCleanup` — `rm -rf` present without BuildKit
- [x] `go build ./...` clean
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)