### PR TITLE
fix(github): strip null values from gh config to prevent unix socket error

### DIFF
--- a/internal/providers/github/provider.go
+++ b/internal/providers/github/provider.go
@@ -105,6 +105,16 @@ func sanitizeGhConfig(content []byte) ([]byte, error) {
 	}
 	delete(cfg, "hosts")
 	delete(cfg, "oauth_token")
+	// Remove nil values to prevent YAML null serialization.
+	// When gh CLI encounters `http_unix_socket: null` in config.yml,
+	// it interprets the YAML null as the literal string "null" and
+	// tries to connect to a unix socket at that path. Stripping nil
+	// values avoids this (see #234).
+	for k, v := range cfg {
+		if v == nil {
+			delete(cfg, k)
+		}
+	}
 	if len(cfg) == 0 {
 		return nil, nil
 	}

--- a/internal/providers/github/provider_test.go
+++ b/internal/providers/github/provider_test.go
@@ -251,6 +251,17 @@ func TestSanitizeGhConfig(t *testing.T) {
 			wantNil: true,
 		},
 		{
+			name:     "strips null values",
+			input:    "git_protocol: ssh\nhttp_unix_socket: null\npager: less\n",
+			contains: []string{"git_protocol: ssh", "pager: less"},
+			excludes: []string{"null", "http_unix_socket"},
+		},
+		{
+			name:    "only null values returns nil",
+			input:   "http_unix_socket: null\n",
+			wantNil: true,
+		},
+		{
 			name:    "invalid yaml returns nil",
 			input:   ":\t:\n",
 			wantNil: true,


### PR DESCRIPTION
## Summary

- Fixes #234: `sanitizeGhConfig` now removes keys with `nil` values after YAML unmarshalling, preventing `null` from being serialized into the container's gh config
- When `gh` CLI encounters `http_unix_socket: null` in `config.yml`, it interprets the YAML null as the literal string `"null"` and tries to connect to a unix socket at that path
- Added test cases for null value stripping in the existing table-driven test

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/providers/github/...` passes (including new test cases)
- [x] `make lint` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)