### PR TITLE
fix(image): include firewall flag in image tag hash

### DIFF
--- a/internal/deps/builder.go
+++ b/internal/deps/builder.go
@@ -22,6 +22,9 @@ type ImageTagOptions struct {
 	// NeedsGeminiInit indicates the image needs the init script for Gemini setup.
 	NeedsGeminiInit bool
 
+	// NeedsFirewall indicates the image needs iptables for strict network policy.
+	NeedsFirewall bool
+
 	// ClaudePlugins are plugins baked into the image.
 	// Format: "plugin-name@marketplace-name"
 	ClaudePlugins []string
@@ -67,6 +70,9 @@ func ImageTag(deps []Dependency, opts *ImageTagOptions) string {
 	}
 	if opts.NeedsGeminiInit {
 		hashInput += ",gemini:init"
+	}
+	if opts.NeedsFirewall {
+		hashInput += ",firewall:iptables"
 	}
 
 	// Include plugins in hash (different plugins = different image).

--- a/internal/deps/builder_test.go
+++ b/internal/deps/builder_test.go
@@ -81,6 +81,15 @@ func TestImageTagWithHooks(t *testing.T) {
 	}
 }
 
+func TestImageTagWithFirewall(t *testing.T) {
+	deps := []Dependency{{Name: "python", Version: "3.11"}}
+	tagWithout := ImageTag(deps, nil)
+	tagWith := ImageTag(deps, &ImageTagOptions{NeedsFirewall: true})
+	if tagWithout == tagWith {
+		t.Error("firewall option should affect tag")
+	}
+}
+
 func TestImageTagDockerModes(t *testing.T) {
 	// docker:host and docker:dind should produce different image tags
 	// because they install different packages (CLI-only vs full daemon)

--- a/internal/image/resolver.go
+++ b/internal/image/resolver.go
@@ -20,6 +20,9 @@ type ResolveOptions struct {
 	// NeedsGeminiInit indicates the image needs the init script for Gemini setup.
 	NeedsGeminiInit bool
 
+	// NeedsFirewall indicates the image needs iptables for strict network policy.
+	NeedsFirewall bool
+
 	// ClaudePlugins are plugins baked into the image.
 	// Format: "plugin-name@marketplace-name"
 	ClaudePlugins []string
@@ -38,8 +41,8 @@ func Resolve(depList []deps.Dependency, opts *ResolveOptions) string {
 
 	hasHooks := opts.Hooks != nil && (opts.Hooks.PostBuild != "" || opts.Hooks.PostBuildRoot != "" || opts.Hooks.PreRun != "")
 
-	// Need custom image if we have dependencies, SSH, Claude init, Codex init, Gemini init, plugins, or hooks
-	needsCustomImage := len(depList) > 0 || opts.NeedsSSH || opts.NeedsClaudeInit || opts.NeedsCodexInit || opts.NeedsGeminiInit || len(opts.ClaudePlugins) > 0 || hasHooks
+	// Need custom image if we have dependencies, SSH, Claude init, Codex init, Gemini init, plugins, hooks, or firewall
+	needsCustomImage := len(depList) > 0 || opts.NeedsSSH || opts.NeedsClaudeInit || opts.NeedsCodexInit || opts.NeedsGeminiInit || opts.NeedsFirewall || len(opts.ClaudePlugins) > 0 || hasHooks
 	if !needsCustomImage {
 		return DefaultImage
 	}
@@ -49,6 +52,7 @@ func Resolve(depList []deps.Dependency, opts *ResolveOptions) string {
 		NeedsClaudeInit: opts.NeedsClaudeInit,
 		NeedsCodexInit:  opts.NeedsCodexInit,
 		NeedsGeminiInit: opts.NeedsGeminiInit,
+		NeedsFirewall:   opts.NeedsFirewall,
 		ClaudePlugins:   opts.ClaudePlugins,
 		Hooks:           opts.Hooks,
 	})

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1331,6 +1331,7 @@ region = %s
 		NeedsClaudeInit: needsClaudeInit,
 		NeedsCodexInit:  needsCodexInit,
 		NeedsGeminiInit: needsGeminiInit,
+		NeedsFirewall:   needsProxyForFirewall,
 		ClaudePlugins:   claudePlugins,
 		Hooks:           hooks,
 	})
@@ -1343,7 +1344,7 @@ region = %s
 
 	// Determine if we need a custom image
 	hasHooks := hooks != nil
-	needsCustomImage := len(installableDeps) > 0 || hasSSHGrants || needsClaudeInit || needsCodexInit || needsGeminiInit || len(claudePlugins) > 0 || hasHooks
+	needsCustomImage := len(installableDeps) > 0 || hasSSHGrants || needsClaudeInit || needsCodexInit || needsGeminiInit || needsProxyForFirewall || len(claudePlugins) > 0 || hasHooks
 
 	// Handle --rebuild: delete existing image to force fresh build
 	if opts.Rebuild && needsCustomImage {


### PR DESCRIPTION
## Summary

- The `NeedsFirewall` flag was passed to Dockerfile generation (correctly adding `iptables` to apt packages) but was **not** included in the image tag hash
- This caused cached images built without firewall support to be reused for runs with `network.policy: strict`, resulting in `iptables not found` errors at runtime (e.g. `moat run examples/firewall`)
- Include `NeedsFirewall` in `ImageTagOptions`, `ResolveOptions`, and the `needsCustomImage` check so firewall-enabled runs produce a distinct image tag

## Test plan

- [x] `make test-unit` passes (including new `TestImageTagWithFirewall`)
- [x] `make lint` clean
- [x] Manual test: `moat run examples/firewall` — all 3 tests pass (allowed request, blocked request, blocked socket)