### PR TITLE
fix(deps): resolve default runtime versions to prevent broken tarball URLs

### DIFF
--- a/internal/deps/resolve.go
+++ b/internal/deps/resolve.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/majorcontext/moat/internal/deps/versions"
+	"github.com/majorcontext/moat/internal/log"
 )
 
 // versionCache is the global cache for resolved versions.
@@ -34,14 +35,30 @@ func ResolveVersions(ctx context.Context, deps []Dependency) ([]Dependency, erro
 	for i, dep := range deps {
 		result[i] = dep // Copy the dependency
 
-		// Skip if no version specified or not a runtime
-		if dep.Version == "" {
-			continue
-		}
-
 		spec, ok := GetSpec(dep.Name)
 		if !ok || spec.Type != TypeRuntime {
 			continue
+		}
+
+		// If no version specified, use the registry default.
+		// This ensures default versions like "1.25" get resolved to a full
+		// patch version (e.g., "1.25.8"), preventing broken tarball URLs
+		// when the runtime is installed via curl rather than a base image.
+		version := dep.Version
+		if version == "" {
+			version = spec.Default
+			if version == "" {
+				continue
+			}
+		}
+
+		// Populate the version and OriginalVersion into the result now, so
+		// even if resolution fails below, the Dockerfile generator sees the
+		// default rather than an empty string, and selectBaseImage can use
+		// OriginalVersion for Docker Hub floating tags.
+		result[i].Version = version
+		if dep.Version == "" {
+			result[i].OriginalVersion = version
 		}
 
 		// Get cached resolver for this runtime
@@ -51,14 +68,17 @@ func ResolveVersions(ctx context.Context, deps []Dependency) ([]Dependency, erro
 		}
 
 		// Resolve the version
-		resolved, err := resolver.Resolve(ctx, dep.Version)
+		resolved, err := resolver.Resolve(ctx, version)
 		if err != nil {
-			// If resolution fails, keep the original version
-			// This allows users to specify exact versions that may not be in APIs
+			// Resolution failed — the partial version (e.g., "1.25") may
+			// produce a broken tarball URL at build time. Log a warning so
+			// the user knows resolution was skipped.
+			log.Warn("version resolution failed, using unresolved version",
+				"runtime", dep.Name, "version", version, "error", err)
 			continue
 		}
 
-		result[i].OriginalVersion = dep.Version
+		result[i].OriginalVersion = version
 		result[i].Version = resolved
 	}
 

--- a/internal/deps/resolve_test.go
+++ b/internal/deps/resolve_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 func TestResolveVersions(t *testing.T) {
-	// Use a fresh in-memory cache for testing
-	SetVersionCache(versions.NewCache(24*time.Hour, ""))
+	// Pre-seed cache so tests don't hit the network
+	cache := versions.NewCache(24*time.Hour, "")
+	cache.Set("go@1.25", "1.25.8")
+	cache.Set("node@22", "22.14.0")
+	SetVersionCache(cache)
 
 	ctx := context.Background()
 
@@ -40,13 +43,31 @@ func TestResolveVersions(t *testing.T) {
 			},
 		},
 		{
-			name: "runtime without version unchanged",
+			name: "runtime without version resolves default",
 			deps: []Dependency{
-				{Name: "node"},
+				{Name: "go"},
+			},
+			validate: func(t *testing.T, deps []Dependency) {
+				// When no version is specified, ResolveVersions should populate
+				// the registry default and resolve it to a full patch version.
+				// This prevents tarball URLs like "go1.25.linux-amd64.tar.gz"
+				// (which don't exist) when Go is installed via curl.
+				if deps[0].Version != "1.25.8" {
+					t.Errorf("go version should be resolved to 1.25.8, got %q", deps[0].Version)
+				}
+				if deps[0].OriginalVersion != "1.25" {
+					t.Errorf("go OriginalVersion should be 1.25, got %q", deps[0].OriginalVersion)
+				}
+			},
+		},
+		{
+			name: "non-runtime without version unchanged",
+			deps: []Dependency{
+				{Name: "jq"},
 			},
 			validate: func(t *testing.T, deps []Dependency) {
 				if deps[0].Version != "" {
-					t.Errorf("node version should remain empty, got %q", deps[0].Version)
+					t.Errorf("jq version should remain empty, got %q", deps[0].Version)
 				}
 			},
 		},
@@ -112,7 +133,6 @@ func TestResolveVersionsOriginalVersionEmptyWhenUnchanged(t *testing.T) {
 
 	ctx := context.Background()
 	deps := []Dependency{
-		{Name: "node"},                    // No version specified
 		{Name: "jq"},                      // Non-runtime dependency
 		{Name: "protoc", Version: "25.1"}, // Non-runtime with version
 	}
@@ -148,5 +168,39 @@ func TestResolveVersionsPreservesOriginalOnError(t *testing.T) {
 	// Original version should be preserved since resolution failed
 	if result[0].Version != "99.99" {
 		t.Errorf("Expected version to remain 99.99, got %q", result[0].Version)
+	}
+}
+
+func TestResolveVersionsDefaultPopulatedOnError(t *testing.T) {
+	// When no version is specified and resolution fails (e.g., network error),
+	// the default version should still be populated so the Dockerfile generator
+	// doesn't fall back to the bare default (e.g., "1.25") which produces
+	// broken tarball URLs.
+	//
+	// Pre-seed cache with an error-inducing value by NOT seeding it,
+	// then use a canceled context to force resolution failure.
+	SetVersionCache(versions.NewCache(24*time.Hour, ""))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately to force resolver failure
+
+	deps := []Dependency{
+		{Name: "go"}, // No version; default "1.25" should be populated even on failure
+	}
+
+	result, err := ResolveVersions(ctx, deps)
+	if err != nil {
+		t.Fatalf("ResolveVersions() unexpected error: %v", err)
+	}
+
+	// Even though resolution failed, Version should be populated with the
+	// registry default rather than remaining empty.
+	if result[0].Version != "1.25" {
+		t.Errorf("go version should be registry default %q on resolution failure, got %q", "1.25", result[0].Version)
+	}
+	// OriginalVersion should also be set so selectBaseImage can use it
+	// for Docker Hub floating tags.
+	if result[0].OriginalVersion != "1.25" {
+		t.Errorf("go OriginalVersion should be registry default %q on resolution failure, got %q", "1.25", result[0].OriginalVersion)
 	}
 }


### PR DESCRIPTION
## Summary

- When a runtime dependency (e.g., `go`) had no explicit version in `moat.yaml`, `ResolveVersions` skipped it entirely because `dep.Version` was empty
- The registry default (e.g., `"1.25"`) was only applied later in the Dockerfile generator, bypassing version resolution
- This produced tarball URLs like `go1.25.linux-amd64.tar.gz` which don't exist — Go tarballs require full patch versions (`go1.25.0`, `go1.25.8`)
- The bug was masked when Go was the sole runtime (Docker Hub's `golang:1.25` floating tag works), only surfacing with multiple runtimes that trigger the tarball install path
- Fix: `ResolveVersions` now populates the registry default before resolution, so `"1.25"` → `"1.25.8"`. `OriginalVersion` is preserved for Docker Hub floating tag selection.

## Test plan

- [x] New test `runtime without version resolves default` — verifies default versions go through resolution
- [x] Updated existing tests that encoded the buggy behavior
- [x] All existing resolve and dockerfile tests pass
- [x] `go vet ./...` clean