### PR TITLE
fix(snapshot): consider current file size in total-size guard

### DIFF
--- a/internal/snapshot/archive.go
+++ b/internal/snapshot/archive.go
@@ -279,7 +279,7 @@ func (b *ArchiveBackend) RestoreTo(nativeRef, destPath string) error {
 			}
 
 			// Check total size limit before writing
-			if totalWritten > maxArchiveTotalSize {
+			if totalWritten+header.Size > maxArchiveTotalSize {
 				_ = f.Close()
 				return fmt.Errorf("archive exceeds maximum total extracted size (limit: %d bytes)", maxArchiveTotalSize)
 			}


### PR DESCRIPTION
Previously, the totalWritten was compared against maxArchiveTotalSize before the current file gets written, which means that it's file size was not considered as part of the check.

This change simply updates the code to also take the current file's size into account as part of the guard.