### PR TITLE
fix(github): strip nil values from gh config to prevent YAML null round-trip

### DIFF
--- a/internal/providers/github/provider.go
+++ b/internal/providers/github/provider.go
@@ -105,11 +105,13 @@ func sanitizeGhConfig(content []byte) ([]byte, error) {
 	}
 	delete(cfg, "hosts")
 	delete(cfg, "oauth_token")
+	// Remove http_unix_socket — the proxy handles HTTP transport.
 	// Remove nil values to prevent YAML null serialization.
 	// When gh CLI encounters `http_unix_socket: null` in config.yml,
 	// it interprets the YAML null as the literal string "null" and
 	// tries to connect to a unix socket at that path. Stripping nil
 	// values avoids this (see #234).
+	delete(cfg, "http_unix_socket")
 	for k, v := range cfg {
 		if v == nil {
 			delete(cfg, k)

--- a/internal/providers/github/provider_test.go
+++ b/internal/providers/github/provider_test.go
@@ -266,6 +266,18 @@ func TestSanitizeGhConfig(t *testing.T) {
 			input:   ":\t:\n",
 			wantNil: true,
 		},
+		{
+			name:     "strips nil values to prevent YAML null round-trip",
+			input:    "git_protocol: https\neditor:\npager:\nbrowser:\nhttp_unix_socket:\n",
+			contains: []string{"git_protocol: https"},
+			excludes: []string{"null", "http_unix_socket", "editor", "pager", "browser"},
+		},
+		{
+			name:     "strips http_unix_socket even when set",
+			input:    "git_protocol: ssh\nhttp_unix_socket: /tmp/gh.sock\n",
+			contains: []string{"git_protocol: ssh"},
+			excludes: []string{"http_unix_socket", "/tmp/gh.sock"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Fixes `dial unix null: connect: no such file or directory` errors when using `gh` CLI inside moat containers.

## Root cause
The gh CLI config (`~/.config/gh/config.yml`) commonly has empty fields like:
```yaml
http_unix_socket:
editor:
pager:
```

Moat copies this config into the container after sanitizing credentials. The YAML round-trip (unmarshal → re-marshal) converts empty/nil values to the string `"null"`:
```yaml
http_unix_socket: null
```

The `gh` CLI interprets this as a Unix socket path and tries to dial it, producing the error.

## Fix
- Strip `http_unix_socket` entirely (proxy handles HTTP transport)
- Remove all nil values to prevent the same issue with other empty fields

## Test plan
- [x] `go test ./internal/providers/github/ -run TestSanitize -v`
- [x] Run `moat run --grant github -- gh api user` and verify it works