### PR TITLE
fix(deps): replace hardcoded Python versions with live API query

### DIFF
--- a/internal/deps/versions/python.go
+++ b/internal/deps/versions/python.go
@@ -122,14 +122,16 @@ func resolvePythonVersion(version string, cycles []pythonCycle) (string, error) 
 		return "", fmt.Errorf("no Python %d.%d.x releases found", major, minor)
 	}
 
+	// Validate the Latest field from the API before using it.
+	_, _, latestPatch, latestOK := parseSemver(matched.Latest)
+	if !latestOK || latestPatch < 0 {
+		return "", fmt.Errorf("malformed version %q in API response for cycle %s", matched.Latest, matched.Cycle)
+	}
+
 	// If fully specified, verify it exists.
 	// CPython patches are sequential (0, 1, 2, ...), so a patch version exists
 	// if its number is between 0 and the latest known patch.
 	if patch >= 0 {
-		_, _, latestPatch, ok := parseSemver(matched.Latest)
-		if !ok || latestPatch < 0 {
-			return "", fmt.Errorf("malformed version %q in API response for cycle %s", matched.Latest, matched.Cycle)
-		}
 		if patch <= latestPatch {
 			return version, nil
 		}

--- a/internal/deps/versions/python_test.go
+++ b/internal/deps/versions/python_test.go
@@ -118,16 +118,16 @@ func TestPythonResolver_Resolve_malformedLatest(t *testing.T) {
 
 	resolver := newTestPythonResolver(server)
 
-	// Partial version still returns the raw latest (caller can validate downstream)
-	got, err := resolver.Resolve(context.Background(), "3.12")
-	if err != nil {
-		t.Fatalf("Resolve(partial) error = %v", err)
+	// Partial version with malformed latest returns a clear error
+	_, err := resolver.Resolve(context.Background(), "3.12")
+	if err == nil {
+		t.Fatal("Resolve(partial) expected error for malformed latest")
 	}
-	if got != "bad-version" {
-		t.Errorf("Resolve(partial) = %v, want bad-version", got)
+	if got := err.Error(); got != `malformed version "bad-version" in API response for cycle 3.12` {
+		t.Errorf("Resolve(partial) error = %q, want malformed version error", got)
 	}
 
-	// Exact version with malformed latest returns a clear error
+	// Exact version with malformed latest also returns a clear error
 	_, err = resolver.Resolve(context.Background(), "3.12.5")
 	if err == nil {
 		t.Fatal("Resolve(exact) expected error for malformed latest")


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `pythonVersions` list with a live query to the [endoflife.date Python API](https://endoflife.date/api/python.json), matching the pattern already used by the Go and Node resolvers
- Adds `HTTPClient` field to `PythonResolver` for testability (consistent with `GoResolver` and `NodeResolver`)
- Extracts resolution logic into testable package-level functions (`resolvePythonVersion`, `pythonVersionsFromCycles`, `latestStablePython`)
- Filters `Available()` and `LatestStable()` to Python 3.x only, while `Resolve()` supports any cycle (including 2.7)
- Validates exact versions by checking patch number against the latest known patch (CPython patches are sequential)

Closes #56

## Test plan

- [x] All existing test cases preserved and passing with mock HTTP server
- [x] Added boundary tests (patch 0, latest patch, 2.x cycle access)
- [x] Added `LatestStable` edge case for no Python 3.x cycles
- [x] Added `Available` ordering test (ensures newest-first regardless of API order)
- [x] `go build ./...` passes
- [x] `golangci-lint run` passes with 0 issues
- [x] Caching layer (`CachedResolver`) continues to work transparently since the `Resolver` interface is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)