### PR TITLE
fix: add Anthropic and Gemini token placeholders

### DIFF
--- a/internal/credential/provider.go
+++ b/internal/credential/provider.go
@@ -36,6 +36,24 @@ const OpenAIAPIKeyPlaceholder = "sk-moat-proxy-injected-placeholder-000000000000
 // Authorization headers, so this placeholder never reaches GitHub's servers.
 const GitHubTokenPlaceholder = "ghp_moatProxyInjectedPlaceholder000000000000"
 
+// AnthropicAPIKeyPlaceholder is a placeholder that looks like a valid Anthropic
+// API key.
+// Some tools validate the API key format locally before making requests.
+// Using a valid-looking placeholder bypasses these checks while still allowing
+// the proxy to inject the real key at the network layer.
+//
+// Note: Anthropic API keys start with `sk-ant-api` while OAuth tokens start
+// with `sk-ant-oat` - we may discover we need an OAuth placeholder and smarter
+// logic later.
+const AnthropicAPIKeyPlaceholder = "sk-ant-api03-moatProxyInjectedPlaceholder0000000000000000000000000000000000000000000000000000000000000000000"
+
+// GeminiAPIKeyPlaceholder is a placeholder that looks like a valid Gemini API
+// key.
+// Some tools validate the API key format locally before making requests.
+// Using a valid-looking placeholder bypasses these checks while still allowing
+// the proxy to inject the real key at the network layer.
+const GeminiAPIKeyPlaceholder = "AIzamoatProxyInjectedPlaceholder0000000"
+
 // JWTPlaceholder is a basic placeholder JWT for format validation only.
 // Use GenerateIDTokenPlaceholder for Codex CLI which needs account_id in claims.
 const JWTPlaceholder = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtb2F0LXByb3h5LXBsYWNlaG9sZGVyIiwiZXhwIjo5OTk5OTk5OTk5fQ.placeholder-signature-not-valid"

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -3764,6 +3764,10 @@ func grantToEnvVar(grant string) (string, bool) {
 // can inject the real token.
 func grantToPlaceholder(grant string) string {
 	switch grant {
+	case "anthropic":
+		return credential.AnthropicAPIKeyPlaceholder
+	case "gemini":
+		return credential.GeminiAPIKeyPlaceholder
 	case "github":
 		return credential.GitHubTokenPlaceholder
 	case "openai":

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/deps"
 	"github.com/majorcontext/moat/internal/routing"
 	"github.com/majorcontext/moat/internal/storage"
@@ -1318,6 +1319,48 @@ func TestResolveMountExcludesToTmpfs(t *testing.T) {
 				if got.Target != want.Target {
 					t.Errorf("tmpfs[%d]: got %q, want %q", i, got.Target, want.Target)
 				}
+			}
+		})
+	}
+}
+
+func Test_grantToPlaceholder(t *testing.T) {
+	tests := []struct {
+		name                string
+		grant               string
+		expectedPlaceholder string
+	}{
+		{
+			name:                "Anthropic grant",
+			grant:               "anthropic",
+			expectedPlaceholder: credential.AnthropicAPIKeyPlaceholder,
+		},
+		{
+			name:                "Gemini grant",
+			grant:               "gemini",
+			expectedPlaceholder: credential.GeminiAPIKeyPlaceholder,
+		},
+		{
+			name:                "GitHub grant",
+			grant:               "github",
+			expectedPlaceholder: credential.GitHubTokenPlaceholder,
+		},
+		{
+			name:                "OpenAI grant",
+			grant:               "openai",
+			expectedPlaceholder: credential.OpenAIAPIKeyPlaceholder,
+		},
+		{
+			name:                "generic grant",
+			grant:               "anything-else",
+			expectedPlaceholder: credential.ProxyInjectedPlaceholder,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := grantToPlaceholder(tt.grant)
+			if got != tt.expectedPlaceholder {
+				t.Errorf("grantToPlaceholder[%s]: got %q, want %q", tt.grant, got, tt.expectedPlaceholder)
 			}
 		})
 	}


### PR DESCRIPTION
As noted in #277 these two conditions were missing.  We've also covered this (internal) function in a test for completeness.