### PR TITLE
docs: add navTitle to workspace sharing guide

### DIFF
--- a/docs/content/guides/13-workspace-sharing.md
+++ b/docs/content/guides/13-workspace-sharing.md
@@ -1,5 +1,6 @@
 ---
 title: "Sharing a workspace between host and container"
+navTitle: "Workspace sharing"
 description: "Use mount excludes to isolate platform-specific dependency directories between host and container."
 keywords: ["moat", "workspace", "node_modules", "venv", "dependencies", "mount", "exclude", "tmpfs"]
 ---


### PR DESCRIPTION
Adds missing `navTitle: "Workspace sharing"` to the workspace sharing guide frontmatter so the sidebar doesn't overflow.