### PR TITLE
fix(claude): skip plugin install when claude CLI is absent

### DIFF
--- a/internal/providers/claude/dockerfile.go
+++ b/internal/providers/claude/dockerfile.go
@@ -115,6 +115,13 @@ func GenerateDockerfileSnippet(marketplaces []MarketplaceConfig, plugins []strin
 	// Ensure the Claude CLI is on PATH. The native installer places the binary
 	// in ~/.claude/local/bin/ which may not be in PATH during image build.
 	script.WriteString(fmt.Sprintf("export PATH=\"/home/%s/.claude/local/bin:/home/%s/.local/bin:$PATH\"\n\n", containerUser, containerUser))
+	// Skip plugin installation if Claude Code is not installed.
+	// Host-level marketplace settings are loaded for all runs, but the claude
+	// binary is only present when claude-code is a dependency or implicit (moat claude).
+	script.WriteString("if ! command -v claude >/dev/null 2>&1; then\n")
+	script.WriteString("  echo 'Claude Code not installed, skipping plugin setup'\n")
+	script.WriteString("  exit 0\n")
+	script.WriteString("fi\n\n")
 	script.WriteString("failures=0\n")
 	script.WriteString("failed_ops=\"\"\n\n")
 

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1226,13 +1226,15 @@ region = %s
 	}
 
 	// Extract plugins and marketplaces for image building.
-	// We use the merged settings which includes both moat.yaml config and host settings.
-	// This allows plugins configured on the host to work in containers.
+	// Only relevant when claude-code is a dependency (explicit or implied by agent).
+	// Host marketplace settings are loaded for all runs, but the claude binary
+	// is only present in claude-code containers.
+	hasClaudeCode := hasDep(depList, "claude-code")
 	var claudeMarketplaces []claude.MarketplaceConfig
 	var claudePlugins []string
 	marketplaceRepos := make(map[string]string)
 
-	if claudeSettings != nil {
+	if claudeSettings != nil && hasClaudeCode {
 		// Build a map of marketplace name -> repo URL from merged settings.
 		// The claude CLI accepts marketplace repos in several formats:
 		// - GitHub shorthand: owner/repo


### PR DESCRIPTION
## Summary

- The plugin installer script (`claude-plugins.sh`) is generated during image build whenever host-level marketplace settings exist, even for non-Claude containers (e.g., `moat run` with only `--grant aws`).
- The script calls `claude plugin marketplace add` which fails if `claude-code` is not a dependency — it's only implicitly added for `moat claude`.
- Add a `command -v claude` guard at the top of the generated script that exits early with a message if the claude binary is not on PATH.

## Test plan

- [x] `go test ./internal/providers/claude/` passes
- [x] `make lint` passes
- [ ] Manual: `moat run` with AWS example (no claude-code dep) — should not fail on plugin script
- [ ] Manual: `moat claude` with plugins configured — plugins should still install normally