### PR TITLE
feat(runctx): surface per-path network rules in agent runtime context

### DIFF
--- a/internal/runctx/build.go
+++ b/internal/runctx/build.go
@@ -71,7 +71,11 @@ func BuildFromConfig(cfg *config.Config, runID string) *RuntimeContext {
 			Policy: cfg.Network.Policy,
 		}
 		for _, entry := range cfg.Network.Rules {
-			np.AllowedHosts = append(np.AllowedHosts, entry.Host)
+			ah := AllowedHost{Host: entry.Host}
+			for _, r := range entry.Rules {
+				ah.Rules = append(ah.Rules, fmt.Sprintf("%s %s %s", r.Action, r.Method, r.PathPattern))
+			}
+			np.AllowedHosts = append(np.AllowedHosts, ah)
 		}
 		rc.NetworkPolicy = np
 	}

--- a/internal/runctx/build_test.go
+++ b/internal/runctx/build_test.go
@@ -15,7 +15,13 @@ func TestBuildFromConfig(t *testing.T) {
 		Network: config.NetworkConfig{
 			Policy: "strict",
 			Rules: []netrules.NetworkRuleEntry{
-				{HostRules: netrules.HostRules{Host: "api.github.com"}},
+				{HostRules: netrules.HostRules{
+					Host: "api.github.com",
+					Rules: []netrules.Rule{
+						{Action: "allow", Method: "GET", PathPattern: "/repos/*"},
+						{Action: "deny", Method: "*", PathPattern: "/**"},
+					},
+				}},
 				{HostRules: netrules.HostRules{Host: "*.npmjs.org"}},
 			},
 		},
@@ -120,6 +126,26 @@ func TestBuildFromConfig(t *testing.T) {
 	}
 	if len(rc.NetworkPolicy.AllowedHosts) != 2 {
 		t.Fatalf("len(AllowedHosts) = %d, want 2", len(rc.NetworkPolicy.AllowedHosts))
+	}
+	// First host should have rules.
+	if rc.NetworkPolicy.AllowedHosts[0].Host != "api.github.com" {
+		t.Errorf("AllowedHosts[0].Host = %q, want %q", rc.NetworkPolicy.AllowedHosts[0].Host, "api.github.com")
+	}
+	if len(rc.NetworkPolicy.AllowedHosts[0].Rules) != 2 {
+		t.Fatalf("len(AllowedHosts[0].Rules) = %d, want 2", len(rc.NetworkPolicy.AllowedHosts[0].Rules))
+	}
+	if rc.NetworkPolicy.AllowedHosts[0].Rules[0] != "allow GET /repos/*" {
+		t.Errorf("AllowedHosts[0].Rules[0] = %q, want %q", rc.NetworkPolicy.AllowedHosts[0].Rules[0], "allow GET /repos/*")
+	}
+	if rc.NetworkPolicy.AllowedHosts[0].Rules[1] != "deny * /**" {
+		t.Errorf("AllowedHosts[0].Rules[1] = %q, want %q", rc.NetworkPolicy.AllowedHosts[0].Rules[1], "deny * /**")
+	}
+	// Second host should have no rules.
+	if rc.NetworkPolicy.AllowedHosts[1].Host != "*.npmjs.org" {
+		t.Errorf("AllowedHosts[1].Host = %q, want %q", rc.NetworkPolicy.AllowedHosts[1].Host, "*.npmjs.org")
+	}
+	if len(rc.NetworkPolicy.AllowedHosts[1].Rules) != 0 {
+		t.Errorf("len(AllowedHosts[1].Rules) = %d, want 0", len(rc.NetworkPolicy.AllowedHosts[1].Rules))
 	}
 
 	// Ports

--- a/internal/runctx/context.go
+++ b/internal/runctx/context.go
@@ -44,7 +44,14 @@ type Port struct {
 // NetworkPolicy describes the network access policy for the run.
 type NetworkPolicy struct {
 	Policy       string
-	AllowedHosts []string
+	AllowedHosts []AllowedHost
+}
+
+// AllowedHost describes a host that the run is allowed to access,
+// optionally with per-path rules that restrict specific methods/paths.
+type AllowedHost struct {
+	Host  string
+	Rules []string // human-readable rule summaries, e.g. "allow GET /repos/*"
 }
 
 // MCPServer describes an MCP server available to the agent.
@@ -103,7 +110,33 @@ func Render(rc *RuntimeContext) string {
 		b.WriteString("\n## Network Policy\n\n")
 		fmt.Fprintf(&b, "- Policy: %s\n", rc.NetworkPolicy.Policy)
 		if len(rc.NetworkPolicy.AllowedHosts) > 0 {
-			fmt.Fprintf(&b, "- Allowed hosts: %s\n", strings.Join(rc.NetworkPolicy.AllowedHosts, ", "))
+			// Check if any host has per-path rules.
+			hasRules := false
+			for _, h := range rc.NetworkPolicy.AllowedHosts {
+				if len(h.Rules) > 0 {
+					hasRules = true
+					break
+				}
+			}
+			if hasRules {
+				// Use nested list so per-path rules are visible.
+				b.WriteString("- Allowed hosts:\n")
+				for _, h := range rc.NetworkPolicy.AllowedHosts {
+					if len(h.Rules) == 0 {
+						fmt.Fprintf(&b, "  - %s\n", h.Host)
+					} else {
+						fmt.Fprintf(&b, "  - %s (%d rules: %s)\n",
+							h.Host, len(h.Rules), strings.Join(h.Rules, ", "))
+					}
+				}
+			} else {
+				// Simple comma-separated list when no per-path rules.
+				hosts := make([]string, len(rc.NetworkPolicy.AllowedHosts))
+				for i, h := range rc.NetworkPolicy.AllowedHosts {
+					hosts[i] = h.Host
+				}
+				fmt.Fprintf(&b, "- Allowed hosts: %s\n", strings.Join(hosts, ", "))
+			}
 		}
 	}
 

--- a/internal/runctx/context_test.go
+++ b/internal/runctx/context_test.go
@@ -92,8 +92,11 @@ func TestRender_full(t *testing.T) {
 			{Name: "api", ContainerPort: 8080, EnvHostPort: "$MOAT_HOST_API"},
 		},
 		NetworkPolicy: &NetworkPolicy{
-			Policy:       "strict",
-			AllowedHosts: []string{"api.github.com", "*.npmjs.org"},
+			Policy: "strict",
+			AllowedHosts: []AllowedHost{
+				{Host: "api.github.com"},
+				{Host: "*.npmjs.org"},
+			},
 		},
 		MCPServers: []MCPServer{
 			{Name: "github", Description: "GitHub tools (issues, PRs, search)"},
@@ -263,6 +266,38 @@ func TestRender_networkPolicyWithoutAllowedHosts(t *testing.T) {
 	// Allowed hosts line must NOT be present.
 	if strings.Contains(got, "Allowed hosts") {
 		t.Error("Allowed hosts line should not appear when AllowedHosts is empty")
+	}
+}
+
+func TestRender_networkPolicyWithRules(t *testing.T) {
+	rc := &RuntimeContext{
+		RunID:     "run-rules",
+		Agent:     "claude",
+		Workspace: "/workspace",
+		NetworkPolicy: &NetworkPolicy{
+			Policy: "strict",
+			AllowedHosts: []AllowedHost{
+				{
+					Host:  "api.github.com",
+					Rules: []string{"allow GET /repos/*", "deny * /**"},
+				},
+				{Host: "registry.npmjs.org"},
+			},
+		},
+	}
+
+	got := Render(rc)
+
+	// Should use nested list format when rules exist.
+	if !strings.Contains(got, "- Allowed hosts:\n") {
+		t.Error("expected nested allowed hosts format")
+	}
+	if !strings.Contains(got, "api.github.com (2 rules: allow GET /repos/*, deny * /**)") {
+		t.Errorf("expected host with rules summary, got:\n%s", got)
+	}
+	// Host without rules should appear without annotation.
+	if !strings.Contains(got, "  - registry.npmjs.org\n") {
+		t.Errorf("expected plain host entry for registry.npmjs.org, got:\n%s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds per-path HTTP request rules to the agent runtime context so agents know what network restrictions apply
- Hosts with rules render as a nested list with rule count and summaries (e.g. `api.github.com (2 rules: allow GET /repos/*, deny * /**)`)
- Hosts without rules continue to render as a simple comma-separated list, preserving backward compatibility

Closes #231

## Test plan

- [x] Existing `runctx` tests updated and passing
- [x] New `TestRender_networkPolicyWithRules` test verifies rule rendering
- [x] `BuildFromConfig` test updated with per-path rules to verify end-to-end flow
- [x] `make lint` passes with 0 issues