### PR TITLE
test(claude): add assertion for plugin script guard

### DIFF
--- a/internal/providers/claude/dockerfile_test.go
+++ b/internal/providers/claude/dockerfile_test.go
@@ -55,6 +55,11 @@ func TestGenerateDockerfileSnippet(t *testing.T) {
 		t.Error("script should export PATH with Claude CLI locations")
 	}
 
+	// Script should guard against missing claude binary
+	if !strings.Contains(scriptStr, "command -v claude") {
+		t.Error("script should guard against missing claude binary")
+	}
+
 	// Script should track failures
 	if !strings.Contains(scriptStr, "failures=0") {
 		t.Error("script should initialize failure counter")


### PR DESCRIPTION
## Summary

- Follow-up to #291 — adds test assertion that the generated plugin install script contains the `command -v claude` guard
- Requested during review but wasn't included before merge

## Test plan

- [x] `go test ./internal/providers/claude/` passes