### PR TITLE
feat(providers): add config-driven credential providers via YAML

### DIFF
--- a/cmd/moat/cli/grant.go
+++ b/cmd/moat/cli/grant.go
@@ -32,82 +32,20 @@ var grantCmd = &cobra.Command{
 Credentials are stored securely and injected into agent containers when
 requested via the --grant flag on 'moat run'.
 
-Supported providers:
-  github      GitHub token (from gh CLI, environment, or interactive prompt)
-  anthropic   Anthropic API key or Claude Code OAuth credentials
-  openai      OpenAI API key
-  gemini      Gemini API key or Gemini CLI OAuth credentials
-  aws         AWS IAM role assumption (uses host credentials to assume role)
+Run 'moat grant providers' to list all available providers.
 
 Subcommands:
+  providers   List all available credential providers
   ssh         Grant SSH access for a specific host
   mcp         Grant credentials for an MCP server
-  npm         Grant npm registry credentials (auto-discovers from .npmrc)
-
-GitHub authentication (in order of precedence):
-  1. GITHUB_TOKEN or GH_TOKEN environment variable
-  2. gh CLI token (if gh is installed and authenticated)
-  3. Interactive prompt for Personal Access Token
 
 Examples:
-  # Grant GitHub access (auto-detects gh CLI or prompts for token)
-  moat grant github
-
-  # Grant GitHub access from environment variable
-  export GITHUB_TOKEN="ghp_..."
-  moat grant github
-
-  # Use the credential in a run
-  moat run my-agent . --grant github
-
-  # Grant Anthropic access (will auto-detect Claude Code credentials)
-  moat grant anthropic
-
-  # Grant Anthropic API access from environment variable
-  export ANTHROPIC_API_KEY="sk-ant-..."
-  moat grant anthropic
-
-  # Grant AWS access via IAM role
-  moat grant aws --role=arn:aws:iam::123456789012:role/AgentRole
-
-  # Grant AWS with custom session duration and region
-  moat grant aws --role=arn:aws:iam::123456789012:role/AgentRole \
-    --region=us-west-2 --session-duration=1h
-
-  # Use AWS credential in a run (credentials auto-refresh)
-  moat run my-agent . --grant aws
-
-  # Grant OpenAI API access
-  moat grant openai
-
-  # Grant OpenAI API access from environment variable
-  export OPENAI_API_KEY="sk-..."  # set in your shell profile
-  moat grant openai
-
-  # Use OpenAI credential for Codex
-  moat run my-agent . --grant openai
-
-  # Grant Gemini access (will auto-detect Gemini CLI credentials)
-  moat grant gemini
-
-  # Grant Gemini API access from environment variable
-  export GEMINI_API_KEY="..."
-  moat grant gemini
-
-  # Use Gemini credential
-  moat gemini ./my-project
-
-  # Grant npm registry access (auto-discovers from .npmrc)
-  moat grant npm
-
-  # Grant npm access for a specific registry
-  moat grant npm --host=npm.company.com
-
-  # Use npm credential in a run
-  moat run my-agent . --grant npm
-
-If you have Claude Code installed and logged in, 'moat grant anthropic' will
-offer to import your existing OAuth credentials.`,
+  moat grant github                    # Grant GitHub access
+  moat grant anthropic                 # Grant Anthropic access
+  moat grant aws --role=arn:aws:...    # Grant AWS access via IAM role
+  moat grant gitlab                    # Grant GitLab access
+  moat grant providers                 # List all available providers
+  moat run my-agent . --grant github   # Use credential in a run`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runGrant,
 }
@@ -158,8 +96,8 @@ func runGrant(cmd *cobra.Command, args []string) error {
 	// Look up provider in registry
 	prov := provider.Get(providerName)
 	if prov == nil {
-		return fmt.Errorf("unknown provider: %s\n\nAvailable providers: %s",
-			args[0], strings.Join(provider.Names(), ", "))
+		return fmt.Errorf("unknown provider: %s\n\nRun 'moat grant providers' to list all available providers",
+			args[0])
 	}
 
 	// For AWS, validate required flags before calling Grant

--- a/cmd/moat/cli/grant_providers.go
+++ b/cmd/moat/cli/grant_providers.go
@@ -1,0 +1,98 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/majorcontext/moat/internal/provider"
+	"github.com/spf13/cobra"
+)
+
+var grantProvidersCmd = &cobra.Command{
+	Use:   "providers",
+	Short: "List available credential providers",
+	Long: `List all credential providers that can be used with 'moat grant'.
+
+Shows built-in providers (shipped with moat) and any custom providers
+defined in ~/.moat/providers/.`,
+	RunE: runGrantProviders,
+}
+
+func init() {
+	grantCmd.AddCommand(grantProvidersCmd)
+}
+
+// goProviderDescriptions provides descriptions for Go-implemented providers
+// that don't implement DescribableProvider.
+var goProviderDescriptions = map[string]string{
+	"github": "GitHub token",
+	"claude": "Anthropic API key or OAuth credentials",
+	"codex":  "OpenAI API key or OAuth credentials",
+	"gemini": "Gemini API key or OAuth credentials",
+	"aws":    "AWS IAM role assumption",
+	"npm":    "npm registry credentials",
+}
+
+// goProviderCLINames maps internal provider names to their CLI-facing names.
+var goProviderCLINames = map[string]string{
+	"claude": "anthropic",
+	"codex":  "openai",
+}
+
+type providerInfo struct {
+	Name        string `json:"provider"`
+	Description string `json:"description"`
+	Type        string `json:"type"`
+}
+
+func runGrantProviders(cmd *cobra.Command, args []string) error {
+	all := provider.All()
+
+	infos := make([]providerInfo, 0, len(all))
+	for _, p := range all {
+		// Skip agent-only providers (claude, codex, gemini) from grant listing
+		// if they have a CLI name alias — we show the alias instead
+		name := p.Name()
+		if cliName, ok := goProviderCLINames[name]; ok {
+			name = cliName
+		}
+
+		desc := ""
+		source := "builtin"
+
+		if dp, ok := p.(provider.DescribableProvider); ok {
+			desc = dp.Description()
+			source = dp.Source()
+		} else if d, ok := goProviderDescriptions[p.Name()]; ok {
+			desc = d
+		}
+
+		infos = append(infos, providerInfo{
+			Name:        name,
+			Description: desc,
+			Type:        source,
+		})
+	}
+
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].Name < infos[j].Name
+	})
+
+	if jsonOut {
+		return json.NewEncoder(os.Stdout).Encode(infos)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "PROVIDER\tDESCRIPTION\tTYPE")
+	for _, info := range infos {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", info.Name, info.Description, info.Type)
+	}
+	w.Flush()
+
+	fmt.Println("\nCustom providers can be added at ~/.moat/providers/")
+
+	return nil
+}

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -650,6 +650,23 @@ moat grant list
 moat grant list --json
 ```
 
+### moat grant providers
+
+List all available credential providers.
+
+```bash
+moat grant providers          # List all providers
+moat grant providers --json   # Output as JSON
+```
+
+Output columns:
+
+| Column | Description |
+|--------|-------------|
+| **PROVIDER** | Provider name (used with `moat grant <name>`) |
+| **DESCRIPTION** | Brief description |
+| **TYPE** | `builtin` or `custom` |
+
 ---
 
 ## moat revoke

--- a/docs/content/reference/04-grants.md
+++ b/docs/content/reference/04-grants.md
@@ -2,7 +2,7 @@
 title: "Grants reference"
 navTitle: "Grants"
 description: "Complete reference for Moat grant types: supported providers, host matching, credential sources, and configuration."
-keywords: ["moat", "grants", "credentials", "github", "anthropic", "aws", "ssh", "openai", "npm"]
+keywords: ["moat", "grants", "credentials", "github", "anthropic", "aws", "ssh", "openai", "npm", "gitlab", "brave-search", "elevenlabs", "linear", "vercel", "sentry", "datadog"]
 ---
 
 # Grants reference
@@ -23,6 +23,15 @@ Store a credential with `moat grant <provider>`, then use it in runs with `--gra
 | `aws` | All AWS service endpoints | AWS `credential_process` (STS temporary credentials) | IAM role assumption via STS |
 | `ssh:<host>` | Specified host only | SSH agent forwarding (not HTTP) | Host SSH agent (`SSH_AUTH_SOCK`) |
 | `mcp-<name>` | Host from MCP server `url` field | Configured per-server header | Interactive prompt |
+| `gitlab` | `gitlab.com`, `*.gitlab.com` | `PRIVATE-TOKEN: ...` | `GITLAB_TOKEN`, `GL_TOKEN`, or prompt |
+| `brave-search` | `api.search.brave.com` | `X-Subscription-Token: ...` | `BRAVE_API_KEY`, `BRAVE_SEARCH_API_KEY`, or prompt |
+| `elevenlabs` | `api.elevenlabs.io` | `xi-api-key: ...` | `ELEVENLABS_API_KEY` or prompt |
+| `linear` | `api.linear.app` | `Authorization: ...` | `LINEAR_API_KEY` or prompt |
+| `vercel` | `api.vercel.com`, `*.vercel.com` | `Authorization: Bearer ...` | `VERCEL_TOKEN` or prompt |
+| `sentry` | `sentry.io`, `*.sentry.io` | `Authorization: Bearer ...` | `SENTRY_AUTH_TOKEN` or prompt |
+| `datadog` | `*.datadoghq.com` | `DD-API-KEY: ...` | `DD_API_KEY`, `DATADOG_API_KEY`, or prompt |
+
+Run `moat grant providers` to list all providers, including any [custom providers](#custom-providers) you've added.
 
 ## GitHub
 
@@ -532,9 +541,34 @@ This deletes the encrypted credential file. Future runs cannot use the credentia
 
 Credentials are stored encrypted in `~/.moat/credentials/`. See [Credential management](../concepts/02-credentials.md) for encryption and storage details.
 
+## Config-driven providers
+
+The providers from `gitlab` through `datadog` in the [grant types table](#grant-types) are defined as YAML configurations shipped with the binary. They work the same as the Go-implemented providers -- credentials are stored encrypted and injected at the network layer -- but are defined declaratively.
+
+Use them the same way:
+
+```bash
+moat grant gitlab
+moat run --grant gitlab ./my-project
+```
+
+### Custom providers
+
+Add your own providers by creating YAML files in `~/.moat/providers/`. Each file defines a provider with host matching rules, header injection, and credential sources. See [Provider YAML reference](./provider-yaml) for the full schema.
+
+### Listing providers
+
+List all available providers (built-in, packaged, and custom) with:
+
+```bash
+moat grant providers
+moat grant providers --json
+```
+
 ## Related pages
 
 - [Credential management](../concepts/02-credentials.md) -- How credential injection works conceptually
 - [Security model](../concepts/08-security.md) -- Threat model and security properties
 - [CLI reference](./01-cli.md) -- Full CLI command reference, including `moat grant` subcommands
 - [agent.yaml reference](./02-agent-yaml.md) -- All `agent.yaml` fields, including `grants` and `mcp`
+- [Provider YAML reference](./provider-yaml) -- Schema for YAML-defined credential providers

--- a/docs/content/reference/07-provider-yaml.md
+++ b/docs/content/reference/07-provider-yaml.md
@@ -1,0 +1,134 @@
+---
+title: "Provider YAML reference"
+navTitle: "Provider YAML"
+description: "Schema reference for YAML-defined credential providers."
+keywords: ["moat", "provider", "yaml", "custom", "credential"]
+---
+
+# Provider YAML reference
+
+Credential providers can be defined as YAML files. Moat ships with several built-in YAML providers and loads custom providers from `~/.moat/providers/`.
+
+## Schema
+
+```yaml
+# Provider identifier, used with `moat grant <name>` and `--grant <name>`.
+name: gitlab
+
+# One-line description shown in `moat grant providers`.
+description: "GitLab personal access token"
+
+# Alternate names for the provider (optional).
+aliases: [gl]
+
+# Hosts to match for credential injection.
+# Supports exact matches and wildcard prefixes (*.example.com).
+hosts:
+  - "gitlab.com"
+  - "*.gitlab.com"
+
+# How credentials are injected into HTTP requests.
+inject:
+  header: "PRIVATE-TOKEN"   # HTTP header name to inject
+  # prefix: "Bearer "       # Optional prefix before token value (default: none)
+
+# Environment variables checked on the host during grant, in order (optional).
+# First non-empty match is used as the token value.
+source_env: [GITLAB_TOKEN, GL_TOKEN]
+
+# Environment variable set inside the container with a placeholder value (optional).
+# SDKs that read this variable will detect a configured credential.
+# The real token is injected at the network layer by the proxy.
+container_env: GITLAB_TOKEN
+
+# Endpoint to validate the token (optional). Omit to skip validation.
+validate:
+  url: "https://gitlab.com/api/v4/user"
+  # method: GET             # HTTP method (default: GET)
+  # header: "PRIVATE-TOKEN" # Header for validation request (default: inject.header)
+  # prefix: ""              # Prefix for validation request (default: inject.prefix)
+
+# Text shown when prompting for interactive token entry (optional).
+prompt: |
+  Enter a GitLab Personal Access Token.
+  Create one at: https://gitlab.com/-/user_settings/personal_access_tokens
+```
+
+## Field reference
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Provider identifier. Must be unique across all providers. |
+| `description` | string | yes | Short description for `moat grant providers` output. |
+| `aliases` | list of strings | no | Alternate names for `moat grant` and `--grant`. |
+| `hosts` | list of strings | yes | Hosts to inject credentials for. Supports `*.domain.com` wildcards. |
+| `inject.header` | string | yes | HTTP header name to inject on matching requests. |
+| `inject.prefix` | string | no | Prefix prepended to the token value (e.g., `"Bearer "`). Default: none. |
+| `source_env` | list of strings | no | Environment variables checked on the host during grant. First non-empty match is used. |
+| `container_env` | string | no | Environment variable set in the container with a placeholder value. |
+| `validate` | object | no | Endpoint to validate the token. Omit to skip validation. |
+| `validate.url` | string | yes (if `validate`) | URL to send a validation request to. |
+| `validate.method` | string | no | HTTP method. Default: `GET`. |
+| `validate.header` | string | no | Header name for the validation request. Default: same as `inject.header`. |
+| `validate.prefix` | string | no | Prefix for the validation request. Default: same as `inject.prefix`. |
+| `prompt` | string | no | Text shown when prompting for interactive token entry. |
+
+## Example
+
+A provider with token validation and `Bearer` prefix:
+
+```yaml
+name: vercel
+description: "Vercel platform API token"
+
+hosts:
+  - "api.vercel.com"
+  - "*.vercel.com"
+
+inject:
+  header: "Authorization"
+  prefix: "Bearer "
+
+source_env: [VERCEL_TOKEN]
+container_env: VERCEL_TOKEN
+
+validate:
+  url: "https://api.vercel.com/v2/user"
+
+prompt: |
+  Create a Vercel API token:
+  1. Go to https://vercel.com/account/tokens
+  2. Click "Create Token"
+  3. Copy the token value
+```
+
+```bash
+moat grant vercel
+moat run --grant vercel ./my-project
+```
+
+## Precedence
+
+When multiple providers share the same name, Moat uses the first match in this order:
+
+1. **Built-in Go providers** -- Compiled into the binary (github, anthropic, openai, gemini, npm, aws)
+2. **User YAML providers** -- Files in `~/.moat/providers/`
+3. **Embedded YAML providers** -- Shipped with Moat (gitlab, brave-search, elevenlabs, linear, vercel, sentry, datadog)
+
+User YAML providers override embedded YAML providers with the same name but cannot override built-in Go providers.
+
+## Custom providers
+
+Create a YAML file in `~/.moat/providers/`:
+
+```bash
+mkdir -p ~/.moat/providers
+```
+
+The file name does not need to match the `name` field, but keeping them consistent is recommended.
+
+After creating the file, verify it loads:
+
+```bash
+moat grant providers
+```

--- a/internal/provider/interfaces.go
+++ b/internal/provider/interfaces.go
@@ -66,6 +66,13 @@ type AgentProvider interface {
 	RegisterCLI(root *cobra.Command)
 }
 
+// DescribableProvider is an optional interface for providers that describe
+// themselves in listings like 'moat grant providers'.
+type DescribableProvider interface {
+	Description() string
+	Source() string // "builtin" or "custom"
+}
+
 // EndpointProvider exposes HTTP endpoints to containers.
 // Implemented by aws for the credential endpoint.
 type EndpointProvider interface {

--- a/internal/providers/configprovider/defaults/brave-search.yaml
+++ b/internal/providers/configprovider/defaults/brave-search.yaml
@@ -1,0 +1,22 @@
+name: brave-search
+description: "Brave Search API key"
+aliases: [brave]
+
+hosts:
+  - "api.search.brave.com"
+
+inject:
+  header: "X-Subscription-Token"
+
+source_env: [BRAVE_API_KEY, BRAVE_SEARCH_API_KEY]
+container_env: BRAVE_API_KEY
+
+validate:
+  url: "https://api.search.brave.com/res/v1/web/search?q=test&count=1"
+
+prompt: |
+  Get a Brave Search API key:
+  1. Go to https://brave.com/search/api/
+  2. Sign up or log in to your account
+  3. Subscribe to a plan (free tier available)
+  4. Copy your API key from the dashboard

--- a/internal/providers/configprovider/defaults/datadog.yaml
+++ b/internal/providers/configprovider/defaults/datadog.yaml
@@ -1,0 +1,18 @@
+name: datadog
+description: "Datadog monitoring API key"
+
+hosts:
+  - "*.datadoghq.com"
+
+inject:
+  header: "DD-API-KEY"
+
+source_env: [DD_API_KEY, DATADOG_API_KEY]
+container_env: DD_API_KEY
+
+prompt: |
+  Get a Datadog API key:
+  1. Go to https://app.datadoghq.com/organization-settings/api-keys
+  2. Click "New Key"
+  3. Give it a name and click "Create Key"
+  4. Copy the API key value

--- a/internal/providers/configprovider/defaults/elevenlabs.yaml
+++ b/internal/providers/configprovider/defaults/elevenlabs.yaml
@@ -1,0 +1,18 @@
+name: elevenlabs
+description: "ElevenLabs text-to-speech API key"
+
+hosts:
+  - "api.elevenlabs.io"
+
+inject:
+  header: "xi-api-key"
+
+source_env: [ELEVENLABS_API_KEY]
+container_env: ELEVENLABS_API_KEY
+
+prompt: |
+  Get an ElevenLabs API key:
+  1. Go to https://elevenlabs.io/app/settings/api-keys
+  2. Sign up or log in to your account
+  3. Click "Create API Key"
+  4. Copy the API key value

--- a/internal/providers/configprovider/defaults/gitlab.yaml
+++ b/internal/providers/configprovider/defaults/gitlab.yaml
@@ -1,0 +1,24 @@
+name: gitlab
+description: "GitLab personal access token"
+aliases: [gl]
+
+hosts:
+  - "gitlab.com"
+  - "*.gitlab.com"
+
+inject:
+  header: "PRIVATE-TOKEN"
+
+source_env: [GITLAB_TOKEN, GL_TOKEN]
+container_env: GITLAB_TOKEN
+
+validate:
+  url: "https://gitlab.com/api/v4/user"
+
+prompt: |
+  Create a GitLab personal access token:
+  1. Go to https://gitlab.com/-/user_settings/personal_access_tokens
+  2. Click "Add new token"
+  3. Give it a name and select the scopes you need (e.g., api, read_repository)
+  4. Click "Create personal access token"
+  5. Copy the token value

--- a/internal/providers/configprovider/defaults/linear.yaml
+++ b/internal/providers/configprovider/defaults/linear.yaml
@@ -1,0 +1,18 @@
+name: linear
+description: "Linear project management API key"
+
+hosts:
+  - "api.linear.app"
+
+inject:
+  header: "Authorization"
+
+source_env: [LINEAR_API_KEY]
+container_env: LINEAR_API_KEY
+
+prompt: |
+  Get a Linear API key:
+  1. Go to https://linear.app/settings/api
+  2. Click "Create key" under "Personal API keys"
+  3. Give it a label and click "Create"
+  4. Copy the API key value

--- a/internal/providers/configprovider/defaults/sentry.yaml
+++ b/internal/providers/configprovider/defaults/sentry.yaml
@@ -1,0 +1,24 @@
+name: sentry
+description: "Sentry error tracking API token"
+
+hosts:
+  - "sentry.io"
+  - "*.sentry.io"
+
+inject:
+  header: "Authorization"
+  prefix: "Bearer "
+
+source_env: [SENTRY_AUTH_TOKEN]
+container_env: SENTRY_AUTH_TOKEN
+
+validate:
+  url: "https://sentry.io/api/0/auth/"
+
+prompt: |
+  Create a Sentry auth token:
+  1. Go to https://sentry.io/settings/auth-tokens/
+  2. Click "Create New Token"
+  3. Select the required scopes for your use case
+  4. Click "Create Token"
+  5. Copy the token value

--- a/internal/providers/configprovider/defaults/vercel.yaml
+++ b/internal/providers/configprovider/defaults/vercel.yaml
@@ -1,0 +1,24 @@
+name: vercel
+description: "Vercel platform API token"
+
+hosts:
+  - "api.vercel.com"
+  - "*.vercel.com"
+
+inject:
+  header: "Authorization"
+  prefix: "Bearer "
+
+source_env: [VERCEL_TOKEN]
+container_env: VERCEL_TOKEN
+
+validate:
+  url: "https://api.vercel.com/v2/user"
+
+prompt: |
+  Create a Vercel API token:
+  1. Go to https://vercel.com/account/tokens
+  2. Click "Create Token"
+  3. Give it a name and select the scope
+  4. Click "Create Token"
+  5. Copy the token value

--- a/internal/providers/configprovider/loader.go
+++ b/internal/providers/configprovider/loader.go
@@ -1,0 +1,164 @@
+package configprovider
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/log"
+	"github.com/majorcontext/moat/internal/provider"
+	"github.com/majorcontext/moat/internal/proxy"
+)
+
+//go:embed defaults/*.yaml
+var defaultsFS embed.FS
+
+var registerOnce sync.Once
+
+// RegisterAll loads and registers all config-driven providers.
+// Embedded defaults are loaded first, then user-defined providers from
+// ~/.moat/providers/. Go providers (registered via init()) take precedence
+// over config-driven providers with the same name.
+// Safe to call multiple times; only the first call has any effect.
+func RegisterAll() {
+	registerOnce.Do(func() {
+		defs := loadEmbedded()
+		userNames := loadUserDir(defs)
+		registerAll(defs, userNames)
+	})
+}
+
+// loadEmbedded loads provider definitions from the embedded defaults directory.
+func loadEmbedded() map[string]ProviderDef {
+	defs := make(map[string]ProviderDef)
+
+	entries, err := defaultsFS.ReadDir("defaults")
+	if err != nil {
+		log.Debug("reading embedded defaults", "error", err)
+		return defs
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		data, err := defaultsFS.ReadFile("defaults/" + entry.Name())
+		if err != nil {
+			log.Debug("reading embedded provider", "file", entry.Name(), "error", err)
+			continue
+		}
+
+		def, err := parseProviderDef(data)
+		if err != nil {
+			log.Warn("parsing embedded provider", "file", entry.Name(), "error", err)
+			continue
+		}
+
+		defs[def.Name] = def
+	}
+
+	return defs
+}
+
+// loadUserDir loads provider definitions from ~/.moat/providers/.
+// User definitions override embedded defaults with the same name.
+// Returns the set of provider names that came from the user directory.
+func loadUserDir(defs map[string]ProviderDef) map[string]bool {
+	userNames := make(map[string]bool)
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return userNames
+	}
+
+	userDir := filepath.Join(homeDir, ".moat", "providers")
+	entries, err := os.ReadDir(userDir)
+	if err != nil {
+		// Directory doesn't exist — normal case
+		return userNames
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(userDir, entry.Name()))
+		if err != nil {
+			log.Debug("reading user provider", "file", entry.Name(), "error", err)
+			continue
+		}
+
+		def, err := parseProviderDef(data)
+		if err != nil {
+			log.Debug("parsing user provider", "file", entry.Name(), "error", err)
+			continue
+		}
+
+		defs[def.Name] = def
+		userNames[def.Name] = true
+	}
+
+	return userNames
+}
+
+// registerAll registers all loaded provider definitions with the provider registry.
+// userNames is the set of provider names loaded from the user directory.
+func registerAll(defs map[string]ProviderDef, userNames map[string]bool) {
+	for _, def := range defs {
+		// Skip if a Go provider already registered with this name
+		if provider.Get(def.Name) != nil {
+			log.Debug("skipping config provider (Go provider registered)", "name", def.Name)
+			continue
+		}
+
+		source := "builtin"
+		if userNames[def.Name] {
+			source = "custom"
+		}
+
+		cp := NewConfigProvider(def, source)
+		provider.Register(cp)
+
+		// Register aliases
+		for _, alias := range def.Aliases {
+			provider.RegisterAlias(alias, def.Name)
+		}
+
+		// Register hosts for network policy
+		proxy.RegisterGrantHosts(def.Name, def.Hosts)
+
+		// Register as a known credential provider
+		credential.RegisterDynamicProvider(credential.Provider(def.Name))
+
+		log.Debug("registered config provider", "name", def.Name, "source", source)
+	}
+}
+
+// parseProviderDef parses and validates a YAML provider definition.
+func parseProviderDef(data []byte) (ProviderDef, error) {
+	var def ProviderDef
+	if err := yaml.Unmarshal(data, &def); err != nil {
+		return ProviderDef{}, err
+	}
+	if def.Name == "" {
+		return ProviderDef{}, fmt.Errorf("provider name is required")
+	}
+	if len(def.Hosts) == 0 {
+		return ProviderDef{}, fmt.Errorf("provider %q: at least one host is required", def.Name)
+	}
+	if def.Description == "" {
+		return ProviderDef{}, fmt.Errorf("provider %q: description is required", def.Name)
+	}
+	if def.Inject.Header == "" {
+		return ProviderDef{}, fmt.Errorf("provider %q: inject.header is required", def.Name)
+	}
+	return def, nil
+}

--- a/internal/providers/configprovider/loader_test.go
+++ b/internal/providers/configprovider/loader_test.go
@@ -1,0 +1,212 @@
+package configprovider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseProviderDef(t *testing.T) {
+	yaml := `
+name: gitlab
+description: "GitLab personal access token"
+aliases: [gl]
+
+hosts:
+  - "gitlab.com"
+  - "*.gitlab.com"
+
+inject:
+  header: "PRIVATE-TOKEN"
+
+source_env: [GITLAB_TOKEN, GL_TOKEN]
+container_env: GITLAB_TOKEN
+
+validate:
+  url: "https://gitlab.com/api/v4/user"
+
+prompt: |
+  Enter a GitLab Personal Access Token.
+  Create one at: https://gitlab.com/-/user_settings/personal_access_tokens
+`
+	def, err := parseProviderDef([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parseProviderDef() error: %v", err)
+	}
+
+	if def.Name != "gitlab" {
+		t.Errorf("Name = %q, want %q", def.Name, "gitlab")
+	}
+	if def.Description != "GitLab personal access token" {
+		t.Errorf("Description = %q, want %q", def.Description, "GitLab personal access token")
+	}
+	if len(def.Aliases) != 1 || def.Aliases[0] != "gl" {
+		t.Errorf("Aliases = %v, want [gl]", def.Aliases)
+	}
+	if len(def.Hosts) != 2 {
+		t.Errorf("Hosts = %v, want 2 entries", def.Hosts)
+	}
+	if def.Inject.Header != "PRIVATE-TOKEN" {
+		t.Errorf("Inject.Header = %q, want %q", def.Inject.Header, "PRIVATE-TOKEN")
+	}
+	if def.Inject.Prefix != "" {
+		t.Errorf("Inject.Prefix = %q, want empty", def.Inject.Prefix)
+	}
+	if len(def.SourceEnv) != 2 {
+		t.Errorf("SourceEnv = %v, want 2 entries", def.SourceEnv)
+	}
+	if def.ContainerEnv != "GITLAB_TOKEN" {
+		t.Errorf("ContainerEnv = %q, want %q", def.ContainerEnv, "GITLAB_TOKEN")
+	}
+	if def.Validate == nil {
+		t.Fatal("Validate is nil, want non-nil")
+	}
+	if def.Validate.URL != "https://gitlab.com/api/v4/user" {
+		t.Errorf("Validate.URL = %q", def.Validate.URL)
+	}
+	if def.Prompt == "" {
+		t.Error("Prompt is empty, want non-empty")
+	}
+}
+
+func TestParseProviderDefWithPrefix(t *testing.T) {
+	yaml := `
+name: vercel
+description: "Vercel platform API token"
+hosts:
+  - "api.vercel.com"
+inject:
+  header: "Authorization"
+  prefix: "Bearer "
+source_env: [VERCEL_TOKEN]
+container_env: VERCEL_TOKEN
+validate:
+  url: "https://api.vercel.com/v2/user"
+`
+	def, err := parseProviderDef([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parseProviderDef() error: %v", err)
+	}
+
+	if def.Inject.Prefix != "Bearer " {
+		t.Errorf("Inject.Prefix = %q, want %q", def.Inject.Prefix, "Bearer ")
+	}
+}
+
+func TestParseProviderDefNoValidate(t *testing.T) {
+	yaml := `
+name: elevenlabs
+description: "ElevenLabs text-to-speech API key"
+hosts:
+  - "api.elevenlabs.io"
+inject:
+  header: "xi-api-key"
+source_env: [ELEVENLABS_API_KEY]
+container_env: ELEVENLABS_API_KEY
+`
+	def, err := parseProviderDef([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parseProviderDef() error: %v", err)
+	}
+
+	if def.Validate != nil {
+		t.Error("Validate should be nil when not specified")
+	}
+}
+
+func TestParseProviderDefInvalidYAML(t *testing.T) {
+	yaml := `{invalid yaml`
+	_, err := parseProviderDef([]byte(yaml))
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestParseProviderDefValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name:    "missing name",
+			yaml:    "hosts: [example.com]\ninject:\n  header: Authorization\n",
+			wantErr: "provider name is required",
+		},
+		{
+			name:    "missing hosts",
+			yaml:    "name: test\ndescription: Test\ninject:\n  header: Authorization\n",
+			wantErr: "at least one host is required",
+		},
+		{
+			name:    "missing description",
+			yaml:    "name: test\nhosts: [example.com]\ninject:\n  header: Authorization\n",
+			wantErr: "description is required",
+		},
+		{
+			name:    "missing inject header",
+			yaml:    "name: test\ndescription: Test\nhosts: [example.com]\n",
+			wantErr: "inject.header is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseProviderDef([]byte(tt.yaml))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestLoadEmbeddedDefaults(t *testing.T) {
+	defs := loadEmbedded()
+
+	if len(defs) == 0 {
+		t.Fatal("loadEmbedded() returned no definitions")
+	}
+
+	// Check that gitlab is present (one of our embedded defaults)
+	if _, ok := defs["gitlab"]; !ok {
+		t.Error("expected gitlab in embedded defaults")
+	}
+
+	// Check that brave-search is present
+	if _, ok := defs["brave-search"]; !ok {
+		t.Error("expected brave-search in embedded defaults")
+	}
+
+	// Verify a loaded definition has required fields
+	gitlab := defs["gitlab"]
+	if gitlab.Description == "" {
+		t.Error("gitlab description should not be empty")
+	}
+	if len(gitlab.Hosts) == 0 {
+		t.Error("gitlab hosts should not be empty")
+	}
+	if gitlab.Inject.Header == "" {
+		t.Error("gitlab inject.header should not be empty")
+	}
+}
+
+func TestLoadEmbeddedAllDefaults(t *testing.T) {
+	defs := loadEmbedded()
+
+	expected := []string{
+		"gitlab",
+		"brave-search",
+		"elevenlabs",
+		"linear",
+		"vercel",
+		"sentry",
+		"datadog",
+	}
+
+	for _, name := range expected {
+		if _, ok := defs[name]; !ok {
+			t.Errorf("expected %q in embedded defaults", name)
+		}
+	}
+}

--- a/internal/providers/configprovider/provider.go
+++ b/internal/providers/configprovider/provider.go
@@ -1,0 +1,182 @@
+package configprovider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/provider"
+	"github.com/majorcontext/moat/internal/provider/util"
+)
+
+// ConfigProvider implements provider.CredentialProvider using a YAML-defined ProviderDef.
+type ConfigProvider struct {
+	def    ProviderDef
+	source string // "builtin" or "custom"
+}
+
+// Verify interface compliance at compile time.
+var (
+	_ provider.CredentialProvider  = (*ConfigProvider)(nil)
+	_ provider.DescribableProvider = (*ConfigProvider)(nil)
+)
+
+// NewConfigProvider creates a new ConfigProvider from a definition.
+func NewConfigProvider(def ProviderDef, source string) *ConfigProvider {
+	return &ConfigProvider{def: def, source: source}
+}
+
+// Name returns the provider identifier.
+func (p *ConfigProvider) Name() string {
+	return p.def.Name
+}
+
+// Grant acquires credentials from environment variables or interactive prompt.
+func (p *ConfigProvider) Grant(ctx context.Context) (*provider.Credential, error) {
+	// Check source environment variables in order
+	if len(p.def.SourceEnv) > 0 {
+		if token, name := util.CheckEnvVarWithName(p.def.SourceEnv...); token != "" {
+			fmt.Printf("Using token from %s environment variable\n", name)
+			return p.validateAndCreate(ctx, token, "env")
+		}
+	}
+
+	// Interactive prompt
+	if p.def.Prompt != "" {
+		fmt.Print(p.def.Prompt)
+	} else {
+		fmt.Printf("Enter a %s token.\n", p.def.Description)
+	}
+
+	token, err := util.PromptForToken("Token")
+	if err != nil {
+		return nil, fmt.Errorf("reading token: %w", err)
+	}
+	if token == "" {
+		return nil, &provider.GrantError{
+			Provider: p.def.Name,
+			Cause:    fmt.Errorf("no token provided"),
+			Hint:     fmt.Sprintf("Run 'moat grant %s' and enter a valid token", p.def.Name),
+		}
+	}
+
+	return p.validateAndCreate(ctx, token, "prompt")
+}
+
+// validateAndCreate optionally validates the token and creates a credential.
+func (p *ConfigProvider) validateAndCreate(ctx context.Context, token, source string) (*provider.Credential, error) {
+	if p.def.Validate != nil {
+		fmt.Println("Validating token...")
+		if err := p.validateToken(ctx, token); err != nil {
+			return nil, &provider.GrantError{
+				Provider: p.def.Name,
+				Cause:    err,
+				Hint:     "Ensure your token is valid and has appropriate permissions",
+			}
+		}
+		fmt.Println("Token validated successfully")
+	}
+
+	return &provider.Credential{
+		Provider:  p.def.Name,
+		Token:     token,
+		CreatedAt: time.Now(),
+		Metadata:  map[string]string{provider.MetaKeyTokenSource: source},
+	}, nil
+}
+
+// validateToken validates a token against the configured endpoint.
+func (p *ConfigProvider) validateToken(ctx context.Context, token string) error {
+	v := p.def.Validate
+
+	method := v.Method
+	if method == "" {
+		method = "GET"
+	}
+
+	header := v.Header
+	if header == "" {
+		header = p.def.Inject.Header
+	}
+
+	prefix := v.Prefix
+	if prefix == "" && v.Header == "" {
+		// Only inherit inject prefix when header is also inherited
+		prefix = p.def.Inject.Prefix
+	}
+
+	client := &http.Client{}
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, v.URL, nil)
+	if err != nil {
+		return fmt.Errorf("creating validation request: %w", err)
+	}
+	req.Header.Set(header, prefix+token)
+	req.Header.Set("User-Agent", "moat")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("validating token: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	switch resp.StatusCode {
+	case 401:
+		return fmt.Errorf("invalid token (401 Unauthorized)")
+	case 403:
+		return fmt.Errorf("token rejected (403 Forbidden)")
+	default:
+		return fmt.Errorf("unexpected status validating token: %d", resp.StatusCode)
+	}
+}
+
+// ConfigureProxy sets up proxy headers for this credential.
+func (p *ConfigProvider) ConfigureProxy(proxy provider.ProxyConfigurer, cred *provider.Credential) {
+	headerValue := p.def.Inject.Prefix + cred.Token
+	for _, host := range p.def.Hosts {
+		proxy.SetCredentialWithGrant(host, p.def.Inject.Header, headerValue, p.def.Name)
+	}
+}
+
+// ContainerEnv returns environment variables to set in the container.
+func (p *ConfigProvider) ContainerEnv(cred *provider.Credential) []string {
+	if p.def.ContainerEnv != "" {
+		return []string{p.def.ContainerEnv + "=" + credential.ProxyInjectedPlaceholder}
+	}
+	return nil
+}
+
+// ContainerMounts returns mounts needed for this credential (none for config providers).
+func (p *ConfigProvider) ContainerMounts(cred *provider.Credential, containerHome string) ([]provider.MountConfig, string, error) {
+	return nil, "", nil
+}
+
+// Cleanup is a no-op for config providers.
+func (p *ConfigProvider) Cleanup(cleanupPath string) {}
+
+// ImpliedDependencies returns nil (no implied dependencies for config providers).
+func (p *ConfigProvider) ImpliedDependencies() []string {
+	return nil
+}
+
+// Description returns the provider description.
+func (p *ConfigProvider) Description() string {
+	return p.def.Description
+}
+
+// Source returns "builtin" or "custom" depending on origin.
+func (p *ConfigProvider) Source() string {
+	return p.source
+}

--- a/internal/providers/configprovider/provider_test.go
+++ b/internal/providers/configprovider/provider_test.go
@@ -1,0 +1,183 @@
+package configprovider
+
+import (
+	"testing"
+
+	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+func TestConfigProviderName(t *testing.T) {
+	cp := NewConfigProvider(ProviderDef{Name: "test-provider"}, "builtin")
+	if cp.Name() != "test-provider" {
+		t.Errorf("Name() = %q, want %q", cp.Name(), "test-provider")
+	}
+}
+
+func TestConfigProviderDescription(t *testing.T) {
+	cp := NewConfigProvider(ProviderDef{
+		Name:        "test",
+		Description: "Test provider",
+	}, "custom")
+	if cp.Description() != "Test provider" {
+		t.Errorf("Description() = %q, want %q", cp.Description(), "Test provider")
+	}
+}
+
+func TestConfigProviderSource(t *testing.T) {
+	tests := []struct {
+		source string
+	}{
+		{"builtin"},
+		{"custom"},
+	}
+	for _, tt := range tests {
+		cp := NewConfigProvider(ProviderDef{Name: "test"}, tt.source)
+		if cp.Source() != tt.source {
+			t.Errorf("Source() = %q, want %q", cp.Source(), tt.source)
+		}
+	}
+}
+
+type mockProxy struct {
+	calls []proxyCall
+}
+
+type proxyCall struct {
+	host, headerName, headerValue, grant string
+}
+
+func (m *mockProxy) SetCredential(host, value string)                                     {}
+func (m *mockProxy) SetCredentialHeader(host, headerName, headerValue string)             {}
+func (m *mockProxy) AddExtraHeader(host, headerName, headerValue string)                  {}
+func (m *mockProxy) AddResponseTransformer(host string, t credential.ResponseTransformer) {}
+func (m *mockProxy) RemoveRequestHeader(host, headerName string)                          {}
+func (m *mockProxy) SetTokenSubstitution(host, placeholder, realToken string)             {}
+
+func (m *mockProxy) SetCredentialWithGrant(host, headerName, headerValue, grant string) {
+	m.calls = append(m.calls, proxyCall{host, headerName, headerValue, grant})
+}
+
+func TestConfigureProxy(t *testing.T) {
+	cp := NewConfigProvider(ProviderDef{
+		Name: "gitlab",
+		Hosts: []string{
+			"gitlab.com",
+			"*.gitlab.com",
+		},
+		Inject: InjectConfig{
+			Header: "PRIVATE-TOKEN",
+		},
+	}, "builtin")
+
+	mock := &mockProxy{}
+	cred := &provider.Credential{Token: "test-token"}
+	cp.ConfigureProxy(mock, cred)
+
+	if len(mock.calls) != 2 {
+		t.Fatalf("expected 2 proxy calls, got %d", len(mock.calls))
+	}
+
+	// First host
+	if mock.calls[0].host != "gitlab.com" {
+		t.Errorf("call[0].host = %q, want %q", mock.calls[0].host, "gitlab.com")
+	}
+	if mock.calls[0].headerName != "PRIVATE-TOKEN" {
+		t.Errorf("call[0].headerName = %q, want %q", mock.calls[0].headerName, "PRIVATE-TOKEN")
+	}
+	if mock.calls[0].headerValue != "test-token" {
+		t.Errorf("call[0].headerValue = %q, want %q", mock.calls[0].headerValue, "test-token")
+	}
+	if mock.calls[0].grant != "gitlab" {
+		t.Errorf("call[0].grant = %q, want %q", mock.calls[0].grant, "gitlab")
+	}
+
+	// Second host
+	if mock.calls[1].host != "*.gitlab.com" {
+		t.Errorf("call[1].host = %q, want %q", mock.calls[1].host, "*.gitlab.com")
+	}
+}
+
+func TestConfigureProxyWithPrefix(t *testing.T) {
+	cp := NewConfigProvider(ProviderDef{
+		Name:  "vercel",
+		Hosts: []string{"api.vercel.com"},
+		Inject: InjectConfig{
+			Header: "Authorization",
+			Prefix: "Bearer ",
+		},
+	}, "builtin")
+
+	mock := &mockProxy{}
+	cred := &provider.Credential{Token: "my-token"}
+	cp.ConfigureProxy(mock, cred)
+
+	if len(mock.calls) != 1 {
+		t.Fatalf("expected 1 proxy call, got %d", len(mock.calls))
+	}
+	if mock.calls[0].headerValue != "Bearer my-token" {
+		t.Errorf("headerValue = %q, want %q", mock.calls[0].headerValue, "Bearer my-token")
+	}
+}
+
+func TestContainerEnv(t *testing.T) {
+	tests := []struct {
+		name         string
+		containerEnv string
+		want         []string
+	}{
+		{
+			name:         "with container_env",
+			containerEnv: "GITLAB_TOKEN",
+			want:         []string{"GITLAB_TOKEN=" + credential.ProxyInjectedPlaceholder},
+		},
+		{
+			name:         "no container_env",
+			containerEnv: "",
+			want:         nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cp := NewConfigProvider(ProviderDef{
+				Name:         "test",
+				ContainerEnv: tt.containerEnv,
+			}, "builtin")
+			got := cp.ContainerEnv(&provider.Credential{Token: "tok"})
+			if len(got) != len(tt.want) {
+				t.Fatalf("ContainerEnv() returned %d items, want %d", len(got), len(tt.want))
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("ContainerEnv()[%d] = %q, want %q", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestContainerMountsReturnsNil(t *testing.T) {
+	cp := NewConfigProvider(ProviderDef{Name: "test"}, "builtin")
+	mounts, cleanup, err := cp.ContainerMounts(&provider.Credential{}, "/home/user")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mounts != nil {
+		t.Error("expected nil mounts")
+	}
+	if cleanup != "" {
+		t.Error("expected empty cleanup path")
+	}
+}
+
+func TestImpliedDependenciesReturnsNil(t *testing.T) {
+	cp := NewConfigProvider(ProviderDef{Name: "test"}, "builtin")
+	if deps := cp.ImpliedDependencies(); deps != nil {
+		t.Errorf("ImpliedDependencies() = %v, want nil", deps)
+	}
+}
+
+func TestInterfaceCompliance(t *testing.T) {
+	var _ provider.CredentialProvider = (*ConfigProvider)(nil)
+	var _ provider.DescribableProvider = (*ConfigProvider)(nil)
+}

--- a/internal/providers/configprovider/types.go
+++ b/internal/providers/configprovider/types.go
@@ -1,0 +1,28 @@
+package configprovider
+
+// ProviderDef defines a credential provider via YAML configuration.
+type ProviderDef struct {
+	Name         string          `yaml:"name"`
+	Description  string          `yaml:"description"`
+	Aliases      []string        `yaml:"aliases,omitempty"`
+	Hosts        []string        `yaml:"hosts"`
+	Inject       InjectConfig    `yaml:"inject"`
+	SourceEnv    []string        `yaml:"source_env,omitempty"`
+	ContainerEnv string          `yaml:"container_env,omitempty"`
+	Validate     *ValidateConfig `yaml:"validate,omitempty"`
+	Prompt       string          `yaml:"prompt,omitempty"`
+}
+
+// InjectConfig defines how credentials are injected into HTTP requests.
+type InjectConfig struct {
+	Header string `yaml:"header"`
+	Prefix string `yaml:"prefix,omitempty"`
+}
+
+// ValidateConfig defines an optional endpoint for token validation.
+type ValidateConfig struct {
+	URL    string `yaml:"url"`
+	Method string `yaml:"method,omitempty"` // default: GET
+	Header string `yaml:"header,omitempty"` // default: inject.header
+	Prefix string `yaml:"prefix,omitempty"` // default: inject.prefix
+}

--- a/internal/providers/register.go
+++ b/internal/providers/register.go
@@ -12,13 +12,15 @@ import (
 	_ "github.com/majorcontext/moat/internal/providers/gemini" // registers Gemini/Google provider
 	_ "github.com/majorcontext/moat/internal/providers/github" // registers GitHub provider
 	_ "github.com/majorcontext/moat/internal/providers/npm"    // registers npm provider
+
+	"github.com/majorcontext/moat/internal/providers/configprovider"
 )
 
-// RegisterAll is a no-op provided for explicit registration semantics.
-// All providers self-register via init() when this package is imported.
-// This function exists so callers can write providers.RegisterAll() to
-// make the registration explicit rather than relying on blank import side effects.
+// RegisterAll registers all credential providers.
+// Go providers self-register via init() when this package is imported.
+// Config-driven providers are loaded after, so Go providers take precedence.
 func RegisterAll() {
-	// Providers register themselves via init() on import.
-	// This function exists for documentation and explicit call semantics.
+	// Go providers already registered via init() on import.
+	// Config-driven providers loaded after, so Go providers take precedence.
+	configprovider.RegisterAll()
 }

--- a/internal/proxy/hosts.go
+++ b/internal/proxy/hosts.go
@@ -111,6 +111,13 @@ var grantHosts = map[string][]string{
 	},
 }
 
+// RegisterGrantHosts registers host patterns for a grant name.
+// This is used by config-driven providers to register their hosts dynamically.
+// Must be called during initialization only (before concurrent access).
+func RegisterGrantHosts(grant string, hosts []string) {
+	grantHosts[grant] = hosts
+}
+
 // GetHostsForGrant returns the host patterns for a given grant name.
 // Supports scoped grants like "github:repo" by extracting the provider name.
 // Returns an empty slice if the grant is unknown.


### PR DESCRIPTION
Used OpenClaw as inspiration for providers that we should support. Some will require oauth integration and token refresh, but a number can work with static credentials.

  - Add YAML-defined credential providers so new services can be supported without writing Go code
  - Ship 7 packaged providers: gitlab, brave-search, elevenlabs, linear, vercel, sentry, datadog
  - Add `moat grant providers` subcommand to list all available providers
  - Users can add custom providers at `~/.moat/providers/`

  ## How it works

  A YAML file defines the provider name, target hosts, header injection rules, environment variables to check, optional token validation, and an interactive prompt. At startup, `configprovider.RegisterAll()`
  loads embedded defaults and user YAML, registering each as a full `CredentialProvider`. Go providers always take precedence; user YAML overrides embedded YAML.

  ## Changes

  **New package:** `internal/providers/configprovider/` — types, provider implementation, loader, embedded defaults, tests

  **Modified:**
  - `internal/provider/interfaces.go` — `DescribableProvider` interface
  - `internal/proxy/hosts.go` — `RegisterGrantHosts()` for dynamic host registration
  - `internal/credential/types.go` — `RegisterDynamicProvider()` + updated `KnownProviders`/`IsKnownProvider`
  - `internal/providers/register.go` — wires up `configprovider.RegisterAll()`
  - `cmd/moat/cli/grant.go` — shorter help text, error points to `moat grant providers`
  - `cmd/moat/cli/grant_providers.go` — new `moat grant providers` subcommand

  **Docs:**
  - `docs/content/reference/04-grants.md` — all providers in grant types table, config-driven section
  - `docs/content/reference/07-provider-yaml.md` — YAML schema reference
  - `docs/content/reference/01-cli.md` — `moat grant providers` subcommand