### PR TITLE
fix: install Rust toolchain to shared location for non-root access

### DIFF
--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -347,13 +347,18 @@ func getCustomCommands(name, version string) InstallCommands {
 			},
 		}
 	case "rust":
-		// Install Rust via rustup
+		// Install Rust toolchain to shared location for non-root access
 		return InstallCommands{
 			Commands: []string{
-				"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable",
+				"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o /tmp/rustup-init",
+				"RUSTUP_HOME=/usr/local/rustup CARGO_HOME=/usr/local/cargo sh /tmp/rustup-init -y --default-toolchain stable",
+				"chmod -R a+rX /usr/local/rustup /usr/local/cargo",
+				"rm /tmp/rustup-init",
 			},
 			EnvVars: map[string]string{
-				"PATH": "/root/.cargo/bin:$PATH",
+				"RUSTUP_HOME": "/usr/local/rustup",
+				"CARGO_HOME":  "/home/moatuser/.cargo",
+				"PATH":        "/usr/local/cargo/bin:$PATH",
 			},
 		}
 	case "claude-code":

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -245,7 +245,7 @@ func TestGetCustomCommands(t *testing.T) {
 		{"playwright", "", []string{"npm install -g playwright", "npx playwright install", "chromium-headless-shell"}, []string{"PLAYWRIGHT_BROWSERS_PATH"}},
 		{"aws", "", []string{"awscli", "uname -m", "unzip"}, nil},
 		{"gcloud", "", []string{"google-cloud", "tar", "install.sh"}, []string{"PATH"}},
-		{"rust", "", []string{"rustup", "sh -s --", "-y"}, []string{"PATH"}},
+		{"rust", "", []string{"rustup", "sh", "-y", "RUSTUP_HOME=/usr/local/rustup", "CARGO_HOME=/usr/local/cargo"}, []string{"PATH", "RUSTUP_HOME", "CARGO_HOME"}},
 		{"protoc", "25.1", []string{"protocolbuffers/protobuf", "protoc-25.1", "uname -m", "unzip", "/usr/local/include/"}, nil},
 		{"kubectl", "", []string{"dl.k8s.io", "uname -m", "chmod"}, nil},
 		{"terraform", "1.10.0", []string{"releases.hashicorp.com", "terraform_1.10.0", "unzip"}, nil},


### PR DESCRIPTION
While working on a Rust project, I found that the model could not make use of the Rust toolchain even though I had `rust` declared as dependency.

This change moves the Rust tooling to be installed under `/usr/local/cargo`, makes it world readable and executable, and finally adds it to PATH.