### PR TITLE
fix(run): stop reconciliation from corrupting persisted run state

### DIFF
--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -377,12 +377,10 @@ func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, meta
 				}
 			}
 		}
-	} else if runState == StateStopped || runState == StateFailed {
-		// Unconfirmed terminal state (e.g. container check failed) — close
-		// exitCh but skip route cleanup since we can't be sure the container
-		// is actually gone.
-		close(r.exitCh)
 	}
+	// Note: no else branch for unconfirmed terminal states. All paths that
+	// reach here with stateConfirmed=false have runState=running/created
+	// (persisted terminal runs are caught early with stateConfirmed=true).
 
 	// Never write state back to disk during reconciliation.
 	// The owning process is responsible for its run's on-disk state.

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -258,23 +258,31 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 				containerState, csErr := m.runtime.ContainerState(callCtx, info.meta.ContainerID)
 				if csErr != nil {
 					log.Debug("container state check failed, preserving persisted state", "id", info.runID, "container", info.meta.ContainerID, "error", csErr)
-					runState = State(info.meta.State)
-				} else {
-					switch containerState {
-					case "running":
-						confirmed = true
-						runState = StateRunning
-					case "exited", "dead", "stopped":
-						confirmed = true
-						runState = StateStopped
-					case "created", "restarting":
-						confirmed = true
-						runState = StateCreated
-					default:
-						// Unknown state (e.g. "paused") — can't confirm,
-						// fall back to persisted state.
-						runState = State(info.meta.State)
+					// Preserve both run state and service containers from
+					// persisted metadata — if the runtime is unavailable,
+					// service container checks would also fail.
+					results[idx] = checkedRun{
+						info:              info,
+						runState:          State(info.meta.State),
+						serviceContainers: info.meta.ServiceContainers,
 					}
+					return
+				}
+
+				switch containerState {
+				case "running":
+					confirmed = true
+					runState = StateRunning
+				case "exited", "dead", "stopped":
+					confirmed = true
+					runState = StateStopped
+				case "created", "restarting":
+					confirmed = true
+					runState = StateCreated
+				default:
+					// Unknown state (e.g. "paused") — can't confirm,
+					// fall back to persisted state.
+					runState = State(info.meta.State)
 				}
 
 				// Filter service containers to only those that still exist.
@@ -387,7 +395,12 @@ func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, meta
 	// These inherited monitors are NOT tracked by monitorWg — they may block
 	// indefinitely on long-running containers from previous CLI invocations.
 	// Only monitors started via Start() are tracked so Close() doesn't hang.
-	if runState == StateRunning {
+	//
+	// Skip cross-runtime runs: monitorContainerExit calls m.runtime.WaitContainer
+	// which would fail immediately for a container from a different runtime,
+	// then write "failed" state to disk — re-triggering the corruption bug.
+	crossRuntime := meta.Runtime != "" && meta.Runtime != string(m.runtime.Type())
+	if runState == StateRunning && !crossRuntime {
 		go m.monitorContainerExit(r)
 	}
 }

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -197,8 +197,10 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 		}
 
 		// Runs already in a terminal state don't need a live container check.
+		// Pass stateConfirmed=true because the owning process authoritatively
+		// wrote this terminal state — it's safe to clean up stale routes.
 		if meta.State == string(StateStopped) || meta.State == string(StateFailed) {
-			m.registerPersistedRun(State(meta.State), meta, store, runID, nil)
+			m.registerPersistedRun(State(meta.State), true, meta, store, runID, nil)
 			continue
 		}
 
@@ -211,6 +213,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 		type checkedRun struct {
 			info              persistedRunInfo
 			runState          State
+			stateConfirmed    bool // true when state was confirmed by a successful container check
 			serviceContainers map[string]string
 		}
 
@@ -226,29 +229,50 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 				select {
 				case sem <- struct{}{}:
 				case <-ctx.Done():
-					results[idx] = checkedRun{info: info, runState: StateStopped}
+					results[idx] = checkedRun{
+						info:              info,
+						runState:          State(info.meta.State),
+						serviceContainers: info.meta.ServiceContainers,
+					}
 					return
 				}
 				defer func() { <-sem }()
+
+				// Skip container state check for runs created with a different runtime.
+				if info.meta.Runtime != "" && info.meta.Runtime != string(m.runtime.Type()) {
+					log.Debug("skipping cross-runtime container check, preserving persisted state", "id", info.runID, "run_runtime", info.meta.Runtime, "current_runtime", m.runtime.Type())
+					results[idx] = checkedRun{
+						info:              info,
+						runState:          State(info.meta.State),
+						serviceContainers: info.meta.ServiceContainers,
+					}
+					return
+				}
 
 				// 5-second timeout per container check.
 				callCtx, callCancel := context.WithTimeout(ctx, 5*time.Second)
 				defer callCancel()
 
 				var runState State
+				var confirmed bool
 				containerState, csErr := m.runtime.ContainerState(callCtx, info.meta.ContainerID)
 				if csErr != nil {
-					log.Debug("container state check failed, assuming stopped", "id", info.runID, "container", info.meta.ContainerID, "error", csErr)
-					runState = StateStopped
+					log.Debug("container state check failed, preserving persisted state", "id", info.runID, "container", info.meta.ContainerID, "error", csErr)
+					runState = State(info.meta.State)
 				} else {
 					switch containerState {
 					case "running":
+						confirmed = true
 						runState = StateRunning
 					case "exited", "dead", "stopped":
+						confirmed = true
 						runState = StateStopped
 					case "created", "restarting":
+						confirmed = true
 						runState = StateCreated
 					default:
+						// Unknown state (e.g. "paused") — can't confirm,
+						// fall back to persisted state.
 						runState = State(info.meta.State)
 					}
 				}
@@ -266,6 +290,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 				results[idx] = checkedRun{
 					info:              info,
 					runState:          runState,
+					stateConfirmed:    confirmed,
 					serviceContainers: serviceContainers,
 				}
 			}(i, info)
@@ -274,7 +299,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 		wg.Wait()
 
 		for _, cr := range results {
-			m.registerPersistedRun(cr.runState, cr.info.meta, cr.info.store, cr.info.runID, cr.serviceContainers)
+			m.registerPersistedRun(cr.runState, cr.stateConfirmed, cr.info.meta, cr.info.store, cr.info.runID, cr.serviceContainers)
 		}
 	}
 
@@ -282,9 +307,11 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 }
 
 // registerPersistedRun creates and registers a Run from persisted metadata.
+// stateConfirmed indicates whether runState was determined by a successful container
+// state check (true) or inferred from persisted state / error fallback (false).
 // If serviceContainers is nil, it is loaded directly from metadata (for terminal-state runs
 // that skip live container checks).
-func (m *Manager) registerPersistedRun(runState State, meta storage.Metadata, store *storage.RunStore, runID string, serviceContainers map[string]string) {
+func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, meta storage.Metadata, store *storage.RunStore, runID string, serviceContainers map[string]string) {
 	if serviceContainers == nil {
 		serviceContainers = meta.ServiceContainers
 	}
@@ -296,6 +323,7 @@ func (m *Manager) registerPersistedRun(runState State, meta storage.Metadata, st
 		Grants:            meta.Grants,
 		Agent:             meta.Agent,
 		Image:             meta.Image,
+		Runtime:           meta.Runtime,
 		Ports:             meta.Ports,
 		State:             runState,
 		ContainerID:       meta.ContainerID,
@@ -314,10 +342,22 @@ func (m *Manager) registerPersistedRun(runState State, meta storage.Metadata, st
 		WorktreeRepoID:    meta.WorktreeRepoID,
 	}
 
-	// If container is already stopped, close exitCh immediately
-	// so any Wait() calls don't hang, and clean up stale routes
-	// so the name can be reused without requiring "moat clean".
-	if runState == StateStopped || runState == StateFailed {
+	// If container is confirmed stopped by a live check or by authoritative
+	// persisted state, close exitCh so Wait() calls don't hang, and clean
+	// up stale routes so the name can be reused without "moat clean".
+	//
+	// Only perform route/daemon cleanup when stateConfirmed is true:
+	// either a successful container state check confirmed the container is
+	// gone, or the owning process wrote the terminal state to disk.
+	//
+	// When stateConfirmed is false (container check failed, context canceled,
+	// or unknown container state), routes are intentionally preserved even if
+	// the container is likely stopped. This avoids corrupting routes for runs
+	// that are actually still alive but temporarily unreachable. The tradeoff
+	// is that routes may become stale in error cases, requiring "moat clean"
+	// to reclaim names. This is preferable to the previous behavior where a
+	// single failed check permanently destroyed routes for live runs.
+	if stateConfirmed && (runState == StateStopped || runState == StateFailed) {
 		close(r.exitCh)
 		if r.Name != "" {
 			if err := m.routes.Remove(r.Name); err != nil {
@@ -329,12 +369,15 @@ func (m *Manager) registerPersistedRun(runState State, meta storage.Metadata, st
 				}
 			}
 		}
+	} else if runState == StateStopped || runState == StateFailed {
+		// Unconfirmed terminal state (e.g. container check failed) — close
+		// exitCh but skip route cleanup since we can't be sure the container
+		// is actually gone.
+		close(r.exitCh)
 	}
 
-	// Update metadata if state changed
-	if string(runState) != meta.State {
-		_ = r.SaveMetadata()
-	}
+	// Never write state back to disk during reconciliation.
+	// The owning process is responsible for its run's on-disk state.
 
 	m.mu.Lock()
 	m.runs[runID] = r
@@ -1491,6 +1534,7 @@ region = %s
 		r.Agent = opts.Config.Agent
 	}
 	r.Image = containerImage
+	r.Runtime = string(m.runtime.Type())
 
 	needsCustomImage := imageSpec.NeedsCustomImage(hasDeps)
 

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -1166,14 +1166,11 @@ func TestLoadPersistedRunsDoesNotModifyMetadata(t *testing.T) {
 }
 
 // TestLoadPersistedRunsSkipsCrossRuntimeCheck verifies that runs created with
-// a different runtime preserve their persisted state without a container check.
+// a different runtime preserve their persisted state without a container check,
+// and that no monitor goroutine is spawned (which would call WaitContainer on
+// the wrong runtime and corrupt state).
 func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
-	// Use os.MkdirTemp because loadPersistedRuns spawns a background
-	// monitorContainerExit goroutine for running containers.
-	tmpHome, err := os.MkdirTemp("", "TestLoadPersistedRunsCrossRuntime")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
@@ -1196,17 +1193,28 @@ func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Read original metadata to verify it's not modified later.
+	metaPath := filepath.Join(store.Dir(), "metadata.json")
+	originalContent, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	routeDir := filepath.Join(tmpHome, ".moat", "routes")
 	routes, err := routing.NewRouteTable(routeDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Docker runtime — should NOT query this Apple container
+	// Docker runtime — should NOT query this Apple container.
+	// done is closed immediately so any accidentally-spawned monitor
+	// goroutine would return from WaitContainer and corrupt state.
+	done := make(chan struct{})
+	close(done)
 	m := &Manager{
 		runtime: &stubRuntime{
 			states: map[string]string{},
-			done:   make(chan struct{}),
+			done:   done,
 		},
 		runs:   make(map[string]*Run),
 		routes: routes,
@@ -1226,6 +1234,23 @@ func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
 	}
 	if r.Runtime != "apple" {
 		t.Errorf("expected runtime %q, got %q", "apple", r.Runtime)
+	}
+
+	// Give any accidentally-spawned monitor goroutine time to corrupt state.
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify in-memory state was not corrupted by a monitor goroutine.
+	if r.GetState() != StateRunning {
+		t.Errorf("cross-runtime run state was corrupted after reconciliation: got %q, want %q", r.GetState(), StateRunning)
+	}
+
+	// Verify on-disk metadata was not modified.
+	afterContent, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterContent) != string(originalContent) {
+		t.Error("cross-runtime run metadata was corrupted — monitorContainerExit should not have been spawned")
 	}
 }
 

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -1034,8 +1034,10 @@ func TestLoadPersistedRunsKeepsRoutesForRunningContainers(t *testing.T) {
 // its persisted state instead of being marked as stopped. Routes are also
 // preserved since the state was not confirmed by a live check.
 func TestLoadPersistedRunsPreservesStateOnContainerError(t *testing.T) {
-	// Use os.MkdirTemp because loadPersistedRuns spawns a background
-	// monitorContainerExit goroutine for running containers.
+	// Use os.MkdirTemp because reconciliation preserves "running" state and
+	// spawns a monitor goroutine. The monitor blocks on WaitContainer (done
+	// is never closed) so it won't write to the filesystem, but we use
+	// os.MkdirTemp to avoid t.TempDir() cleanup racing with the goroutine.
 	tmpHome, err := os.MkdirTemp("", "TestLoadPersistedRunsPreservesState")
 	if err != nil {
 		t.Fatal(err)
@@ -1070,7 +1072,11 @@ func TestLoadPersistedRunsPreservesStateOnContainerError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Stub runtime with NO containers — ContainerState will return error
+	// Stub runtime with NO containers — ContainerState will return error.
+	// done is never closed, so the monitor goroutine blocks on WaitContainer
+	// indefinitely. This is intentional: the monitor's job IS to update state
+	// when a container exits, but here we only test that reconciliation itself
+	// doesn't corrupt state during the read path.
 	m := &Manager{
 		runtime: &stubRuntime{
 			states: map[string]string{},

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -1029,11 +1029,17 @@ func TestLoadPersistedRunsKeepsRoutesForRunningContainers(t *testing.T) {
 	}
 }
 
-// TestLoadPersistedRunsCleansRoutesForMissingContainers verifies that
-// loadPersistedRuns removes routes when the container no longer exists at all
-// (e.g., was manually removed via docker rm).
-func TestLoadPersistedRunsCleansRoutesForMissingContainers(t *testing.T) {
-	tmpHome := t.TempDir()
+// TestLoadPersistedRunsPreservesStateOnContainerError verifies that when
+// ContainerState returns an error (container not found), the run preserves
+// its persisted state instead of being marked as stopped. Routes are also
+// preserved since the state was not confirmed by a live check.
+func TestLoadPersistedRunsPreservesStateOnContainerError(t *testing.T) {
+	// Use os.MkdirTemp because loadPersistedRuns spawns a background
+	// monitorContainerExit goroutine for running containers.
+	tmpHome, err := os.MkdirTemp("", "TestLoadPersistedRunsPreservesState")
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("HOME", tmpHome)
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
@@ -1068,6 +1074,7 @@ func TestLoadPersistedRunsCleansRoutesForMissingContainers(t *testing.T) {
 	m := &Manager{
 		runtime: &stubRuntime{
 			states: map[string]string{},
+			done:   make(chan struct{}),
 		},
 		runs:   make(map[string]*Run),
 		routes: routes,
@@ -1078,8 +1085,210 @@ func TestLoadPersistedRunsCleansRoutesForMissingContainers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if routes.AgentExists("gone-agent") {
-		t.Error("stale route for missing container should have been removed by loadPersistedRuns")
+	// Route should be preserved — container state was not confirmed
+	if !routes.AgentExists("gone-agent") {
+		t.Error("route should be preserved when container state check fails")
+	}
+
+	// Run should preserve its persisted "running" state
+	r := m.runs[runID]
+	if r.GetState() != StateRunning {
+		t.Errorf("expected run state %q (preserved from disk), got %q", StateRunning, r.GetState())
+	}
+}
+
+// TestLoadPersistedRunsDoesNotModifyMetadata verifies that loadPersistedRuns
+// never writes state changes back to disk. The owning process is responsible
+// for its run's on-disk state.
+func TestLoadPersistedRunsDoesNotModifyMetadata(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	baseDir := filepath.Join(tmpHome, ".moat", "runs")
+	runID := "run_nodeadbeef12"
+	store, err := storage.NewRunStore(baseDir, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.SaveMetadata(storage.Metadata{
+		Name:        "test-agent",
+		ContainerID: "container-xyz",
+		State:       "running",
+		Workspace:   "/tmp/workspace",
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+		StartedAt:   time.Now().Add(-1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the original metadata file content
+	metaPath := filepath.Join(store.Dir(), "metadata.json")
+	originalContent, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routeDir := filepath.Join(tmpHome, ".moat", "routes")
+	routes, err := routing.NewRouteTable(routeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Runtime reports container as exited — state differs from persisted "running"
+	m := &Manager{
+		runtime: &stubRuntime{
+			states: map[string]string{"container-xyz": "exited"},
+		},
+		runs:   make(map[string]*Run),
+		routes: routes,
+	}
+
+	err = m.loadPersistedRuns(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// In-memory state should reflect the live check
+	r := m.runs[runID]
+	if r.GetState() != StateStopped {
+		t.Errorf("expected in-memory state %q, got %q", StateStopped, r.GetState())
+	}
+
+	// On-disk metadata must NOT be modified
+	afterContent, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(afterContent) != string(originalContent) {
+		t.Error("loadPersistedRuns modified metadata.json — reconciliation must be read-only")
+	}
+}
+
+// TestLoadPersistedRunsSkipsCrossRuntimeCheck verifies that runs created with
+// a different runtime preserve their persisted state without a container check.
+func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
+	// Use os.MkdirTemp because loadPersistedRuns spawns a background
+	// monitorContainerExit goroutine for running containers.
+	tmpHome, err := os.MkdirTemp("", "TestLoadPersistedRunsCrossRuntime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmpHome)
+
+	baseDir := filepath.Join(tmpHome, ".moat", "runs")
+	runID := "run_applerun1234"
+	store, err := storage.NewRunStore(baseDir, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a run created with Apple containers
+	err = store.SaveMetadata(storage.Metadata{
+		Name:        "apple-agent",
+		ContainerID: "run_applerun1234",
+		State:       "running",
+		Runtime:     "apple",
+		Workspace:   "/tmp/workspace",
+		CreatedAt:   time.Now().Add(-1 * time.Hour),
+		StartedAt:   time.Now().Add(-1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routeDir := filepath.Join(tmpHome, ".moat", "routes")
+	routes, err := routing.NewRouteTable(routeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Docker runtime — should NOT query this Apple container
+	m := &Manager{
+		runtime: &stubRuntime{
+			states: map[string]string{},
+			done:   make(chan struct{}),
+		},
+		runs:   make(map[string]*Run),
+		routes: routes,
+	}
+
+	err = m.loadPersistedRuns(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := m.runs[runID]
+	if r == nil {
+		t.Fatal("expected run to be loaded")
+	}
+	if r.GetState() != StateRunning {
+		t.Errorf("cross-runtime run should preserve persisted state %q, got %q", StateRunning, r.GetState())
+	}
+	if r.Runtime != "apple" {
+		t.Errorf("expected runtime %q, got %q", "apple", r.Runtime)
+	}
+}
+
+// TestLoadPersistedRunsCleansRoutesForPersistedTerminalState verifies that
+// runs persisted in a terminal state (stopped/failed) have their stale routes
+// cleaned up. The owning process authoritatively wrote the terminal state,
+// so route cleanup is safe.
+func TestLoadPersistedRunsCleansRoutesForPersistedTerminalState(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	baseDir := filepath.Join(tmpHome, ".moat", "runs")
+	runID := "run_stoppedbeef12"
+	store, err := storage.NewRunStore(baseDir, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.SaveMetadata(storage.Metadata{
+		Name:        "done-agent",
+		ContainerID: "container-done",
+		State:       "stopped",
+		Workspace:   "/tmp/workspace",
+		CreatedAt:   time.Now().Add(-2 * time.Hour),
+		StartedAt:   time.Now().Add(-2 * time.Hour),
+		StoppedAt:   time.Now().Add(-1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routeDir := filepath.Join(tmpHome, ".moat", "routes")
+	routes, err := routing.NewRouteTable(routeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = routes.Add("done-agent", map[string]string{"default": "127.0.0.1:6060"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Runtime is irrelevant — persisted terminal state skips live container checks
+	m := &Manager{
+		runtime: &stubRuntime{
+			states: map[string]string{},
+		},
+		runs:   make(map[string]*Run),
+		routes: routes,
+	}
+
+	err = m.loadPersistedRuns(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale route should be cleaned for a persisted terminal state
+	if routes.AgentExists("done-agent") {
+		t.Error("stale route for persisted stopped run should have been removed by loadPersistedRuns")
+	}
+
+	// Run should be loaded with stopped state
+	r := m.runs[runID]
+	if r.GetState() != StateStopped {
+		t.Errorf("expected run state %q, got %q", StateStopped, r.GetState())
 	}
 }
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -44,6 +44,7 @@ type Run struct {
 	Grants            []string
 	Agent             string            // Agent type from config (e.g., "claude-code", "codex")
 	Image             string            // Container image used for this run
+	Runtime           string            // Container runtime type ("docker" or "apple")
 	ProviderMeta      map[string]string // Provider-specific metadata (e.g., claude_session_id)
 	Ports             map[string]int    // endpoint name -> container port
 	HostPorts         map[string]int    // endpoint name -> host port (after binding)
@@ -177,6 +178,7 @@ func (r *Run) SaveMetadata() error {
 		WorktreeBranch:      r.WorktreeBranch,
 		WorktreePath:        r.WorktreePath,
 		WorktreeRepoID:      r.WorktreeRepoID,
+		Runtime:             r.Runtime,
 		BuildkitContainerID: r.BuildkitContainerID,
 		NetworkID:           r.NetworkID,
 		ServiceContainers:   r.ServiceContainers,

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -41,6 +41,10 @@ type Metadata struct {
 	// Service dependency fields
 	ServiceContainers map[string]string `json:"service_containers,omitempty"` // service name -> container ID
 
+	// Runtime records which container runtime was used ("docker" or "apple").
+	// Used during reconciliation to skip cross-runtime container state checks.
+	Runtime string `json:"runtime,omitempty"`
+
 	// BuildKit sidecar fields (docker:dind only)
 	BuildkitContainerID string `json:"buildkit_container_id,omitempty"`
 	NetworkID           string `json:"network_id,omitempty"`


### PR DESCRIPTION
## Summary

- **Remove metadata write-back from reconciliation** — `moat status`/`moat list` no longer corrupt on-disk state. Read-only commands must not have write side effects.
- **Add `Runtime` field to metadata** — reconciliation skips cross-runtime container checks (e.g. Apple runtime checking Docker container IDs), preventing false-negative state detection.
- **Preserve persisted state on errors** — container state check failures now trust the persisted state instead of assuming "stopped", which was the root cause of corruption.
- **Gate route/daemon cleanup on confirmed state** — routes and daemon registrations are only cleaned when a live container check confirms the container is gone, not when inferred from errors.

Fixes the bug where six active `moat` runs showed zero active runs in `moat status` because a single status check with the wrong runtime permanently overwrote all their metadata.

Design doc: `docs/plans/2026-04-10-run-state-reconciliation-design.md`

## Test plan

- [x] `TestLoadPersistedRunsCleansStaleRoutes` — confirmed-stopped runs clean routes
- [x] `TestLoadPersistedRunsKeepsRoutesForRunningContainers` — running containers preserve routes
- [x] `TestLoadPersistedRunsPreservesStateOnContainerError` — container check errors preserve persisted state and routes
- [x] `TestLoadPersistedRunsDoesNotModifyMetadata` — reconciliation never writes to metadata.json
- [x] `TestLoadPersistedRunsSkipsCrossRuntimeCheck` — cross-runtime runs skip container checks
- [x] `TestLoadPersistedRunsCleansRoutesForPersistedTerminalState` — persisted stopped/failed runs clean stale routes
- [x] `go test -race ./internal/run/` passes
- [x] `go build ./...` passes
- [x] `go vet ./...` passes