### PR TITLE
feat(claude): add support for managed settings

### DIFF
--- a/internal/deps/scripts/moat-init.sh
+++ b/internal/deps/scripts/moat-init.sh
@@ -86,6 +86,14 @@ if [ -n "$MOAT_CLAUDE_INIT" ] && [ -d "$MOAT_CLAUDE_INIT" ]; then
     chmod 600 "$TARGET_HOME/.claude/.credentials.json"
   fi
 
+  # Copy remote-settings.json if present (server-managed settings cache)
+  # This prevents Claude Code from prompting for managed settings approval
+  # on every container startup by providing the cached approval state.
+  if [ -f "$MOAT_CLAUDE_INIT/remote-settings.json" ]; then
+    cp -p "$MOAT_CLAUDE_INIT/remote-settings.json" "$TARGET_HOME/.claude/"
+    chmod 600 "$TARGET_HOME/.claude/remote-settings.json"
+  fi
+
   # Copy statsig directory if present (feature flags, preserve permissions)
   [ -d "$MOAT_CLAUDE_INIT/statsig" ] && \
     cp -rp "$MOAT_CLAUDE_INIT/statsig" "$TARGET_HOME/.claude/"

--- a/internal/providers/claude/agent.go
+++ b/internal/providers/claude/agent.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/provider"
 )
 
@@ -70,16 +71,17 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 		}
 	}
 
+	// Resolve host home directory once for host config and remote-settings.
+	hostHome, hostHomeErr := os.UserHomeDir()
+
 	// Get host config - use provided or read from host's ~/.claude.json
 	var hostConfig map[string]any
 	if opts.HostConfig != nil {
 		hostConfig = opts.HostConfig
-	} else {
+	} else if hostHomeErr == nil {
 		// Read host config automatically
-		if hostHome, err := os.UserHomeDir(); err == nil {
-			hostConfig, _ = ReadHostConfig(filepath.Join(hostHome, ".claude.json"))
-			// Ignore errors - missing host config is OK
-		}
+		hostConfig, _ = ReadHostConfig(filepath.Join(hostHome, ".claude.json"))
+		// Ignore errors - missing host config is OK
 	}
 
 	// Write .claude.json config
@@ -90,10 +92,12 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 	// Copy remote-settings.json from host's ~/.claude/ directory.
 	// This caches the server-managed settings so Claude Code doesn't prompt
 	// for managed settings approval on every container startup.
-	if hostHome, homeErr := os.UserHomeDir(); homeErr == nil {
+	if hostHomeErr == nil {
 		remoteSettingsPath := filepath.Join(hostHome, ".claude", "remote-settings.json")
 		if data, readErr := os.ReadFile(remoteSettingsPath); readErr == nil {
-			_ = os.WriteFile(filepath.Join(tmpDir, "remote-settings.json"), data, 0600) //nolint:gosec // G703 false positive: tmpDir from MkdirTemp, filename is constant
+			if writeErr := os.WriteFile(filepath.Join(tmpDir, "remote-settings.json"), data, 0600); writeErr != nil {
+				log.Debug("failed to stage remote-settings.json", "error", writeErr)
+			}
 		}
 	}
 

--- a/internal/providers/claude/agent.go
+++ b/internal/providers/claude/agent.go
@@ -87,6 +87,16 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 		return nil, fmt.Errorf("writing claude config: %w", err)
 	}
 
+	// Copy remote-settings.json from host's ~/.claude/ directory.
+	// This caches the server-managed settings so Claude Code doesn't prompt
+	// for managed settings approval on every container startup.
+	if hostHome, homeErr := os.UserHomeDir(); homeErr == nil {
+		remoteSettingsPath := filepath.Join(hostHome, ".claude", "remote-settings.json")
+		if data, readErr := os.ReadFile(remoteSettingsPath); readErr == nil {
+			_ = os.WriteFile(filepath.Join(tmpDir, "remote-settings.json"), data, 0600) //nolint:gosec // G703 false positive: tmpDir from MkdirTemp, filename is constant
+		}
+	}
+
 	// Write runtime context file if provided
 	if opts.RuntimeContext != "" {
 		if err := os.WriteFile(filepath.Join(tmpDir, "CLAUDE.md"), []byte(opts.RuntimeContext), 0644); err != nil {

--- a/internal/providers/claude/agent_test.go
+++ b/internal/providers/claude/agent_test.go
@@ -33,6 +33,66 @@ func TestPrepareContainer_writesContextFile(t *testing.T) {
 	}
 }
 
+func TestPrepareContainer_copiesRemoteSettings(t *testing.T) {
+	// Set up a fake home with remote-settings.json
+	fakeHome := t.TempDir()
+	claudeDir := filepath.Join(fakeHome, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	settingsContent := `{"version":1,"settings":{"hooks":true}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "remote-settings.json"), []byte(settingsContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	p := &OAuthProvider{}
+	cfg, err := p.PrepareContainer(context.Background(), provider.PrepareOpts{})
+	if err != nil {
+		t.Fatalf("PrepareContainer() error = %v", err)
+	}
+	defer cfg.Cleanup()
+
+	// Verify remote-settings.json was copied to the staging directory
+	data, err := os.ReadFile(filepath.Join(cfg.StagingDir, "remote-settings.json"))
+	if err != nil {
+		t.Fatalf("reading remote-settings.json: %v", err)
+	}
+	if string(data) != settingsContent {
+		t.Errorf("remote-settings.json content = %q, want %q", string(data), settingsContent)
+	}
+
+	// Verify permissions are 0600
+	info, err := os.Stat(filepath.Join(cfg.StagingDir, "remote-settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Errorf("remote-settings.json permissions = %o, want 0600", perm)
+	}
+}
+
+func TestPrepareContainer_skipsRemoteSettingsWhenMissing(t *testing.T) {
+	// Set up a fake home without remote-settings.json
+	fakeHome := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(fakeHome, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", fakeHome)
+
+	p := &OAuthProvider{}
+	cfg, err := p.PrepareContainer(context.Background(), provider.PrepareOpts{})
+	if err != nil {
+		t.Fatalf("PrepareContainer() error = %v", err)
+	}
+	defer cfg.Cleanup()
+
+	// Verify remote-settings.json was NOT created
+	if _, err := os.Stat(filepath.Join(cfg.StagingDir, "remote-settings.json")); err == nil {
+		t.Error("remote-settings.json should not exist when host file is missing")
+	}
+}
+
 func TestPrepareContainer_skipsContextFileWhenEmpty(t *testing.T) {
 	p := &OAuthProvider{}
 


### PR DESCRIPTION
## Summary

Claude managed settings flow: if there are managed settings enforced by user's organization, Claude prompts user on startup and immediately exists regardless of whether user accepted or rejected the managed settings prompt. On the next startup Claude runs normally if settings were accepted. Moat does not store the result of settings prompt, so users sees managed settings prompt every time and it is impossible to start the Claude in moat.

Sample managed settings prompt:
```
 Managed settings require approval 

 Your organization has configured managed settings that could allow execution of arbitrary code or interception of your prompts and responses.                                                                              
   
 Settings requiring approval:                                                                                                                                                                                               
   · otelHeadersHelper                                                                                                                                                                                                    
   · OTEL_EXPORTER_OTLP_ENDPOINT
   · hooks

 Only accept if you trust your organization's IT administration and expect these settings to be configured.

 ❯ 1. Yes, I trust these settings
   2. No, exit Claude Code
```

Changes (written by Claude):
- Fixes a bug where organizations with server-managed settings (hooks, OTEL, etc.) saw Claude Code's "Managed settings require approval" prompt on **every** container startup, making it impossible to use moat with Claude.
- Root cause: Claude Code caches server-managed settings in `~/.claude/remote-settings.json` after user approval. On subsequent startups, it compares fetched settings against this cache — if they match, no prompt. Moat wasn't copying this cache into containers.
- Copies `remote-settings.json` from the host into the container staging directory and places it at `~/.claude/remote-settings.json` via `moat-init.sh`.

## Test plan

- [x] Run `moat run` with a Claude grant on an org that has server-managed settings — verify no approval prompt appears
- [ ] Run `moat run` without server-managed settings (no `~/.claude/remote-settings.json`) — verify no regression
- [x] Verify existing unit tests pass (`make test-unit`)