### PR TITLE
fix(plugins): add Claude CLI path so plugins can be baked into image

### DIFF
--- a/internal/deps/dockerfile_test.go
+++ b/internal/deps/dockerfile_test.go
@@ -659,8 +659,8 @@ func TestGenerateDockerfileClaudeCodeNativeInstall(t *testing.T) {
 		t.Errorf("claude-code installer should run as moatuser, got %q", foundUser)
 	}
 
-	// Should add PATH from install commands' EnvVars
-	if !strings.Contains(result.Dockerfile, `ENV PATH="/home/moatuser/.local/bin:$PATH"`) {
+	// Should add PATH from install commands' EnvVars (includes native installer path)
+	if !strings.Contains(result.Dockerfile, `ENV PATH="/home/moatuser/.claude/local/bin:/home/moatuser/.local/bin:$PATH"`) {
 		t.Error("Dockerfile should add installer's PATH to environment")
 	}
 

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -358,12 +358,13 @@ func getCustomCommands(name, version string) InstallCommands {
 		}
 	case "claude-code":
 		// Native installer - avoids Claude startup warnings from npm-based installs.
+		// The installer places the binary in ~/.claude/local/bin/.
 		return InstallCommands{
 			Commands: []string{
 				`curl -fsSL https://claude.ai/install.sh | bash`,
 			},
 			EnvVars: map[string]string{
-				"PATH": "/home/moatuser/.local/bin:$PATH",
+				"PATH": "/home/moatuser/.claude/local/bin:/home/moatuser/.local/bin:$PATH",
 			},
 		}
 	case "kubectl":

--- a/internal/providers/claude/dockerfile.go
+++ b/internal/providers/claude/dockerfile.go
@@ -75,6 +75,9 @@ func GenerateDockerfileSnippet(marketplaces []MarketplaceConfig, plugins []strin
 	script.WriteString("#!/bin/bash\n")
 	script.WriteString("# Auto-generated Claude Code plugin installer\n")
 	script.WriteString("# Note: no 'set -e' — individual commands use || guards for non-fatal failures.\n\n")
+	// Ensure the Claude CLI is on PATH. The native installer places the binary
+	// in ~/.claude/local/bin/ which may not be in PATH during image build.
+	script.WriteString(fmt.Sprintf("export PATH=\"/home/%s/.claude/local/bin:/home/%s/.local/bin:$PATH\"\n\n", containerUser, containerUser))
 
 	// Add marketplaces - failures are non-fatal (private repos may not be accessible during build)
 	for _, m := range sortedMarketplaces {

--- a/internal/providers/claude/dockerfile_test.go
+++ b/internal/providers/claude/dockerfile_test.go
@@ -50,6 +50,11 @@ func TestGenerateDockerfileSnippet(t *testing.T) {
 
 	scriptStr := string(result.ScriptContent)
 
+	// Script should export PATH so claude CLI is findable
+	if !strings.Contains(scriptStr, `export PATH="/home/moatuser/.claude/local/bin:/home/moatuser/.local/bin:$PATH"`) {
+		t.Error("script should export PATH with Claude CLI locations")
+	}
+
 	// Script should add marketplaces (in sorted order)
 	if !strings.Contains(scriptStr, "marketplace add anthropics/claude-plugins-official &&") {
 		t.Error("should add claude-plugins-official marketplace")


### PR DESCRIPTION
## Summary

- Fixes #222
- The Claude Code native installer places the binary in `~/.claude/local/bin/`, but the generated Dockerfile's `ENV PATH` only included `~/.local/bin/`
- `claude-plugins.sh` couldn't find the `claude` command, so all plugin/marketplace installs failed silently
- Adds `/home/moatuser/.claude/local/bin` to the PATH in both the Dockerfile `ENV` and as an explicit `export` in the plugin script

## Test plan

- [x] `make test-unit` passes
- [x] `make lint` passes
- [ ] Configure marketplaces and plugins in `moat.yaml`, build, and verify plugins install successfully