### PR TITLE
docs(reference): add troubleshooting page with error-to-fix lookup table

### DIFF
--- a/docs/content/reference/08-troubleshooting.md
+++ b/docs/content/reference/08-troubleshooting.md
@@ -14,9 +14,9 @@ Common errors, their causes, and fixes.
 
 ### `Proxy authentication required` / `Invalid proxy token` (407)
 
-**Cause:** The container's proxy auth token does not match any run registered with the daemon. This happens when the daemon restarts while a container is still running.
+**Cause:** The container's proxy auth token does not match any run registered with the daemon. Runs normally re-register automatically after a daemon restart, so this typically indicates a stale container from a previous run that was not properly stopped.
 
-**Fix:** Stop and re-run the agent:
+**Fix:** Stop the stale container and start a new run:
 
 ```bash
 moat stop <run-id>


### PR DESCRIPTION
## Summary

- Fixes #245
- New reference page: `docs/content/reference/08-troubleshooting.md`
- Error-to-fix lookup table covering proxy, TLS, authentication, credential, SSH, container runtime, daemon, build, service, and firewall errors
- All error messages sourced from actual codebase strings
- Includes general debugging tips (verbose mode, debug logs, `moat doctor`, run storage)

## Test plan

- [x] `make lint` passes
- [ ] Verify error messages match current codebase output
- [ ] Verify CA cert path matches actual mount location