### PR TITLE
fix(ci): fix Claude code review with track_progress and tuned prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,3 +57,8 @@ jobs:
             Be concise and specific — quote the relevant code, explain why it's a problem,
             and suggest a fix when the solution isn't obvious. If the PR looks good, say so
             briefly.
+
+            Use inline comments for specific code issues. Use a top-level PR comment for
+            the overall summary.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

Fixes the Claude code review action which stopped posting reviews after the v1 migration.

- **`track_progress: true`** — per the [migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md), forces tag mode with tracking comments and automatic GitHub context
- **Keeps the `code-review` plugin** for the actual review skill
- **Inline comments** — enables `mcp__github_inline_comment__create_inline_comment` so Claude can comment directly on specific lines in the diff
- **Tuned review prompt** — guides Claude to act as a second pair of eyes, catching things authors or coding agents miss:
  - Bugs, logic errors, nil/zero-value pitfalls
  - Security issues (injection, credential leaks, path traversal, TOCTOU)
  - Race conditions, deadlocks, missing synchronization
  - Error handling gaps
  - Edge cases and uncovered failure modes
  - Missing/outdated docs, checked against `docs/STYLE-GUIDE.md`
  - Duplicated code that should be consolidated
  - Misuse of internal conventions (log vs ui, error message quality)
- **Collapse previous reviews** — wraps old Claude review comments in `<details>` blocks

Previous fix attempts: #161 (permissions), #163 (allowed tools whitelist).

## Test plan

- [ ] Open a new PR and verify Claude posts a review with inline comments on specific lines
- [ ] Verify a top-level summary comment is also posted
- [ ] Verify the review catches real issues, not just style nits
- [ ] Verify previous reviews get collapsed on subsequent pushes