### PR TITLE
ci: skip secret-requiring jobs for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
 
   e2e:
     name: E2E Tests
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip E2E tests and Claude Code review for fork PRs since they can't access repository secrets
- Fork PRs still get Lint and Test jobs, which catch code issues without needing secrets
- E2E job condition also allows `push` events (merges to main) to continue running

Fixes the failures seen on #208 and #209 (submitted from a fork).

## Test plan
- [ ] Verify CI passes on this PR (from same repo — all jobs should run)
- [ ] Verify fork PRs show E2E and claude-review as skipped, not failed