### PR TITLE
fix(claude): disable git credential prompt during host-side marketplace clone

### DIFF
--- a/internal/providers/claude/marketplace.go
+++ b/internal/providers/claude/marketplace.go
@@ -136,6 +136,11 @@ func CloneMarketplace(ctx context.Context, repo string) (dir string, commitTime 
 	args := []string{"clone", "--depth", "1", "--no-recurse-submodules", url, dir}
 
 	cmd := exec.CommandContext(ctx, "git", args...)
+	// Prevent git from opening /dev/tty to prompt for credentials.
+	// Without this, private repos cause an interactive username/password
+	// prompt that blocks the build. Failing fast lets the caller report
+	// a clear error about needing 'gh auth login' or SSH keys.
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		// Clean up on failure.


### PR DESCRIPTION
## Summary

- Set `GIT_TERMINAL_PROMPT=0` on the `git clone` command in `CloneMarketplace` to prevent interactive credential prompts during host-side marketplace cloning
- Without this, private repos cause git to open `/dev/tty` and prompt for username/password, blocking the build unexpectedly
- When the prompt is canceled, the clone fails and falls through to build-time `claude plugin marketplace add`, which also fails (no credentials in Docker build), preventing the container from starting
- Matches the existing pattern in `internal/providers/github/provider.go`

## Test plan

- [ ] Verify `go test ./internal/providers/claude/...` passes
- [ ] Verify `make lint` passes
- [ ] Test `moat run` with a private marketplace repo — should fail fast with a clear error instead of prompting for credentials
- [ ] Test `moat run` with a public marketplace repo — should continue to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)