### PR TITLE
fix(langserver): use uv tool install for pyright instead of pip

### DIFF
--- a/internal/langserver/registry.go
+++ b/internal/langserver/registry.go
@@ -53,7 +53,7 @@ var registry = map[string]ServerSpec{
 		Description:  "Python language server (code intelligence, type checking, diagnostics)",
 		Plugin:       "pyright-lsp@claude-plugins-official",
 		Dependencies: []string{"python"},
-		InstallDeps:  []string{"pip:pyright"},
+		InstallDeps:  []string{"uv:pyright"},
 	},
 }
 

--- a/internal/langserver/registry_test.go
+++ b/internal/langserver/registry_test.go
@@ -46,8 +46,8 @@ func TestGet(t *testing.T) {
 		if spec.Plugin != "pyright-lsp@claude-plugins-official" {
 			t.Errorf("Plugin = %q, want %q", spec.Plugin, "pyright-lsp@claude-plugins-official")
 		}
-		if len(spec.InstallDeps) != 1 || spec.InstallDeps[0] != "pip:pyright" {
-			t.Errorf("InstallDeps = %v, want [pip:pyright]", spec.InstallDeps)
+		if len(spec.InstallDeps) != 1 || spec.InstallDeps[0] != "uv:pyright" {
+			t.Errorf("InstallDeps = %v, want [uv:pyright]", spec.InstallDeps)
 		}
 	})
 
@@ -137,7 +137,7 @@ func TestAllDependencies(t *testing.T) {
 			switch d {
 			case "python":
 				hasPython = true
-			case "pip:pyright":
+			case "uv:pyright":
 				hasPyright = true
 			}
 		}
@@ -145,7 +145,7 @@ func TestAllDependencies(t *testing.T) {
 			t.Error("python dependencies should include 'python'")
 		}
 		if !hasPyright {
-			t.Error("python dependencies should include 'pip:pyright'")
+			t.Error("python dependencies should include 'uv:pyright'")
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Fixes #256
- Changes pyright language server installation from `pip install pyright` to `uv tool install pyright`
- `pip install` fails on Debian Bookworm due to PEP 668 (externally-managed-environment)
- `uv` is already installed earlier in the build and used for other Python tools (ruff, black, mypy, pytest)

## Test plan

- [x] `make test-unit` passes
- [x] `make lint` passes
- [ ] Build an image with `claude.language_servers.python: true` and verify pyright installs successfully