### PR TITLE
fix(snapshot): prevent silent truncation of large files

### DIFF
--- a/internal/snapshot/archive.go
+++ b/internal/snapshot/archive.go
@@ -284,6 +284,12 @@ func (b *ArchiveBackend) RestoreTo(nativeRef, destPath string) error {
 				return fmt.Errorf("archive exceeds maximum total extracted size (limit: %d bytes)", maxArchiveTotalSize)
 			}
 
+			// Check file size before attempting to copy
+			if header.Size > maxArchiveFileSize {
+				_ = f.Close()
+				return fmt.Errorf("file exceeds maximum file size (limit: %d bytes)", maxArchiveFileSize)
+			}
+
 			// Limit copy size to prevent decompression bombs
 			written, copyErr := io.Copy(f, io.LimitReader(tr, maxArchiveFileSize))
 			totalWritten += written


### PR DESCRIPTION
A file that exceeded the 1GB per file limit could be read up to the maximum limit of 1GB, but then silently skipped over the remaining contents.

This change makes the RestoreTo code return an error if any of the individual files in the archive were to exceed the maximum file size.