### PR TITLE
feat: multi-runtime manager for cross-engine CLI commands

### DIFF
--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -43,12 +43,12 @@ func init() {
 func cleanResources(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Get runtime (no sandbox needed for listing/cleaning)
-	rt, err := container.NewRuntimeWithOptions(container.RuntimeOptions{Sandbox: false})
+	// Get runtime pool (no sandbox needed for listing/cleaning)
+	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
 	if err != nil {
 		return fmt.Errorf("initializing runtime: %w", err)
 	}
-	defer rt.Close()
+	defer pool.Close()
 
 	// Get runs (no sandbox needed for listing/cleaning)
 	noSandbox := true
@@ -76,27 +76,43 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find unused images (images not used by any running container)
-	// For now, we consider all moat images as candidates for cleanup.
-	// A more sophisticated approach would track which images are in use,
-	// but this is complex: we'd need to inspect each container's image tag.
-	images, err := rt.ListImages(ctx)
-	if err != nil {
-		return fmt.Errorf("listing images: %w", err)
+	// Collect images from all available runtimes, tracking which runtime owns each.
+	type runtimeImage struct {
+		image container.ImageInfo
+		rt    container.Runtime
 	}
+	var allImages []runtimeImage
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		imgs, err := rt.ListImages(ctx)
+		if err != nil {
+			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
+			return nil
+		}
+		for _, img := range imgs {
+			allImages = append(allImages, runtimeImage{image: img, rt: rt})
+		}
+		return nil
+	})
 
 	// Build a tag-to-ID mapping so we can track images by both identifiers.
 	// This handles cases where the same image ID has multiple tags.
 	tagToID := make(map[string]string)
-	for _, img := range images {
-		tagToID[img.Tag] = img.ID
+	for _, ri := range allImages {
+		tagToID[ri.image.Tag] = ri.image.ID
 	}
 
 	// Filter out images that might be in use by running containers.
 	// Track both tags and IDs since containers report tags but we need
 	// to match against image IDs for correctness.
-	containers, containerErr := rt.ListContainers(ctx)
 	runningImages := make(map[string]bool)
-	if containerErr == nil {
+	var containerListFailed bool
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		containers, err := rt.ListContainers(ctx)
+		if err != nil {
+			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
+			containerListFailed = true
+			return nil
+		}
 		for _, c := range containers {
 			if c.Status == "running" {
 				runningImages[c.Image] = true
@@ -106,42 +122,54 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
-	} else {
-		// Log the error so users know why we might not detect in-use images
-		ui.Warnf("Failed to list containers: %v", containerErr)
+		return nil
+	})
+	if containerListFailed {
 		ui.Info("Images will be skipped if running containers cannot be verified")
 	}
 
-	var unusedImages []container.ImageInfo
-	for _, img := range images {
+	var unusedRuntimeImages []runtimeImage
+	for _, ri := range allImages {
 		// Check both tag and ID since an image might be referenced either way
-		if !runningImages[img.Tag] && !runningImages[img.ID] {
-			unusedImages = append(unusedImages, img)
+		if !runningImages[ri.image.Tag] && !runningImages[ri.image.ID] {
+			unusedRuntimeImages = append(unusedRuntimeImages, ri)
 		}
+	}
+	unusedImages := make([]container.ImageInfo, len(unusedRuntimeImages))
+	for i, ri := range unusedRuntimeImages {
+		unusedImages[i] = ri.image
 	}
 
 	// Find orphaned networks (moat-managed networks not associated with any known run)
-	var orphanedNetworks []container.NetworkInfo
-	netMgr := rt.NetworkManager()
-	if netMgr != nil {
+	type runtimeNetwork struct {
+		network container.NetworkInfo
+		rt      container.Runtime
+	}
+	var orphanedNetworks []runtimeNetwork
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		netMgr := rt.NetworkManager()
+		if netMgr == nil {
+			return nil
+		}
 		allNetworks, netErr := netMgr.ListNetworks(ctx)
 		if netErr != nil {
-			ui.Warnf("Failed to list networks: %v", netErr)
-		} else {
-			// Build set of network IDs associated with known runs
-			knownNetworkIDs := make(map[string]bool)
-			for _, r := range runs {
-				if r.NetworkID != "" {
-					knownNetworkIDs[r.NetworkID] = true
-				}
-			}
-			for _, n := range allNetworks {
-				if !knownNetworkIDs[n.ID] {
-					orphanedNetworks = append(orphanedNetworks, n)
-				}
+			ui.Warnf("Failed to list %s networks: %v", rt.Type(), netErr)
+			return nil
+		}
+		// Build set of network IDs associated with known runs
+		knownNetworkIDs := make(map[string]bool)
+		for _, r := range runs {
+			if r.NetworkID != "" {
+				knownNetworkIDs[r.NetworkID] = true
 			}
 		}
-	}
+		for _, n := range allNetworks {
+			if !knownNetworkIDs[n.ID] {
+				orphanedNetworks = append(orphanedNetworks, runtimeNetwork{network: n, rt: rt})
+			}
+		}
+		return nil
+	})
 
 	// Nothing to clean?
 	if len(stoppedRuns) == 0 && len(unusedImages) == 0 && len(orphanedNetworks) == 0 {
@@ -193,8 +221,8 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 
 	if len(orphanedNetworks) > 0 {
 		fmt.Printf("%s (%d):\n", ui.Bold("Orphaned networks"), len(orphanedNetworks))
-		for _, n := range orphanedNetworks {
-			fmt.Printf("  %s\n", n.Name)
+		for _, rn := range orphanedNetworks {
+			fmt.Printf("  %s\n", rn.network.Name)
 		}
 		fmt.Println()
 	}
@@ -255,16 +283,17 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	// Remove unused images
 	// Re-check each image before removal to handle race condition where
 	// a container might have started using the image since we listed them.
-	for _, img := range unusedImages {
+	for _, ri := range unusedRuntimeImages {
+		img := ri.image
 		fmt.Printf("Removing image %s... ", img.Tag)
 
 		// Re-check if image is now in use
-		if isImageInUse(ctx, rt, img.ID, img.Tag) {
+		if isImageInUse(ctx, ri.rt, img.ID, img.Tag) {
 			fmt.Println(ui.Yellow("skipped (now in use)"))
 			continue
 		}
 
-		if err := rt.RemoveImage(ctx, img.ID); err != nil {
+		if err := ri.rt.RemoveImage(ctx, img.ID); err != nil {
 			fmt.Printf("%s\n", ui.Red(fmt.Sprintf("error: %v", err)))
 			failedCount++
 			continue
@@ -275,17 +304,19 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	}
 
 	// Remove orphaned networks
-	if netMgr != nil {
-		for _, n := range orphanedNetworks {
-			fmt.Printf("Removing network %s... ", n.Name)
-			if err := netMgr.ForceRemoveNetwork(ctx, n.ID); err != nil {
-				fmt.Printf("%s\n", ui.Red(fmt.Sprintf("error: %v", err)))
-				failedCount++
-				continue
-			}
-			fmt.Println(ui.Green("done"))
-			removedCount++
+	for _, rn := range orphanedNetworks {
+		fmt.Printf("Removing network %s... ", rn.network.Name)
+		netMgr := rn.rt.NetworkManager()
+		if netMgr == nil {
+			continue
 		}
+		if err := netMgr.ForceRemoveNetwork(ctx, rn.network.ID); err != nil {
+			fmt.Printf("%s\n", ui.Red(fmt.Sprintf("error: %v", err)))
+			failedCount++
+			continue
+		}
+		fmt.Println(ui.Green("done"))
+		removedCount++
 	}
 
 	// Clean worktree directories only for runs that were successfully destroyed.

--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -92,22 +92,34 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		ui.Warnf("Error scanning images: %v", err)
 	}
 
-	// Build a tag-to-ID mapping so we can track images by both identifiers.
-	// This handles cases where the same image ID has multiple tags.
-	tagToID := make(map[string]string)
-	for _, ri := range allImages {
-		tagToID[ri.image.Tag] = ri.image.ID
+	// Build per-runtime maps of tag-to-ID and running images to avoid
+	// cross-runtime contamination (e.g., a Docker container using
+	// moat/claude:latest should not prevent Apple's moat/claude:latest
+	// from being cleaned up).
+	type runtimeImageState struct {
+		tagToID       map[string]string
+		runningImages map[string]bool
 	}
+	rtImageState := make(map[container.RuntimeType]*runtimeImageState)
 
-	// Filter out images that might be in use by running containers.
-	// Track both tags and IDs since containers report tags but we need
-	// to match against image IDs for correctness.
-	runningImages := make(map[string]bool)
 	// Track which runtimes failed container listing — we must skip both
 	// image and network cleanup for those runtimes to avoid removing
 	// resources that may still be in use by containers we couldn't verify.
 	failedRuntimes := make(map[container.RuntimeType]bool)
 	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
+		state := &runtimeImageState{
+			tagToID:       make(map[string]string),
+			runningImages: make(map[string]bool),
+		}
+		rtImageState[rt.Type()] = state
+
+		// Build tag-to-ID from this runtime's images only
+		for _, ri := range allImages {
+			if ri.rt.Type() == rt.Type() {
+				state.tagToID[ri.image.Tag] = ri.image.ID
+			}
+		}
+
 		containers, err := rt.ListContainers(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
@@ -116,10 +128,9 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		}
 		for _, c := range containers {
 			if c.Status == "running" {
-				runningImages[c.Image] = true
-				// Also mark the image ID as in-use if we can resolve it
-				if id, ok := tagToID[c.Image]; ok {
-					runningImages[id] = true
+				state.runningImages[c.Image] = true
+				if id, ok := state.tagToID[c.Image]; ok {
+					state.runningImages[id] = true
 				}
 			}
 		}
@@ -137,10 +148,12 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		if failedRuntimes[ri.rt.Type()] {
 			continue
 		}
-		// Check both tag and ID since an image might be referenced either way
-		if !runningImages[ri.image.Tag] && !runningImages[ri.image.ID] {
-			unusedRuntimeImages = append(unusedRuntimeImages, ri)
+		// Check this image against its own runtime's running containers only
+		state := rtImageState[ri.rt.Type()]
+		if state != nil && (state.runningImages[ri.image.Tag] || state.runningImages[ri.image.ID]) {
+			continue
 		}
+		unusedRuntimeImages = append(unusedRuntimeImages, ri)
 	}
 	// Find orphaned networks (moat-managed networks not associated with any known run)
 	type runtimeNetwork struct {

--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -43,13 +43,6 @@ func init() {
 func cleanResources(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Get runtime pool (no sandbox needed for listing/cleaning)
-	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
-	if err != nil {
-		return fmt.Errorf("initializing runtime: %w", err)
-	}
-	defer pool.Close()
-
 	// Get runs (no sandbox needed for listing/cleaning)
 	noSandbox := true
 	manager, err := run.NewManagerWithOptions(run.ManagerOptions{NoSandbox: &noSandbox})
@@ -57,6 +50,9 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating run manager: %w", err)
 	}
 	defer manager.Close()
+
+	// Use the manager's runtime pool to avoid creating a duplicate.
+	pool := manager.RuntimePool()
 
 	fmt.Println("Scanning for resources to clean...")
 	fmt.Println()
@@ -82,7 +78,7 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		rt    container.Runtime
 	}
 	var allImages []runtimeImage
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		imgs, err := rt.ListImages(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
@@ -92,7 +88,9 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 			allImages = append(allImages, runtimeImage{image: img, rt: rt})
 		}
 		return nil
-	})
+	}); err != nil {
+		ui.Warnf("Error scanning images: %v", err)
+	}
 
 	// Build a tag-to-ID mapping so we can track images by both identifiers.
 	// This handles cases where the same image ID has multiple tags.
@@ -105,12 +103,15 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	// Track both tags and IDs since containers report tags but we need
 	// to match against image IDs for correctness.
 	runningImages := make(map[string]bool)
-	var containerListFailed bool
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	// Track which runtimes failed container listing — we must skip both
+	// image and network cleanup for those runtimes to avoid removing
+	// resources that may still be in use by containers we couldn't verify.
+	failedRuntimes := make(map[container.RuntimeType]bool)
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		containers, err := rt.ListContainers(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
-			containerListFailed = true
+			failedRuntimes[rt.Type()] = true
 			return nil
 		}
 		for _, c := range containers {
@@ -123,13 +124,19 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 			}
 		}
 		return nil
-	})
-	if containerListFailed {
-		ui.Info("Images will be skipped if running containers cannot be verified")
+	}); err != nil {
+		ui.Warnf("Error scanning containers: %v", err)
+	}
+	if len(failedRuntimes) > 0 {
+		ui.Info("Images and networks will be skipped for runtimes where containers cannot be verified")
 	}
 
 	var unusedRuntimeImages []runtimeImage
 	for _, ri := range allImages {
+		// Skip images from runtimes where we couldn't list containers
+		if failedRuntimes[ri.rt.Type()] {
+			continue
+		}
 		// Check both tag and ID since an image might be referenced either way
 		if !runningImages[ri.image.Tag] && !runningImages[ri.image.ID] {
 			unusedRuntimeImages = append(unusedRuntimeImages, ri)
@@ -146,7 +153,12 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		rt      container.Runtime
 	}
 	var orphanedNetworks []runtimeNetwork
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
+		// Skip runtimes where container listing failed — we can't
+		// reliably determine which networks are orphaned.
+		if failedRuntimes[rt.Type()] {
+			return nil
+		}
 		netMgr := rt.NetworkManager()
 		if netMgr == nil {
 			return nil
@@ -169,7 +181,9 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 			}
 		}
 		return nil
-	})
+	}); err != nil {
+		ui.Warnf("Error scanning networks: %v", err)
+	}
 
 	// Nothing to clean?
 	if len(stoppedRuns) == 0 && len(unusedImages) == 0 && len(orphanedNetworks) == 0 {

--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -142,11 +142,6 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 			unusedRuntimeImages = append(unusedRuntimeImages, ri)
 		}
 	}
-	unusedImages := make([]container.ImageInfo, len(unusedRuntimeImages))
-	for i, ri := range unusedRuntimeImages {
-		unusedImages[i] = ri.image
-	}
-
 	// Find orphaned networks (moat-managed networks not associated with any known run)
 	type runtimeNetwork struct {
 		network container.NetworkInfo
@@ -186,7 +181,7 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	}
 
 	// Nothing to clean?
-	if len(stoppedRuns) == 0 && len(unusedImages) == 0 && len(orphanedNetworks) == 0 {
+	if len(stoppedRuns) == 0 && len(unusedRuntimeImages) == 0 && len(orphanedNetworks) == 0 {
 		fmt.Println("Nothing to clean.")
 		return nil
 	}
@@ -221,13 +216,14 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
-	if len(unusedImages) > 0 {
-		fmt.Printf("%s (%d):\n", ui.Bold("Unused images"), len(unusedImages))
+	if len(unusedRuntimeImages) > 0 {
+		fmt.Printf("%s (%d):\n", ui.Bold("Unused images"), len(unusedRuntimeImages))
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		for _, img := range unusedImages {
+		for _, ri := range unusedRuntimeImages {
+			img := ri.image
 			sizeMB := img.Size / (1024 * 1024)
 			totalSize += img.Size
-			fmt.Fprintf(w, "  %s\t%s\t%d MB\n", img.Tag, formatAge(img.Created), sizeMB)
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%d MB\n", img.Tag, ri.rt.Type(), formatAge(img.Created), sizeMB)
 		}
 		w.Flush()
 		fmt.Println()
@@ -256,7 +252,7 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	}
 
 	// worktreeRuns is a subset of stoppedRuns, so don't count them separately.
-	resourceCount := len(stoppedRuns) + len(unusedImages) + len(orphanedNetworks)
+	resourceCount := len(stoppedRuns) + len(unusedRuntimeImages) + len(orphanedNetworks)
 	fmt.Printf("Total: %d resources, %d MB\n\n", resourceCount, totalSize/(1024*1024))
 
 	// Dry run - just show, don't prompt

--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -82,7 +82,7 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		rt    container.Runtime
 	}
 	var allImages []runtimeImage
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		imgs, err := rt.ListImages(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
@@ -106,7 +106,7 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 	// to match against image IDs for correctness.
 	runningImages := make(map[string]bool)
 	var containerListFailed bool
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		containers, err := rt.ListContainers(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
@@ -146,7 +146,7 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		rt      container.Runtime
 	}
 	var orphanedNetworks []runtimeNetwork
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		netMgr := rt.NetworkManager()
 		if netMgr == nil {
 			return nil

--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -147,6 +147,14 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		network container.NetworkInfo
 		rt      container.Runtime
 	}
+	// Build set of network IDs associated with known runs (once, not per-runtime).
+	knownNetworkIDs := make(map[string]bool)
+	for _, r := range runs {
+		if r.NetworkID != "" {
+			knownNetworkIDs[r.NetworkID] = true
+		}
+	}
+
 	var orphanedNetworks []runtimeNetwork
 	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		// Skip runtimes where container listing failed — we can't
@@ -162,13 +170,6 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 		if netErr != nil {
 			ui.Warnf("Failed to list %s networks: %v", rt.Type(), netErr)
 			return nil
-		}
-		// Build set of network IDs associated with known runs
-		knownNetworkIDs := make(map[string]bool)
-		for _, r := range runs {
-			if r.NetworkID != "" {
-				knownNetworkIDs[r.NetworkID] = true
-			}
 		}
 		for _, n := range allNetworks {
 			if !knownNetworkIDs[n.ID] {

--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -232,9 +232,11 @@ func cleanResources(cmd *cobra.Command, args []string) error {
 
 	if len(orphanedNetworks) > 0 {
 		fmt.Printf("%s (%d):\n", ui.Bold("Orphaned networks"), len(orphanedNetworks))
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		for _, rn := range orphanedNetworks {
-			fmt.Printf("  %s\n", rn.network.Name)
+			fmt.Fprintf(w, "  %s\t%s\n", rn.network.Name, rn.rt.Type())
 		}
+		w.Flush()
 		fmt.Println()
 	}
 

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -95,7 +95,10 @@ func setupStatusBar(manager *run.Manager, r *run.Run) (writer *tui.Writer, clean
 		return nil, cleanup, stdout
 	}
 
-	runtimeType := manager.RuntimeType()
+	runtimeType := r.Runtime
+	if runtimeType == "" {
+		runtimeType = manager.RuntimeType()
+	}
 	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
 	bar.SetGrants(r.Grants)
 	if r.DaemonCommit != "" && r.DaemonCommit != commit {

--- a/cmd/moat/cli/list.go
+++ b/cmd/moat/cli/list.go
@@ -64,9 +64,9 @@ func listRuns(cmd *cobra.Command, args []string) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	if hasWorktree {
-		fmt.Fprintln(w, "NAME\tRUN ID\tSTATE\tAGE\tWORKTREE\tENDPOINTS")
+		fmt.Fprintln(w, "NAME\tRUN ID\tRUNTIME\tSTATE\tAGE\tWORKTREE\tENDPOINTS")
 	} else {
-		fmt.Fprintln(w, "NAME\tRUN ID\tSTATE\tAGE\tENDPOINTS")
+		fmt.Fprintln(w, "NAME\tRUN ID\tRUNTIME\tSTATE\tAGE\tENDPOINTS")
 	}
 	for _, r := range runs {
 		endpoints := ""
@@ -78,23 +78,29 @@ func listRuns(cmd *cobra.Command, args []string) error {
 			sort.Strings(names)
 			endpoints = strings.Join(names, ", ")
 		}
+		rtLabel := r.Runtime
+		if rtLabel == "" {
+			rtLabel = "-"
+		}
 		if hasWorktree {
 			wt := ""
 			if r.WorktreeBranch != "" {
 				wt = r.WorktreeBranch
 			}
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				r.Name,
 				r.ID,
+				rtLabel,
 				r.GetState(),
 				formatAge(r.CreatedAt),
 				wt,
 				endpoints,
 			)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
 				r.Name,
 				r.ID,
+				rtLabel,
 				r.GetState(),
 				formatAge(r.CreatedAt),
 				endpoints,

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -89,9 +89,11 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		return runs[i].CreatedAt.After(runs[j].CreatedAt)
 	})
 
-	// Get images from all available runtimes
+	// Get images and runtime names from all available runtimes
 	var images []imageInfo
+	var runtimeNames []string
 	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
+		runtimeNames = append(runtimeNames, string(rt.Type()))
 		rtImages, err := rt.ListImages(ctx)
 		if err != nil {
 			log.Debug("listing images failed", "runtime", rt.Type(), "error", err)
@@ -135,13 +137,6 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build output
-	var runtimeNames []string
-	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
-		runtimeNames = append(runtimeNames, string(rt.Type()))
-		return nil
-	}); err != nil {
-		log.Debug("listing runtimes failed", "error", err)
-	}
 	output := statusOutput{
 		Runtimes: runtimeNames,
 	}

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/run"
 	"github.com/majorcontext/moat/internal/storage"
 	"github.com/majorcontext/moat/internal/ui"
@@ -68,12 +69,12 @@ type healthItem struct {
 func showStatus(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Get runtime (no sandbox needed for status queries)
-	rt, err := container.NewRuntimeWithOptions(container.RuntimeOptions{Sandbox: false})
+	// Get runtime pool (no sandbox needed for status queries)
+	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
 	if err != nil {
 		return fmt.Errorf("initializing runtime: %w", err)
 	}
-	defer rt.Close()
+	defer pool.Close()
 
 	// Get runs (no sandbox needed for status queries)
 	noSandbox := true
@@ -90,11 +91,17 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		return runs[i].CreatedAt.After(runs[j].CreatedAt)
 	})
 
-	// Get images
-	images, err := rt.ListImages(ctx)
-	if err != nil {
-		return fmt.Errorf("listing images: %w", err)
-	}
+	// Get images from all available runtimes
+	var images []container.ImageInfo
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		rtImages, err := rt.ListImages(ctx)
+		if err != nil {
+			log.Debug("listing images failed", "runtime", rt.Type(), "error", err)
+			return nil
+		}
+		images = append(images, rtImages...)
+		return nil
+	})
 
 	// Calculate disk usage only for active runs (with timeout to prevent blocking on slow disks)
 	runDiskUsage := make(map[string]int64)
@@ -121,8 +128,13 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build output
+	var runtimeNames []string
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		runtimeNames = append(runtimeNames, string(rt.Type()))
+		return nil
+	})
 	output := statusOutput{
-		Runtime: string(rt.Type()),
+		Runtime: strings.Join(runtimeNames, ", "),
 	}
 
 	// Active runs section
@@ -174,31 +186,36 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Check for orphaned containers
-	containers, err := rt.ListContainers(ctx)
-	if err != nil {
-		// Add health warning so users know container checks are incomplete
-		output.Health = append(output.Health, healthItem{
-			Status:  "warning",
-			Message: fmt.Sprintf("Failed to list containers: %v", err),
-		})
-	} else {
-		knownRunIDs := make(map[string]bool)
-		for _, r := range runs {
-			knownRunIDs[r.ID] = true
-		}
-		orphanedCount := 0
-		for _, c := range containers {
-			if !knownRunIDs[c.Name] {
-				orphanedCount++
-			}
-		}
-		if orphanedCount > 0 {
+	// Check for orphaned containers across all runtimes
+	var allContainers []container.Info
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		cs, err := rt.ListContainers(ctx)
+		if err != nil {
 			output.Health = append(output.Health, healthItem{
 				Status:  "warning",
-				Message: fmt.Sprintf("%d orphaned containers", orphanedCount),
+				Message: fmt.Sprintf("Failed to list %s containers: %v", rt.Type(), err),
 			})
+			return nil
 		}
+		allContainers = append(allContainers, cs...)
+		return nil
+	})
+
+	knownRunIDs := make(map[string]bool)
+	for _, r := range runs {
+		knownRunIDs[r.ID] = true
+	}
+	orphanedCount := 0
+	for _, c := range allContainers {
+		if !knownRunIDs[c.Name] {
+			orphanedCount++
+		}
+	}
+	if orphanedCount > 0 {
+		output.Health = append(output.Health, healthItem{
+			Status:  "warning",
+			Message: fmt.Sprintf("%d orphaned containers", orphanedCount),
+		})
 	}
 
 	output.TotalDisk = totalImageSize + stoppedDisk

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -49,6 +49,7 @@ type statusOutput struct {
 type runInfo struct {
 	Name      string `json:"name"`
 	ID        string `json:"id"`
+	Runtime   string `json:"runtime"`
 	State     string `json:"state"`
 	Age       string `json:"age"`
 	DiskMB    int64  `json:"disk_mb"`
@@ -69,13 +70,6 @@ type healthItem struct {
 func showStatus(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Get runtime pool (no sandbox needed for status queries)
-	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
-	if err != nil {
-		return fmt.Errorf("initializing runtime: %w", err)
-	}
-	defer pool.Close()
-
 	// Get runs (no sandbox needed for status queries)
 	noSandbox := true
 	manager, err := run.NewManagerWithOptions(run.ManagerOptions{NoSandbox: &noSandbox})
@@ -83,6 +77,9 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating run manager: %w", err)
 	}
 	defer manager.Close()
+
+	// Use the manager's runtime pool to avoid creating a duplicate.
+	pool := manager.RuntimePool()
 
 	runs := manager.List()
 
@@ -92,16 +89,24 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	})
 
 	// Get images from all available runtimes
-	var images []container.ImageInfo
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	var images []imageInfo
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		rtImages, err := rt.ListImages(ctx)
 		if err != nil {
 			log.Debug("listing images failed", "runtime", rt.Type(), "error", err)
 			return nil
 		}
-		images = append(images, rtImages...)
+		for _, img := range rtImages {
+			images = append(images, imageInfo{
+				Tag:     img.Tag,
+				Created: formatAge(img.Created),
+				SizeMB:  img.Size / (1024 * 1024),
+			})
+		}
 		return nil
-	})
+	}); err != nil {
+		ui.Warnf("Error scanning images: %v", err)
+	}
 
 	// Calculate disk usage only for active runs (with timeout to prevent blocking on slow disks)
 	runDiskUsage := make(map[string]int64)
@@ -129,10 +134,12 @@ func showStatus(cmd *cobra.Command, args []string) error {
 
 	// Build output
 	var runtimeNames []string
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		runtimeNames = append(runtimeNames, string(rt.Type()))
 		return nil
-	})
+	}); err != nil {
+		log.Debug("listing runtimes failed", "error", err)
+	}
 	output := statusOutput{
 		Runtime: strings.Join(runtimeNames, ", "),
 	}
@@ -159,6 +166,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		output.ActiveRuns = append(output.ActiveRuns, runInfo{
 			Name:      r.Name,
 			ID:        r.ID,
+			Runtime:   r.Runtime,
 			State:     string(r.GetState()),
 			Age:       age,
 			DiskMB:    diskMB,
@@ -166,16 +174,12 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Images section - only need count for summary
+	// Images section - calculate total size from image info
 	var totalImageSize int64
 	for _, img := range images {
-		totalImageSize += img.Size
-		output.Images = append(output.Images, imageInfo{
-			Tag:     img.Tag,
-			Created: formatAge(img.Created),
-			SizeMB:  img.Size / (1024 * 1024),
-		})
+		totalImageSize += img.SizeMB * (1024 * 1024)
 	}
+	output.Images = images
 
 	// Health section
 	if stoppedCount > 0 {
@@ -188,7 +192,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 
 	// Check for orphaned containers across all runtimes
 	var allContainers []container.Info
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		cs, err := rt.ListContainers(ctx)
 		if err != nil {
 			output.Health = append(output.Health, healthItem{
@@ -199,7 +203,9 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		}
 		allContainers = append(allContainers, cs...)
 		return nil
-	})
+	}); err != nil {
+		ui.Warnf("Error scanning containers: %v", err)
+	}
 
 	knownRunIDs := make(map[string]bool)
 	for _, r := range runs {

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 type statusOutput struct {
-	Runtime    string       `json:"runtime"`
+	Runtimes   []string     `json:"runtimes"`
 	ActiveRuns []runInfo    `json:"active_runs"`
 	Images     []imageInfo  `json:"images"`
 	Health     []healthItem `json:"health"`
@@ -58,6 +58,7 @@ type runInfo struct {
 
 type imageInfo struct {
 	Tag     string `json:"tag"`
+	Runtime string `json:"runtime"`
 	Created string `json:"created"`
 	SizeMB  int64  `json:"size_mb"`
 }
@@ -99,6 +100,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		for _, img := range rtImages {
 			images = append(images, imageInfo{
 				Tag:     img.Tag,
+				Runtime: string(rt.Type()),
 				Created: formatAge(img.Created),
 				SizeMB:  img.Size / (1024 * 1024),
 			})
@@ -141,7 +143,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 		log.Debug("listing runtimes failed", "error", err)
 	}
 	output := statusOutput{
-		Runtime: strings.Join(runtimeNames, ", "),
+		Runtimes: runtimeNames,
 	}
 
 	// Active runs section
@@ -237,7 +239,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Human-readable output
-	fmt.Printf("%s: %s\n\n", ui.Bold("Runtime"), output.Runtime)
+	fmt.Printf("%s: %s\n\n", ui.Bold("Runtime"), strings.Join(output.Runtimes, ", "))
 
 	// Active runs table
 	if len(activeRuns) == 0 {

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -239,7 +239,11 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Human-readable output
-	fmt.Printf("%s: %s\n\n", ui.Bold("Runtime"), strings.Join(output.Runtimes, ", "))
+	runtimeLabel := "Runtime"
+	if len(output.Runtimes) > 1 {
+		runtimeLabel = "Runtimes"
+	}
+	fmt.Printf("%s: %s\n\n", ui.Bold(runtimeLabel), strings.Join(output.Runtimes, ", "))
 
 	// Active runs table
 	if len(activeRuns) == 0 {

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -93,7 +93,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 
 	// Get images from all available runtimes
 	var images []container.ImageInfo
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		rtImages, err := rt.ListImages(ctx)
 		if err != nil {
 			log.Debug("listing images failed", "runtime", rt.Type(), "error", err)
@@ -129,7 +129,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 
 	// Build output
 	var runtimeNames []string
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		runtimeNames = append(runtimeNames, string(rt.Type()))
 		return nil
 	})
@@ -188,7 +188,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 
 	// Check for orphaned containers across all runtimes
 	var allContainers []container.Info
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		cs, err := rt.ListContainers(ctx)
 		if err != nil {
 			output.Health = append(output.Health, healthItem{

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -252,8 +252,12 @@ func showStatus(cmd *cobra.Command, args []string) error {
 			if r.DiskMB < 0 {
 				diskStr = "?"
 			}
+			rtLabel := r.Runtime
+			if rtLabel == "" {
+				rtLabel = "-"
+			}
 			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%s\n",
-				r.Name, r.ID, r.Runtime, r.Age, diskStr, r.Endpoints)
+				r.Name, r.ID, rtLabel, r.Age, diskStr, r.Endpoints)
 		}
 		w.Flush()
 	}

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -57,10 +57,10 @@ type runInfo struct {
 }
 
 type imageInfo struct {
-	Tag     string `json:"tag"`
-	Runtime string `json:"runtime"`
-	Created string `json:"created"`
-	SizeMB  int64  `json:"size_mb"`
+	Tag     string    `json:"tag"`
+	Runtime string    `json:"runtime"`
+	Size    int64     `json:"size"`
+	Created time.Time `json:"created"`
 }
 
 type healthItem struct {
@@ -101,8 +101,8 @@ func showStatus(cmd *cobra.Command, args []string) error {
 			images = append(images, imageInfo{
 				Tag:     img.Tag,
 				Runtime: string(rt.Type()),
-				Created: formatAge(img.Created),
-				SizeMB:  img.Size / (1024 * 1024),
+				Size:    img.Size,
+				Created: img.Created,
 			})
 		}
 		return nil
@@ -179,7 +179,7 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	// Images section - calculate total size from image info
 	var totalImageSize int64
 	for _, img := range images {
-		totalImageSize += img.SizeMB * (1024 * 1024)
+		totalImageSize += img.Size
 	}
 	output.Images = images
 

--- a/cmd/moat/cli/status.go
+++ b/cmd/moat/cli/status.go
@@ -247,14 +247,14 @@ func showStatus(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("%s: %d\n", ui.Bold("Active Runs"), len(activeRuns))
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintln(w, "  NAME\tRUN ID\tAGE\tDISK\tENDPOINTS")
+		fmt.Fprintln(w, "  NAME\tRUN ID\tRUNTIME\tAGE\tDISK\tENDPOINTS")
 		for _, r := range output.ActiveRuns {
 			diskStr := fmt.Sprintf("%d MB", r.DiskMB)
 			if r.DiskMB < 0 {
 				diskStr = "?"
 			}
-			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
-				r.Name, r.ID, r.Age, diskStr, r.Endpoints)
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\t%s\n",
+				r.Name, r.ID, r.Runtime, r.Age, diskStr, r.Endpoints)
 		}
 		w.Flush()
 	}

--- a/cmd/moat/cli/system_containers.go
+++ b/cmd/moat/cli/system_containers.go
@@ -17,7 +17,7 @@ var systemContainersCmd = &cobra.Command{
 	Short: "List moat-managed containers",
 	Long: `List all containers created by moat.
 
-This is an escape hatch for debugging. Use 'agent status' for normal operations.
+This is an escape hatch for debugging. Use 'moat status' for normal operations.
 
 To remove a container, use the native container CLI:
   docker rm <container-id>

--- a/cmd/moat/cli/system_containers.go
+++ b/cmd/moat/cli/system_containers.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -31,43 +32,55 @@ func init() {
 func listSystemContainers(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// No sandbox needed for listing containers
-	rt, err := container.NewRuntimeWithOptions(container.RuntimeOptions{Sandbox: false})
+	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
 	if err != nil {
 		return fmt.Errorf("initializing runtime: %w", err)
 	}
-	defer rt.Close()
+	defer pool.Close()
 
-	containers, err := rt.ListContainers(ctx)
-	if err != nil {
-		return fmt.Errorf("listing containers: %w", err)
+	type runtimeContainer struct {
+		info   container.Info
+		rtType container.RuntimeType
 	}
+	var all []runtimeContainer
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		containers, err := rt.ListContainers(ctx)
+		if err != nil {
+			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
+			return nil
+		}
+		for _, c := range containers {
+			all = append(all, runtimeContainer{info: c, rtType: rt.Type()})
+		}
+		return nil
+	})
 
 	if jsonOut {
+		containers := make([]container.Info, len(all))
+		for i, rc := range all {
+			containers[i] = rc.info
+		}
 		return json.NewEncoder(os.Stdout).Encode(containers)
 	}
 
-	if len(containers) == 0 {
+	if len(all) == 0 {
 		fmt.Println("No moat containers found")
 		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "CONTAINER ID\tNAME\tSTATUS\tCREATED")
-	for _, c := range containers {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-			c.ID, c.Name, c.Status, formatAge(c.Created))
+	fmt.Fprintln(w, "CONTAINER ID\tNAME\tRUNTIME\tSTATUS\tCREATED")
+	for _, rc := range all {
+		c := rc.info
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			c.ID, c.Name, rc.rtType, c.Status, formatAge(c.Created))
 	}
 	w.Flush()
 
 	fmt.Println()
-	if rt.Type() == container.RuntimeDocker {
-		fmt.Println("To remove a container: docker rm <container-id>")
-		fmt.Println("To view logs: docker logs <container-id>")
-	} else {
-		fmt.Println("To remove a container: container rm <container-id>")
-		fmt.Println("To view logs: container logs <container-id>")
-	}
+	fmt.Println("To remove a container:")
+	fmt.Println("  docker rm <container-id>      (Docker)")
+	fmt.Println("  container rm <container-id>    (Apple)")
 
 	return nil
 }

--- a/cmd/moat/cli/system_containers.go
+++ b/cmd/moat/cli/system_containers.go
@@ -43,7 +43,7 @@ func listSystemContainers(cmd *cobra.Command, args []string) error {
 		rtType container.RuntimeType
 	}
 	var all []runtimeContainer
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		containers, err := rt.ListContainers(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
@@ -53,14 +53,20 @@ func listSystemContainers(cmd *cobra.Command, args []string) error {
 			all = append(all, runtimeContainer{info: c, rtType: rt.Type()})
 		}
 		return nil
-	})
+	}); err != nil {
+		ui.Warnf("Error scanning containers: %v", err)
+	}
 
 	if jsonOut {
-		containers := make([]container.Info, len(all))
-		for i, rc := range all {
-			containers[i] = rc.info
+		type containerJSON struct {
+			container.Info
+			Runtime string `json:"runtime"`
 		}
-		return json.NewEncoder(os.Stdout).Encode(containers)
+		out := make([]containerJSON, len(all))
+		for i, rc := range all {
+			out[i] = containerJSON{Info: rc.info, Runtime: string(rc.rtType)}
+		}
+		return json.NewEncoder(os.Stdout).Encode(out)
 	}
 
 	if len(all) == 0 {

--- a/cmd/moat/cli/system_containers.go
+++ b/cmd/moat/cli/system_containers.go
@@ -43,7 +43,7 @@ func listSystemContainers(cmd *cobra.Command, args []string) error {
 		rtType container.RuntimeType
 	}
 	var all []runtimeContainer
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		containers, err := rt.ListContainers(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)

--- a/cmd/moat/cli/system_images.go
+++ b/cmd/moat/cli/system_images.go
@@ -43,7 +43,7 @@ func listSystemImages(cmd *cobra.Command, args []string) error {
 		rtType container.RuntimeType
 	}
 	var all []runtimeImage
-	pool.ForEachAvailable(func(rt container.Runtime) error {
+	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
 		imgs, err := rt.ListImages(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)

--- a/cmd/moat/cli/system_images.go
+++ b/cmd/moat/cli/system_images.go
@@ -43,7 +43,7 @@ func listSystemImages(cmd *cobra.Command, args []string) error {
 		rtType container.RuntimeType
 	}
 	var all []runtimeImage
-	_ = pool.ForEachAvailable(func(rt container.Runtime) error {
+	if err := pool.ForEachAvailable(func(rt container.Runtime) error {
 		imgs, err := rt.ListImages(ctx)
 		if err != nil {
 			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
@@ -53,14 +53,20 @@ func listSystemImages(cmd *cobra.Command, args []string) error {
 			all = append(all, runtimeImage{image: img, rtType: rt.Type()})
 		}
 		return nil
-	})
+	}); err != nil {
+		ui.Warnf("Error scanning images: %v", err)
+	}
 
 	if jsonOut {
-		images := make([]container.ImageInfo, len(all))
-		for i, ri := range all {
-			images[i] = ri.image
+		type imageJSON struct {
+			container.ImageInfo
+			Runtime string `json:"runtime"`
 		}
-		return json.NewEncoder(os.Stdout).Encode(images)
+		out := make([]imageJSON, len(all))
+		for i, ri := range all {
+			out[i] = imageJSON{ImageInfo: ri.image, Runtime: string(ri.rtType)}
+		}
+		return json.NewEncoder(os.Stdout).Encode(out)
 	}
 
 	if len(all) == 0 {

--- a/cmd/moat/cli/system_images.go
+++ b/cmd/moat/cli/system_images.go
@@ -8,6 +8,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -31,45 +32,59 @@ func init() {
 func listSystemImages(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// No sandbox needed for listing images
-	rt, err := container.NewRuntimeWithOptions(container.RuntimeOptions{Sandbox: false})
+	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
 	if err != nil {
 		return fmt.Errorf("initializing runtime: %w", err)
 	}
-	defer rt.Close()
+	defer pool.Close()
 
-	images, err := rt.ListImages(ctx)
-	if err != nil {
-		return fmt.Errorf("listing images: %w", err)
+	type runtimeImage struct {
+		image  container.ImageInfo
+		rtType container.RuntimeType
 	}
+	var all []runtimeImage
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		imgs, err := rt.ListImages(ctx)
+		if err != nil {
+			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
+			return nil
+		}
+		for _, img := range imgs {
+			all = append(all, runtimeImage{image: img, rtType: rt.Type()})
+		}
+		return nil
+	})
 
 	if jsonOut {
+		images := make([]container.ImageInfo, len(all))
+		for i, ri := range all {
+			images[i] = ri.image
+		}
 		return json.NewEncoder(os.Stdout).Encode(images)
 	}
 
-	if len(images) == 0 {
+	if len(all) == 0 {
 		fmt.Println("No moat images found")
 		return nil
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "IMAGE ID\tTAG\tSIZE\tCREATED")
-	for _, img := range images {
+	fmt.Fprintln(w, "IMAGE ID\tTAG\tRUNTIME\tSIZE\tCREATED")
+	for _, ri := range all {
+		img := ri.image
 		id := img.ID
 		if len(id) > 12 {
 			id = id[:12]
 		}
-		fmt.Fprintf(w, "%s\t%s\t%d MB\t%s\n",
-			id, img.Tag, img.Size/(1024*1024), formatAge(img.Created))
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d MB\t%s\n",
+			id, img.Tag, ri.rtType, img.Size/(1024*1024), formatAge(img.Created))
 	}
 	w.Flush()
 
 	fmt.Println()
-	if rt.Type() == container.RuntimeDocker {
-		fmt.Println("To remove an image: docker rmi <image-id>")
-	} else {
-		fmt.Println("To remove an image: container image rm <image-id>")
-	}
+	fmt.Println("To remove an image:")
+	fmt.Println("  docker rmi <image-id>            (Docker)")
+	fmt.Println("  container image rm <image-id>    (Apple)")
 
 	return nil
 }

--- a/cmd/moat/cli/system_images.go
+++ b/cmd/moat/cli/system_images.go
@@ -17,7 +17,7 @@ var systemImagesCmd = &cobra.Command{
 	Short: "List moat-managed images",
 	Long: `List all container images created by moat.
 
-This is an escape hatch for debugging. Use 'agent status' for normal operations.
+This is an escape hatch for debugging. Use 'moat status' for normal operations.
 
 To remove an image, use the native container CLI:
   docker rmi <image-id>

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -985,8 +985,8 @@ With `--json`, emits a single object:
 | images | object[] | Cached container images |
 | images[].tag | string | Image tag |
 | images[].runtime | string | Container runtime |
-| images[].created | string | Human-readable age |
-| images[].size_mb | integer | Image size in MB |
+| images[].size | integer | Image size in bytes |
+| images[].created | string | RFC 3339 timestamp |
 | health | object[] | Health warnings |
 | health[].status | string | "ok" or "warning" |
 | health[].message | string | Description |
@@ -1384,6 +1384,18 @@ moat system images
 | SIZE | Image size in MB |
 | CREATED | Time since image was created |
 
+#### JSON output
+
+With `--json`, emits an array of objects:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Full image ID |
+| tag | string | Image tag |
+| size | integer | Image size in bytes |
+| created | string | RFC 3339 timestamp |
+| runtime | string | Container runtime (docker, apple) |
+
 ### moat system containers
 
 List moat containers across all available runtimes.
@@ -1401,6 +1413,19 @@ moat system containers
 | RUNTIME | Container runtime (docker, apple) |
 | STATUS | Container status (running, exited, etc.) |
 | CREATED | Time since container was created |
+
+#### JSON output
+
+With `--json`, emits an array of objects:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Container ID |
+| name | string | Container name |
+| image | string | Image name |
+| status | string | Container status (running, exited, created) |
+| created | string | RFC 3339 timestamp |
+| runtime | string | Container runtime (docker, apple) |
 
 ### moat system clean-temp
 

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -956,6 +956,42 @@ moat status
 - **Summary**: Counts and disk usage for stopped runs and cached images
 - **Health**: Warnings about stopped runs and orphaned containers
 
+### Active Runs columns
+
+| Column | Description |
+|--------|-------------|
+| NAME | Run name |
+| RUN ID | Unique run identifier |
+| RUNTIME | Container runtime (docker or apple) |
+| AGE | Time since run was created |
+| DISK | Disk usage in MB |
+| ENDPOINTS | Exposed services (from ports) |
+
+### JSON output
+
+With `--json`, emits a single object:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| runtimes | string[] | Available container runtimes |
+| active_runs | object[] | Currently active runs |
+| active_runs[].name | string | Run name |
+| active_runs[].id | string | Run ID |
+| active_runs[].runtime | string | Container runtime |
+| active_runs[].state | string | Run state |
+| active_runs[].age | string | Human-readable age |
+| active_runs[].disk_mb | integer | Disk usage in MB (-1 if unknown) |
+| active_runs[].endpoints | string | Comma-separated endpoint names |
+| images | object[] | Cached container images |
+| images[].tag | string | Image tag |
+| images[].runtime | string | Container runtime |
+| images[].created | string | Human-readable age |
+| images[].size_mb | integer | Image size in MB |
+| health | object[] | Health warnings |
+| health[].status | string | "ok" or "warning" |
+| health[].message | string | Description |
+| total_disk_bytes | integer | Total disk usage in bytes |
+
 For detailed information about all runs, use `moat list`.
 For image details, use `moat system images`
 

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -977,7 +977,7 @@ With `--json`, emits a single object:
 | active_runs | object[] | Currently active runs |
 | active_runs[].name | string | Run name |
 | active_runs[].id | string | Run ID |
-| active_runs[].runtime | string | Container runtime |
+| active_runs[].runtime | string | Container runtime (empty for legacy runs) |
 | active_runs[].state | string | Run state |
 | active_runs[].age | string | Human-readable age |
 | active_runs[].disk_mb | integer | Disk usage in MB (-1 if unknown) |

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -931,6 +931,7 @@ moat list
 |--------|-------------|
 | NAME | Run name |
 | RUN ID | Unique identifier |
+| RUNTIME | Container runtime (docker, apple) |
 | STATE | running, stopped, failed |
 | AGE | Time since run was created |
 | WORKTREE | Branch name (appears when any run has a worktree) |
@@ -950,7 +951,7 @@ moat status
 
 ### Output sections
 
-- **Runtime**: Docker or Apple containers
+- **Runtime**: Available container runtimes (shows all available, e.g., "docker, apple")
 - **Active Runs**: Currently running containers with age, disk usage, and endpoints
 - **Summary**: Counts and disk usage for stopped runs and cached images
 - **Health**: Warnings about stopped runs and orphaned containers
@@ -1331,19 +1332,39 @@ Low-level system commands.
 
 ### moat system images
 
-List moat-managed container images.
+List moat-managed container images across all available runtimes.
 
 ```
 moat system images
 ```
 
+#### Output columns
+
+| Column | Description |
+|--------|-------------|
+| IMAGE ID | Short image identifier |
+| TAG | Image tag |
+| RUNTIME | Container runtime (docker, apple) |
+| SIZE | Image size in MB |
+| CREATED | Time since image was created |
+
 ### moat system containers
 
-List moat containers.
+List moat containers across all available runtimes.
 
 ```
 moat system containers
 ```
+
+#### Output columns
+
+| Column | Description |
+|--------|-------------|
+| CONTAINER ID | Container identifier |
+| NAME | Container name |
+| RUNTIME | Container runtime (docker, apple) |
+| STATUS | Container status (running, exited, etc.) |
+| CREATED | Time since container was created |
 
 ### moat system clean-temp
 

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -981,7 +981,7 @@ With `--json`, emits a single object:
 | active_runs[].state | string | Run state |
 | active_runs[].age | string | Human-readable age |
 | active_runs[].disk_mb | integer | Disk usage in MB (-1 if unknown) |
-| active_runs[].endpoints | string | Comma-separated endpoint names |
+| active_runs[].endpoints | string | Comma-separated endpoint names (omitted when empty) |
 | images | object[] | Cached container images |
 | images[].tag | string | Image tag |
 | images[].runtime | string | Container runtime |

--- a/docs/plans/2026-04-11-multi-runtime-manager-plan.md
+++ b/docs/plans/2026-04-11-multi-runtime-manager-plan.md
@@ -1,0 +1,1470 @@
+# Multi-Runtime Manager Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make all moat CLI commands (status, stop, destroy, exec, clean, etc.) work correctly when runs exist across both Docker and Apple container runtimes on the same machine.
+
+**Architecture:** Replace the single `container.Runtime` in `Manager` with a `RuntimePool` that lazily initializes runtimes by type. Each run records which runtime created it (already done in PR #309). Operations on existing runs resolve the correct runtime from the pool via `Run.Runtime`. New run creation uses the auto-detected default runtime. Commands that query infrastructure directly (`moat status`, `moat clean`, `moat system images/containers`) query all available runtimes and merge results.
+
+**Tech Stack:** Go, Docker SDK, Apple `container` CLI
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `internal/container/pool.go` (new) | `RuntimePool` — manages multiple runtime instances, lazily initialized, keyed by `RuntimeType`. Thread-safe. Single source of truth for "give me a runtime for this type." |
+| `internal/container/pool_test.go` (new) | Tests for `RuntimePool` |
+| `internal/container/detect.go` (modify) | Add `NewRuntimeByType(RuntimeType, RuntimeOptions) (Runtime, error)` factory |
+| `internal/container/runtime.go` (modify) | Add `AllRuntimeTypes()` helper |
+| `internal/run/manager.go` (modify) | Replace `runtime container.Runtime` with `runtimePool *container.RuntimePool`. Add `runtimeForRun(r *Run)` helper. Update all `m.runtime.X()` call sites. |
+| `internal/run/manager_test.go` (modify) | Update `stubRuntime` and tests to work with pool |
+| `cmd/moat/cli/status.go` (modify) | Query all available runtimes for images/containers |
+| `cmd/moat/cli/clean.go` (modify) | Query all available runtimes for images/containers/networks |
+| `cmd/moat/cli/system_containers.go` (modify) | Query all available runtimes |
+| `cmd/moat/cli/system_images.go` (modify) | Query all available runtimes |
+
+---
+
+### Task 1: RuntimePool — the multi-runtime abstraction
+
+The core new type. A thread-safe pool that holds at most one runtime per `RuntimeType`, lazily initialized on first access. This replaces all direct `container.NewRuntime()` calls with a single shared pool.
+
+**Files:**
+- Create: `internal/container/pool.go`
+- Create: `internal/container/pool_test.go`
+- Modify: `internal/container/detect.go`
+- Modify: `internal/container/runtime.go`
+
+- [ ] **Step 1: Add `AllRuntimeTypes()` to `runtime.go`**
+
+Add after the `RuntimeApple` constant block in `internal/container/runtime.go`:
+
+```go
+// AllRuntimeTypes returns all known runtime types.
+func AllRuntimeTypes() []RuntimeType {
+	return []RuntimeType{RuntimeDocker, RuntimeApple}
+}
+```
+
+- [ ] **Step 2: Add `NewRuntimeByType` factory to `detect.go`**
+
+Add at the end of `internal/container/detect.go`:
+
+```go
+// NewRuntimeByType creates a runtime of the specified type.
+// Returns an error if the runtime is not available on this system.
+func NewRuntimeByType(rt RuntimeType, opts RuntimeOptions) (Runtime, error) {
+	switch rt {
+	case RuntimeDocker:
+		return newDockerRuntimeWithPing(opts.Sandbox)
+	case RuntimeApple:
+		r, reason := tryAppleRuntime()
+		if r != nil {
+			return r, nil
+		}
+		return nil, fmt.Errorf("Apple container runtime not available: %s", reason)
+	default:
+		return nil, fmt.Errorf("unknown runtime type: %q", rt)
+	}
+}
+```
+
+- [ ] **Step 3: Run existing tests to verify no breakage**
+
+Run: `go test ./internal/container/... -count=1`
+Expected: PASS (new functions are additive)
+
+- [ ] **Step 4: Write failing test for `RuntimePool`**
+
+Create `internal/container/pool_test.go`:
+
+```go
+package container
+
+import (
+	"testing"
+)
+
+func TestRuntimePoolGetDefault(t *testing.T) {
+	pool, err := NewRuntimePool(RuntimeOptions{Sandbox: false})
+	if err != nil {
+		t.Fatalf("NewRuntimePool: %v", err)
+	}
+	defer pool.Close()
+
+	// Default runtime should be available
+	rt := pool.Default()
+	if rt == nil {
+		t.Fatal("Default() returned nil")
+	}
+	if rt.Type() != RuntimeDocker && rt.Type() != RuntimeApple {
+		t.Fatalf("unexpected default runtime type: %s", rt.Type())
+	}
+}
+
+func TestRuntimePoolGet(t *testing.T) {
+	pool, err := NewRuntimePool(RuntimeOptions{Sandbox: false})
+	if err != nil {
+		t.Fatalf("NewRuntimePool: %v", err)
+	}
+	defer pool.Close()
+
+	defaultType := pool.Default().Type()
+
+	// Getting the default type should return the same instance
+	rt, err := pool.Get(defaultType)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", defaultType, err)
+	}
+	if rt != pool.Default() {
+		t.Fatal("Get(default type) returned different instance than Default()")
+	}
+}
+
+func TestRuntimePoolGetUnknownType(t *testing.T) {
+	pool, err := NewRuntimePool(RuntimeOptions{Sandbox: false})
+	if err != nil {
+		t.Fatalf("NewRuntimePool: %v", err)
+	}
+	defer pool.Close()
+
+	_, err = pool.Get("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown runtime type")
+	}
+}
+
+func TestRuntimePoolAvailable(t *testing.T) {
+	pool, err := NewRuntimePool(RuntimeOptions{Sandbox: false})
+	if err != nil {
+		t.Fatalf("NewRuntimePool: %v", err)
+	}
+	defer pool.Close()
+
+	runtimes := pool.Available()
+	if len(runtimes) == 0 {
+		t.Fatal("Available() returned empty list")
+	}
+
+	// The default runtime must be in the available list
+	found := false
+	for _, rt := range runtimes {
+		if rt.Type() == pool.Default().Type() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("default runtime not in Available() list")
+	}
+}
+
+func TestRuntimePoolCloseIdempotent(t *testing.T) {
+	pool, err := NewRuntimePool(RuntimeOptions{Sandbox: false})
+	if err != nil {
+		t.Fatalf("NewRuntimePool: %v", err)
+	}
+
+	if err := pool.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}
+```
+
+- [ ] **Step 5: Run test to verify it fails**
+
+Run: `go test ./internal/container/ -run TestRuntimePool -count=1`
+Expected: FAIL — `NewRuntimePool` doesn't exist
+
+- [ ] **Step 6: Implement `RuntimePool`**
+
+Create `internal/container/pool.go`:
+
+```go
+package container
+
+import (
+	"fmt"
+	"sync"
+)
+
+// RuntimePool manages multiple container runtime instances, keyed by RuntimeType.
+// It lazily initializes runtimes on first access and provides a default runtime
+// for new run creation. Thread-safe for concurrent access.
+type RuntimePool struct {
+	mu       sync.Mutex
+	runtimes map[RuntimeType]Runtime
+	dflt     Runtime
+	opts     RuntimeOptions
+	closed   bool
+}
+
+// NewRuntimePool creates a pool with the auto-detected default runtime.
+// The default runtime is initialized immediately; other runtimes are
+// created lazily when first requested via Get().
+func NewRuntimePool(opts RuntimeOptions) (*RuntimePool, error) {
+	rt, err := NewRuntimeWithOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := &RuntimePool{
+		runtimes: map[RuntimeType]Runtime{rt.Type(): rt},
+		dflt:     rt,
+		opts:     opts,
+	}
+	return pool, nil
+}
+
+// NewRuntimePoolWithDefault creates a pool with a pre-existing runtime as default.
+// Used in tests to inject a stub runtime.
+func NewRuntimePoolWithDefault(rt Runtime) *RuntimePool {
+	return &RuntimePool{
+		runtimes: map[RuntimeType]Runtime{rt.Type(): rt},
+		dflt:     rt,
+	}
+}
+
+// Default returns the auto-detected default runtime.
+// Used for creating new runs.
+func (p *RuntimePool) Default() Runtime {
+	return p.dflt
+}
+
+// Get returns the runtime for the given type, lazily initializing it if needed.
+// Returns the default runtime if typ is empty (legacy runs without a runtime field).
+func (p *RuntimePool) Get(typ RuntimeType) (Runtime, error) {
+	if typ == "" {
+		return p.dflt, nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("runtime pool is closed")
+	}
+
+	if rt, ok := p.runtimes[typ]; ok {
+		return rt, nil
+	}
+
+	rt, err := NewRuntimeByType(typ, p.opts)
+	if err != nil {
+		return nil, fmt.Errorf("runtime %s not available: %w", typ, err)
+	}
+
+	p.runtimes[typ] = rt
+	return rt, nil
+}
+
+// Available returns all runtimes that are currently initialized in the pool.
+// Does not probe for new runtimes — only returns what has been lazily created
+// via Get() or the default from construction.
+func (p *RuntimePool) Available() []Runtime {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	rts := make([]Runtime, 0, len(p.runtimes))
+	for _, rt := range p.runtimes {
+		rts = append(rts, rt)
+	}
+	return rts
+}
+
+// ForEachAvailable calls fn for each runtime type, initializing it if possible.
+// Errors from unavailable runtimes are silently skipped — fn is only called
+// for runtimes that can be successfully initialized.
+// Used by status/clean commands that need to query all runtimes.
+func (p *RuntimePool) ForEachAvailable(fn func(Runtime) error) error {
+	for _, typ := range AllRuntimeTypes() {
+		rt, err := p.Get(typ)
+		if err != nil {
+			continue // Runtime not available on this system
+		}
+		if err := fn(rt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close closes all runtimes in the pool.
+func (p *RuntimePool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	var firstErr error
+	for _, rt := range p.runtimes {
+		if err := rt.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `go test ./internal/container/ -run TestRuntimePool -count=1`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/container/pool.go internal/container/pool_test.go internal/container/detect.go internal/container/runtime.go
+git commit -m "feat(container): add RuntimePool for multi-runtime support
+
+Introduces RuntimePool, a thread-safe pool that manages multiple container
+runtime instances keyed by RuntimeType. Runtimes are lazily initialized
+on first access. Includes NewRuntimeByType factory and ForEachAvailable
+for querying all available runtimes."
+```
+
+---
+
+### Task 2: Migrate Manager to RuntimePool
+
+Replace `m.runtime` with `m.runtimePool` and add a `runtimeForRun` helper. This is the core refactor — every `m.runtime.X()` call becomes either `m.runtimePool.Default().X()` (for new run creation) or uses the pool to resolve the correct runtime for an existing run.
+
+**Files:**
+- Modify: `internal/run/manager.go`
+
+- [ ] **Step 1: Change Manager struct and constructor**
+
+In `internal/run/manager.go`, replace the `runtime` field in the Manager struct (line 85):
+
+```go
+// Before:
+runtime        container.Runtime
+
+// After:
+runtimePool    *container.RuntimePool
+```
+
+Replace the constructor `NewManagerWithOptions` (lines 110-155). Change lines 120-123:
+
+```go
+// Before:
+rt, err := container.NewRuntimeWithOptions(runtimeOpts)
+if err != nil {
+    return nil, fmt.Errorf("initializing container runtime: %w", err)
+}
+
+// After:
+pool, err := container.NewRuntimePool(runtimeOpts)
+if err != nil {
+    return nil, fmt.Errorf("initializing container runtime: %w", err)
+}
+```
+
+Change line 137:
+
+```go
+// Before:
+runtime:        rt,
+
+// After:
+runtimePool:    pool,
+```
+
+- [ ] **Step 2: Add `runtimeForRun` helper**
+
+Add after the Manager struct definition (around line 100):
+
+```go
+// runtimeForRun returns the correct container runtime for an existing run.
+// It uses the run's Runtime field to look up the matching runtime from the pool.
+// For legacy runs without a Runtime field, falls back to the default runtime.
+func (m *Manager) runtimeForRun(r *Run) (container.Runtime, error) {
+	return m.runtimePool.Get(container.RuntimeType(r.Runtime))
+}
+```
+
+- [ ] **Step 3: Update `RuntimeType()` and `Close()` methods**
+
+Update `RuntimeType()` (line 3628):
+
+```go
+// Before:
+func (m *Manager) RuntimeType() string {
+    return string(m.runtime.Type())
+}
+
+// After:
+func (m *Manager) RuntimeType() string {
+    return string(m.runtimePool.Default().Type())
+}
+```
+
+Update `Close()` (line 3668):
+
+```go
+// Before:
+return m.runtime.Close()
+
+// After:
+return m.runtimePool.Close()
+```
+
+- [ ] **Step 4: Update `Create()` — use `runtimePool.Default()` for new runs**
+
+In the `Create()` method, replace all `m.runtime.` calls with `m.runtimePool.Default().` since `Create` always uses the default runtime for new runs. These are on lines:
+
+- 875, 1115, 1131, 1224, 1235, 1363, 1548, 1554, 1557, 1575, 1621, 1624, 1653, 1765
+- 2092, 2098, 2139, 2141, 2149, 2154, 2177, 2178, 2199, 2227, 2433, 2473, 2479
+- 2504, 2505, 2506, 2545, 2555, 2571, 2594
+
+Use a global find-and-replace within the `Create()` method body only. Replace:
+```
+m.runtime.
+```
+with:
+```
+m.runtimePool.Default().
+```
+
+Verify line 1548 still reads:
+```go
+r.Runtime = string(m.runtimePool.Default().Type())
+```
+
+- [ ] **Step 5: Update `Start()` and `StartAttached()` — use `runtimePool.Default()`**
+
+These methods are called on newly created runs, so they use the default runtime. Replace `m.runtime.` with `m.runtimePool.Default().` in:
+
+- `setupPortBindings()` (line 2718)
+- `setupFirewall()` (lines 2761, 2763)
+- `Start()` (line 2783)
+- `StartAttached()` (lines 2896, 2955)
+
+- [ ] **Step 6: Update `Stop()` — use `runtimeForRun()`**
+
+This is the first method that may operate on a cross-runtime run. Replace the `m.runtime.StopContainer()` call at line 3016:
+
+```go
+// Before:
+if err := m.runtime.StopContainer(ctx, r.ContainerID); err != nil {
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+}
+if err := rt.StopContainer(ctx, r.ContainerID); err != nil {
+```
+
+- [ ] **Step 7: Update `cleanupResources()` — use `runtimeForRun()`**
+
+This method calls many runtime methods for stopping services, removing containers, and removing networks. Resolve the runtime once at the top of the `cleanupOnce.Do` closure and use it throughout.
+
+At the start of the `cleanupOnce.Do` closure (around line 3213), add:
+
+```go
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    log.Debug("cleanup: cannot resolve runtime, skipping container cleanup", "run", r.ID, "error", rtErr)
+    // Still clean up non-container resources (proxy, SSH, routes, temp dirs) below
+}
+```
+
+Then replace all `m.runtime.` inside `cleanupResources` with `rt.`, guarding container operations with `if rt != nil`:
+
+```go
+// Service containers (line 3231)
+if rt != nil && len(r.ServiceContainers) > 0 {
+    svcMgr := rt.ServiceManager()
+    // ...
+}
+
+// BuildKit sidecar (line 3244)
+if rt != nil && r.BuildkitContainerID != "" {
+    // ...rt.StopContainer, rt.RemoveContainer...
+}
+
+// Main container (line 3255)
+if rt != nil && !r.KeepContainer {
+    if err := rt.RemoveContainer(ctx, r.ContainerID); err != nil {
+        // ...
+    }
+}
+
+// Network (line 3262)
+if rt != nil && r.NetworkID != "" {
+    netMgr := rt.NetworkManager()
+    // ...
+}
+```
+
+Non-container cleanup (proxy, SSH agent, routes, temp dirs, provider paths) stays unconditional — those don't need the container runtime.
+
+- [ ] **Step 8: Update `Exec()`, `ResizeTTY()`, `WriteClipboard()` — use `runtimeForRun()`**
+
+`Exec()` at line 3544:
+
+```go
+// Before:
+execErr := m.runtime.Exec(ctx, containerID, cmd, stdin, stdout, stderr)
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    return fmt.Errorf("resolving runtime: %w", rtErr)
+}
+execErr := rt.Exec(ctx, containerID, cmd, stdin, stdout, stderr)
+```
+
+Note: the `r` variable needs to be captured before `m.mu.RUnlock()`. It's already done — `r` is read at line 3530.
+
+`ResizeTTY()` at line 3494:
+
+```go
+// Before:
+return m.runtime.ResizeTTY(ctx, containerID, height, width)
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    return fmt.Errorf("resolving runtime: %w", rtErr)
+}
+return rt.ResizeTTY(ctx, containerID, height, width)
+```
+
+Note: need to keep `r` in scope — it's already available at line 3487.
+
+- [ ] **Step 9: Update `FollowLogs()` and `RecentLogs()` — use `runtimeForRun()`**
+
+`FollowLogs()` at line 3574:
+
+```go
+// Before:
+logs, err := m.runtime.ContainerLogs(ctx, containerID)
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    return fmt.Errorf("resolving runtime: %w", rtErr)
+}
+logs, err := rt.ContainerLogs(ctx, containerID)
+```
+
+`RecentLogs()` at line 3597:
+
+```go
+// Before:
+allLogs, err := m.runtime.ContainerLogsAll(context.Background(), containerID)
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    return "", fmt.Errorf("resolving runtime: %w", rtErr)
+}
+allLogs, err := rt.ContainerLogsAll(context.Background(), containerID)
+```
+
+- [ ] **Step 10: Update `captureLogs()` — use `runtimeForRun()`**
+
+At line 3101, change the Apple runtime type check:
+
+```go
+// Before:
+if r.Interactive && m.runtime.Type() == container.RuntimeApple {
+
+// After:
+if r.Interactive && container.RuntimeType(r.Runtime) == container.RuntimeApple {
+```
+
+At line 3130:
+
+```go
+// Before:
+allLogs, logErr := m.runtime.ContainerLogsAll(logCtx, r.ContainerID)
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    log.Debug("cannot resolve runtime for log capture", "run", r.ID, "error", rtErr)
+    return
+}
+allLogs, logErr := rt.ContainerLogsAll(logCtx, r.ContainerID)
+```
+
+- [ ] **Step 11: Update `monitorContainerExit()` — use `runtimeForRun()`**
+
+At line 3312:
+
+```go
+// Before:
+exitCode, err := m.runtime.WaitContainer(context.Background(), r.ContainerID)
+
+// After:
+rt, rtErr := m.runtimeForRun(r)
+if rtErr != nil {
+    log.Debug("cannot resolve runtime for container monitor", "run", r.ID, "error", rtErr)
+    r.SetStateFailedAt("runtime unavailable: "+rtErr.Error(), time.Now())
+    _ = r.SaveMetadata()
+    close(r.exitCh)
+    return
+}
+exitCode, err := rt.WaitContainer(context.Background(), r.ContainerID)
+```
+
+This also removes the need for the `crossRuntime` guard at line 400 in `registerPersistedRun`. Since `runtimeForRun` will resolve the correct runtime for any run, `monitorContainerExit` can now be spawned for all running containers regardless of runtime type:
+
+```go
+// Before (line 397-403):
+crossRuntime := meta.Runtime != "" && meta.Runtime != string(m.runtime.Type())
+if runState == StateRunning && !crossRuntime {
+    go m.monitorContainerExit(r)
+}
+
+// After:
+if runState == StateRunning {
+    m.monitorWg.Add(1)
+    go func() {
+        defer m.monitorWg.Done()
+        m.monitorContainerExit(r)
+    }()
+}
+```
+
+Wait — check the existing code at lines 401-403 to see if the `monitorWg.Add/Done` is already there or if it's handled inside `monitorContainerExit`. Read the full method to confirm.
+
+Looking at `registerPersistedRun` lines 397-403:
+
+```go
+crossRuntime := meta.Runtime != "" && meta.Runtime != string(m.runtime.Type())
+if runState == StateRunning && !crossRuntime {
+    m.monitorWg.Add(1)
+    go func() {
+        defer m.monitorWg.Done()
+        m.monitorContainerExit(r)
+    }()
+}
+```
+
+The `monitorWg` is handled at the call site. Remove the `crossRuntime` guard and keep the `monitorWg` wrapping:
+
+```go
+if runState == StateRunning {
+    m.monitorWg.Add(1)
+    go func() {
+        defer m.monitorWg.Done()
+        m.monitorContainerExit(r)
+    }()
+}
+```
+
+- [ ] **Step 12: Update `loadPersistedRuns()` — use pool for cross-runtime state checks**
+
+The cross-runtime skip at lines 242-250 is no longer needed. The pool will lazily initialize the correct runtime. Replace:
+
+```go
+// Before (lines 242-250):
+if info.meta.Runtime != "" && info.meta.Runtime != string(m.runtime.Type()) {
+    log.Debug("skipping cross-runtime container check, preserving persisted state", ...)
+    results[idx] = checkedRun{
+        info:              info,
+        runState:          State(info.meta.State),
+        serviceContainers: info.meta.ServiceContainers,
+    }
+    return
+}
+
+containerState, csErr := m.runtime.ContainerState(callCtx, info.meta.ContainerID)
+
+// After:
+rt, rtErr := m.runtimePool.Get(container.RuntimeType(info.meta.Runtime))
+if rtErr != nil {
+    log.Debug("runtime not available, preserving persisted state",
+        "id", info.runID, "runtime", info.meta.Runtime, "error", rtErr)
+    results[idx] = checkedRun{
+        info:              info,
+        runState:          State(info.meta.State),
+        serviceContainers: info.meta.ServiceContainers,
+    }
+    return
+}
+
+containerState, csErr := rt.ContainerState(callCtx, info.meta.ContainerID)
+```
+
+Similarly update the service container state check at line 292:
+
+```go
+// Before:
+if _, scErr := m.runtime.ContainerState(svcCtx, id); scErr == nil {
+
+// After:
+if _, scErr := rt.ContainerState(svcCtx, id); scErr == nil {
+```
+
+- [ ] **Step 13: Verify compilation**
+
+Run: `go build ./...`
+Expected: PASS
+
+- [ ] **Step 14: Run all unit tests**
+
+Run: `make test-unit`
+Expected: Some test failures in `manager_test.go` (tests use `stubRuntime` which needs updating — addressed in Task 3)
+
+- [ ] **Step 15: Commit**
+
+```bash
+git add internal/run/manager.go
+git commit -m "refactor(run): migrate Manager from single runtime to RuntimePool
+
+Replace m.runtime with m.runtimePool throughout Manager. Operations on
+existing runs use runtimeForRun() to resolve the correct runtime from
+the pool. New run creation uses runtimePool.Default().
+
+This enables cross-runtime stop, destroy, exec, logs, and cleanup —
+a Docker Manager can now operate on Apple container runs and vice versa.
+
+Removes the cross-runtime skip guard from loadPersistedRuns and the
+crossRuntime guard from monitorContainerExit, since the pool lazily
+initializes the correct runtime on demand."
+```
+
+---
+
+### Task 3: Update manager tests for RuntimePool
+
+The existing tests use `stubRuntime` and construct a Manager with a direct `runtime` field assignment. These need to use `NewRuntimePoolWithDefault(stub)` instead.
+
+**Files:**
+- Modify: `internal/run/manager_test.go`
+
+- [ ] **Step 1: Find all test setup patterns**
+
+Search for `m.runtime` or `runtime:` in `manager_test.go`. Every test that creates a Manager manually needs to change from:
+
+```go
+m := &Manager{
+    runtime: stub,
+    runs:    make(map[string]*Run),
+    // ...
+}
+```
+
+to:
+
+```go
+m := &Manager{
+    runtimePool: container.NewRuntimePoolWithDefault(stub),
+    runs:        make(map[string]*Run),
+    // ...
+}
+```
+
+- [ ] **Step 2: Update all Manager construction in tests**
+
+Replace every occurrence of `runtime: stub` (or `runtime: &stubRuntime{...}`) with `runtimePool: container.NewRuntimePoolWithDefault(stub)`.
+
+Add the import `"github.com/majorcontext/moat/internal/container"` if not already present.
+
+- [ ] **Step 3: Update `TestLoadPersistedRunsSkipsCrossRuntimeCheck`**
+
+This test verifies that a run created with a different runtime is handled correctly. With the pool, the behavior changes: instead of skipping the check entirely, the pool will try to initialize the other runtime and fail (since only the stub is available). The fallback behavior (preserve persisted state) is the same.
+
+The test should still pass as-is because `runtimePool.Get("docker")` when the stub is "apple" (or vice versa) will fail with "runtime not available", which triggers the same preserve-persisted-state path.
+
+Verify the test still sets `meta.Runtime` to a value different from the stub's `Type()` return value.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `make test-unit`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/run/manager_test.go
+git commit -m "test(run): update manager tests for RuntimePool
+
+Replace direct runtime field assignment with
+NewRuntimePoolWithDefault(stub) in all test Manager construction."
+```
+
+---
+
+### Task 4: Multi-runtime `moat status`
+
+The `status` command currently creates its own `container.Runtime` directly (not via Manager) to list images and containers. It needs to query all available runtimes.
+
+**Files:**
+- Modify: `cmd/moat/cli/status.go`
+
+- [ ] **Step 1: Replace single runtime with RuntimePool**
+
+In `showStatus()` (line 68), replace:
+
+```go
+// Before (lines 71-76):
+rt, err := container.NewRuntimeWithOptions(container.RuntimeOptions{Sandbox: false})
+if err != nil {
+    return fmt.Errorf("initializing runtime: %w", err)
+}
+defer rt.Close()
+
+// After:
+pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
+if err != nil {
+    return fmt.Errorf("initializing runtime: %w", err)
+}
+defer pool.Close()
+```
+
+- [ ] **Step 2: Query all runtimes for images**
+
+Replace lines 93-97:
+
+```go
+// Before:
+images, err := rt.ListImages(ctx)
+if err != nil {
+    return fmt.Errorf("listing images: %w", err)
+}
+
+// After:
+var images []container.ImageInfo
+pool.ForEachAvailable(func(rt container.Runtime) error {
+    rtImages, err := rt.ListImages(ctx)
+    if err != nil {
+        log.Debug("listing images failed", "runtime", rt.Type(), "error", err)
+        return nil // Continue to next runtime
+    }
+    images = append(images, rtImages...)
+    return nil
+})
+```
+
+- [ ] **Step 3: Query all runtimes for orphan container check**
+
+Replace lines 178-202:
+
+```go
+// Before:
+containers, err := rt.ListContainers(ctx)
+if err != nil {
+    // ...
+} else {
+    // orphan check
+}
+
+// After:
+var allContainers []container.Info
+pool.ForEachAvailable(func(rt container.Runtime) error {
+    cs, err := rt.ListContainers(ctx)
+    if err != nil {
+        output.Health = append(output.Health, healthItem{
+            Status:  "warning",
+            Message: fmt.Sprintf("Failed to list %s containers: %v", rt.Type(), err),
+        })
+        return nil
+    }
+    allContainers = append(allContainers, cs...)
+    return nil
+})
+if len(allContainers) > 0 {
+    knownRunIDs := make(map[string]bool)
+    for _, r := range runs {
+        knownRunIDs[r.ID] = true
+    }
+    orphanedCount := 0
+    for _, c := range allContainers {
+        if !knownRunIDs[c.Name] {
+            orphanedCount++
+        }
+    }
+    if orphanedCount > 0 {
+        output.Health = append(output.Health, healthItem{
+            Status:  "warning",
+            Message: fmt.Sprintf("%d orphaned containers", orphanedCount),
+        })
+    }
+}
+```
+
+- [ ] **Step 4: Update runtime display**
+
+Replace lines 124-126:
+
+```go
+// Before:
+output := statusOutput{
+    Runtime: string(rt.Type()),
+}
+
+// After:
+var runtimeNames []string
+pool.ForEachAvailable(func(rt container.Runtime) error {
+    runtimeNames = append(runtimeNames, string(rt.Type()))
+    return nil
+})
+output := statusOutput{
+    Runtime: strings.Join(runtimeNames, ", "),
+}
+```
+
+Add `"strings"` to the import block if not already present.
+
+- [ ] **Step 5: Verify compilation and test**
+
+Run: `go build ./cmd/moat/ && go vet ./cmd/moat/...`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/moat/cli/status.go
+git commit -m "feat(status): query all available runtimes for images and containers
+
+moat status now shows images, containers, and orphan checks across
+both Docker and Apple runtimes when both are available."
+```
+
+---
+
+### Task 5: Multi-runtime `moat clean`
+
+Same pattern as status — query all runtimes for images, containers, and networks.
+
+**Files:**
+- Modify: `cmd/moat/cli/clean.go`
+
+- [ ] **Step 1: Replace single runtime with RuntimePool**
+
+Replace lines 46-50:
+
+```go
+// Before:
+rt, err := container.NewRuntimeWithOptions(container.RuntimeOptions{Sandbox: false})
+if err != nil {
+    return fmt.Errorf("initializing runtime: %w", err)
+}
+defer rt.Close()
+
+// After:
+pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
+if err != nil {
+    return fmt.Errorf("initializing runtime: %w", err)
+}
+defer pool.Close()
+```
+
+- [ ] **Step 2: Query all runtimes for images**
+
+Replace lines 82-86 (image listing):
+
+```go
+// Before:
+images, err := rt.ListImages(ctx)
+if err != nil {
+    return fmt.Errorf("listing images: %w", err)
+}
+
+// After:
+type runtimeImage struct {
+    image container.ImageInfo
+    rt    container.Runtime
+}
+var allImages []runtimeImage
+pool.ForEachAvailable(func(rt container.Runtime) error {
+    imgs, err := rt.ListImages(ctx)
+    if err != nil {
+        ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
+        return nil
+    }
+    for _, img := range imgs {
+        allImages = append(allImages, runtimeImage{image: img, rt: rt})
+    }
+    return nil
+})
+// Rebuild the images slice for the existing code below
+images := make([]container.ImageInfo, len(allImages))
+for i, ri := range allImages {
+    images[i] = ri.image
+}
+```
+
+- [ ] **Step 3: Query all runtimes for container in-use check**
+
+Replace lines 97-113 (container listing for in-use check):
+
+```go
+// Before:
+containers, containerErr := rt.ListContainers(ctx)
+runningImages := make(map[string]bool)
+if containerErr == nil {
+    for _, c := range containers {
+        if c.Status == "running" {
+            runningImages[c.Image] = true
+            if id, ok := tagToID[c.Image]; ok {
+                runningImages[id] = true
+            }
+        }
+    }
+} else {
+    ui.Warnf("Failed to list containers: %v", containerErr)
+    ui.Info("Images will be skipped if running containers cannot be verified")
+}
+
+// After:
+runningImages := make(map[string]bool)
+var containerListFailed bool
+pool.ForEachAvailable(func(rt container.Runtime) error {
+    containers, err := rt.ListContainers(ctx)
+    if err != nil {
+        ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
+        containerListFailed = true
+        return nil
+    }
+    for _, c := range containers {
+        if c.Status == "running" {
+            runningImages[c.Image] = true
+            if id, ok := tagToID[c.Image]; ok {
+                runningImages[id] = true
+            }
+        }
+    }
+    return nil
+})
+if containerListFailed {
+    ui.Info("Images will be skipped if running containers cannot be verified")
+}
+```
+
+- [ ] **Step 4: Query all runtimes for orphaned networks**
+
+Replace lines 123-144:
+
+```go
+// Before:
+var orphanedNetworks []container.NetworkInfo
+netMgr := rt.NetworkManager()
+if netMgr != nil {
+    // ...
+}
+
+// After:
+type runtimeNetwork struct {
+    network container.NetworkInfo
+    rt      container.Runtime
+}
+var orphanedNetworks []runtimeNetwork
+pool.ForEachAvailable(func(rt container.Runtime) error {
+    netMgr := rt.NetworkManager()
+    if netMgr == nil {
+        return nil
+    }
+    allNetworks, netErr := netMgr.ListNetworks(ctx)
+    if netErr != nil {
+        ui.Warnf("Failed to list %s networks: %v", rt.Type(), netErr)
+        return nil
+    }
+    knownNetworkIDs := make(map[string]bool)
+    for _, r := range runs {
+        if r.NetworkID != "" {
+            knownNetworkIDs[r.NetworkID] = true
+        }
+    }
+    for _, n := range allNetworks {
+        if !knownNetworkIDs[n.ID] {
+            orphanedNetworks = append(orphanedNetworks, runtimeNetwork{network: n, rt: rt})
+        }
+    }
+    return nil
+})
+```
+
+- [ ] **Step 5: Update image removal to use correct runtime**
+
+Replace lines 258-275 (image removal loop) to use the tracked runtime:
+
+```go
+// Before:
+for _, img := range unusedImages {
+    // ...
+    if isImageInUse(ctx, rt, img.ID, img.Tag) {
+    // ...
+    if err := rt.RemoveImage(ctx, img.ID); err != nil {
+
+// After — use allImages with runtime tracking:
+for _, ri := range unusedRuntimeImages {
+    img := ri.image
+    fmt.Printf("Removing image %s... ", img.Tag)
+
+    if isImageInUse(ctx, ri.rt, img.ID, img.Tag) {
+        fmt.Println(ui.Yellow("skipped (now in use)"))
+        continue
+    }
+
+    if err := ri.rt.RemoveImage(ctx, img.ID); err != nil {
+```
+
+This requires building `unusedRuntimeImages` instead of `unusedImages` in the filtering step (lines 115-121):
+
+```go
+var unusedRuntimeImages []runtimeImage
+for _, ri := range allImages {
+    if !runningImages[ri.image.Tag] && !runningImages[ri.image.ID] {
+        unusedRuntimeImages = append(unusedRuntimeImages, ri)
+    }
+}
+// Keep unusedImages for display logic
+unusedImages := make([]container.ImageInfo, len(unusedRuntimeImages))
+for i, ri := range unusedRuntimeImages {
+    unusedImages[i] = ri.image
+}
+```
+
+- [ ] **Step 6: Update network removal to use correct runtime**
+
+Replace lines 278-289 (network removal loop):
+
+```go
+// Before:
+if netMgr != nil {
+    for _, n := range orphanedNetworks {
+        fmt.Printf("Removing network %s... ", n.Name)
+        if err := netMgr.ForceRemoveNetwork(ctx, n.ID); err != nil {
+
+// After:
+for _, rn := range orphanedNetworks {
+    fmt.Printf("Removing network %s... ", rn.network.Name)
+    netMgr := rn.rt.NetworkManager()
+    if netMgr == nil {
+        continue
+    }
+    if err := netMgr.ForceRemoveNetwork(ctx, rn.network.ID); err != nil {
+```
+
+- [ ] **Step 7: Update `isImageInUse` helper**
+
+The `isImageInUse` function at line 336 takes a single `rt`. To check across all runtimes, update it to accept the pool:
+
+Actually, looking more carefully, `isImageInUse` is a race-condition guard called per-image. It should check the runtime that owns the image, which is already passed as `ri.rt`. The existing function signature works — no change needed.
+
+- [ ] **Step 8: Update orphaned networks display and count**
+
+The display loop and count logic reference `orphanedNetworks` fields. Update:
+
+```go
+// Display (around line 194):
+if len(orphanedNetworks) > 0 {
+    fmt.Printf("%s (%d):\n", ui.Bold("Orphaned networks"), len(orphanedNetworks))
+    for _, rn := range orphanedNetworks {
+        fmt.Printf("  %s\n", rn.network.Name)
+    }
+    fmt.Println()
+}
+```
+
+- [ ] **Step 9: Verify compilation**
+
+Run: `go build ./cmd/moat/ && go vet ./cmd/moat/...`
+Expected: PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add cmd/moat/cli/clean.go
+git commit -m "feat(clean): query all available runtimes for images, containers, and networks
+
+moat clean now discovers and removes resources from both Docker and Apple
+runtimes. Each image and network tracks which runtime owns it so removal
+uses the correct runtime."
+```
+
+---
+
+### Task 6: Multi-runtime `moat system` commands
+
+These commands create their own `container.Runtime` directly. They need to query both runtimes.
+
+**Files:**
+- Modify: `cmd/moat/cli/system_containers.go`
+- Modify: `cmd/moat/cli/system_images.go`
+
+- [ ] **Step 1: Update `system_containers.go`**
+
+Replace the single runtime with a pool and merge container lists:
+
+```go
+func listSystemContainers(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
+	if err != nil {
+		return fmt.Errorf("initializing runtime: %w", err)
+	}
+	defer pool.Close()
+
+	type runtimeContainer struct {
+		info    container.Info
+		rtType  container.RuntimeType
+	}
+	var all []runtimeContainer
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		containers, err := rt.ListContainers(ctx)
+		if err != nil {
+			ui.Warnf("Failed to list %s containers: %v", rt.Type(), err)
+			return nil
+		}
+		for _, c := range containers {
+			all = append(all, runtimeContainer{info: c, rtType: rt.Type()})
+		}
+		return nil
+	})
+
+	if jsonOut {
+		// Flatten to plain container list for JSON
+		containers := make([]container.Info, len(all))
+		for i, rc := range all {
+			containers[i] = rc.info
+		}
+		return json.NewEncoder(os.Stdout).Encode(containers)
+	}
+
+	if len(all) == 0 {
+		fmt.Println("No moat containers found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "CONTAINER ID\tNAME\tRUNTIME\tSTATUS\tCREATED")
+	for _, rc := range all {
+		c := rc.info
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			c.ID, c.Name, rc.rtType, c.Status, formatAge(c.Created))
+	}
+	w.Flush()
+
+	fmt.Println()
+	fmt.Println("To remove a container:")
+	fmt.Println("  docker rm <container-id>     (Docker)")
+	fmt.Println("  container rm <container-id>   (Apple)")
+
+	return nil
+}
+```
+
+Add `"github.com/majorcontext/moat/internal/ui"` to imports.
+
+- [ ] **Step 2: Update `system_images.go`**
+
+Same pattern:
+
+```go
+func listSystemImages(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	pool, err := container.NewRuntimePool(container.RuntimeOptions{Sandbox: false})
+	if err != nil {
+		return fmt.Errorf("initializing runtime: %w", err)
+	}
+	defer pool.Close()
+
+	type runtimeImage struct {
+		image  container.ImageInfo
+		rtType container.RuntimeType
+	}
+	var all []runtimeImage
+	pool.ForEachAvailable(func(rt container.Runtime) error {
+		imgs, err := rt.ListImages(ctx)
+		if err != nil {
+			ui.Warnf("Failed to list %s images: %v", rt.Type(), err)
+			return nil
+		}
+		for _, img := range imgs {
+			all = append(all, runtimeImage{image: img, rtType: rt.Type()})
+		}
+		return nil
+	})
+
+	if jsonOut {
+		images := make([]container.ImageInfo, len(all))
+		for i, ri := range all {
+			images[i] = ri.image
+		}
+		return json.NewEncoder(os.Stdout).Encode(images)
+	}
+
+	if len(all) == 0 {
+		fmt.Println("No moat images found")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "IMAGE ID\tTAG\tRUNTIME\tSIZE\tCREATED")
+	for _, ri := range all {
+		img := ri.image
+		id := img.ID
+		if len(id) > 12 {
+			id = id[:12]
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d MB\t%s\n",
+			id, img.Tag, ri.rtType, img.Size/(1024*1024), formatAge(img.Created))
+	}
+	w.Flush()
+
+	fmt.Println()
+	fmt.Println("To remove an image:")
+	fmt.Println("  docker rmi <image-id>           (Docker)")
+	fmt.Println("  container image rm <image-id>   (Apple)")
+
+	return nil
+}
+```
+
+Add `"github.com/majorcontext/moat/internal/ui"` to imports.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `go build ./cmd/moat/ && go vet ./cmd/moat/...`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/moat/cli/system_containers.go cmd/moat/cli/system_images.go
+git commit -m "feat(system): show containers and images from all available runtimes
+
+moat system containers and moat system images now query both Docker and
+Apple runtimes. Output includes a RUNTIME column to identify which
+runtime owns each resource."
+```
+
+---
+
+### Task 7: Add RUNTIME column to `moat list`
+
+Now that runs track their runtime, display it in the list output so users can see which runtime each run uses.
+
+**Files:**
+- Modify: `cmd/moat/cli/list.go`
+
+- [ ] **Step 1: Add RUNTIME column**
+
+In `listRuns()`, add a RUNTIME column to the table headers and rows. Update the header (line 67-69):
+
+```go
+// Before:
+if hasWorktree {
+    fmt.Fprintln(w, "NAME\tRUN ID\tSTATE\tAGE\tWORKTREE\tENDPOINTS")
+} else {
+    fmt.Fprintln(w, "NAME\tRUN ID\tSTATE\tAGE\tENDPOINTS")
+}
+
+// After:
+if hasWorktree {
+    fmt.Fprintln(w, "NAME\tRUN ID\tRUNTIME\tSTATE\tAGE\tWORKTREE\tENDPOINTS")
+} else {
+    fmt.Fprintln(w, "NAME\tRUN ID\tRUNTIME\tSTATE\tAGE\tENDPOINTS")
+}
+```
+
+Update the row output (lines 81-102) to include `r.Runtime`:
+
+```go
+rtLabel := r.Runtime
+if rtLabel == "" {
+    rtLabel = "-"
+}
+if hasWorktree {
+    // ...
+    fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+        r.Name, r.ID, rtLabel, r.GetState(), formatAge(r.CreatedAt), wt, endpoints)
+} else {
+    fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+        r.Name, r.ID, rtLabel, r.GetState(), formatAge(r.CreatedAt), endpoints)
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `go build ./cmd/moat/ && go vet ./cmd/moat/...`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/moat/cli/list.go
+git commit -m "feat(list): show RUNTIME column in moat list output
+
+Displays which container runtime (docker/apple) each run uses,
+making it easy to identify cross-runtime runs."
+```
+
+---
+
+### Task 8: Final lint, test, and cleanup
+
+Run the full test suite and lint to catch any issues from the refactor.
+
+**Files:**
+- Possibly modify any files with lint issues
+
+- [ ] **Step 1: Run lint**
+
+Run: `make lint`
+Expected: PASS (fix any issues)
+
+- [ ] **Step 2: Run full unit test suite**
+
+Run: `make test-unit`
+Expected: PASS
+
+- [ ] **Step 3: Run go vet**
+
+Run: `go vet ./...`
+Expected: PASS
+
+- [ ] **Step 4: Check for any remaining `m.runtime.` references**
+
+Run: `grep -rn 'm\.runtime\.' internal/run/manager.go`
+Expected: No results (all replaced with `m.runtimePool` or `rt.`)
+
+- [ ] **Step 5: Check for any remaining `container.NewRuntimeWithOptions` in CLI commands**
+
+Run: `grep -rn 'container\.NewRuntimeWithOptions\|container\.NewRuntime()' cmd/moat/cli/`
+
+Expected: Only `doctor.go` and `exec.go` (which sets `MOAT_RUNTIME` env before Manager creation — this is correct behavior since the runtime flag should influence the default runtime).
+
+The `doctor.go` usage is a diagnostic tool that checks runtime availability — it intentionally probes a single runtime. This is fine as-is.
+
+- [ ] **Step 6: Final commit (if any lint fixes)**
+
+```bash
+git add -A
+git commit -m "fix: lint and vet fixes from multi-runtime refactor"
+```
+
+---
+
+## Summary of changes
+
+| Component | Before | After |
+|-----------|--------|-------|
+| `Manager.runtime` | Single `container.Runtime` | `*container.RuntimePool` with lazy init |
+| Cross-runtime ops | Silently fail or skip | Resolve correct runtime via `runtimeForRun()` |
+| `moat stop/destroy` | Wrong runtime → error | Correct runtime for each run |
+| `moat exec` | Wrong runtime → error | Correct runtime for each run |
+| `moat status` | Shows one runtime's images/containers | Merges all available runtimes |
+| `moat clean` | Cleans one runtime's resources | Cleans all available runtimes |
+| `moat system images/containers` | Lists one runtime | Lists all runtimes with RUNTIME column |
+| `moat list` | No runtime info | Shows RUNTIME column |
+| `loadPersistedRuns` | Skips cross-runtime checks | Uses pool to check with correct runtime |
+| `monitorContainerExit` | Skipped for cross-runtime runs | Runs for all runs via correct runtime |

--- a/internal/container/detect.go
+++ b/internal/container/detect.go
@@ -293,6 +293,23 @@ func startAppleContainerSystem() error {
 	return fmt.Errorf("system started but did not become ready within the allotted timeout")
 }
 
+// NewRuntimeByType creates a runtime of the specified type.
+// Returns an error if the runtime is not available on this system.
+func NewRuntimeByType(rt RuntimeType, opts RuntimeOptions) (Runtime, error) {
+	switch rt {
+	case RuntimeDocker:
+		return newDockerRuntimeWithPing(opts.Sandbox)
+	case RuntimeApple:
+		r, reason := tryAppleRuntime()
+		if r != nil {
+			return r, nil
+		}
+		return nil, fmt.Errorf("Apple container runtime not available: %s", reason)
+	default:
+		return nil, fmt.Errorf("unknown runtime type: %q", rt)
+	}
+}
+
 // appleContainerAvailable checks if Apple's container CLI is installed.
 // Requires macOS 26+ with the containerization framework.
 func appleContainerAvailable() bool {

--- a/internal/container/pool.go
+++ b/internal/container/pool.go
@@ -9,11 +9,12 @@ import (
 // It lazily initializes runtimes on first access and provides a default runtime
 // for new run creation. Thread-safe for concurrent access.
 type RuntimePool struct {
-	mu        sync.Mutex
-	runtimes  map[RuntimeType]Runtime
-	defaultRT Runtime
-	opts      RuntimeOptions
-	closed    bool
+	mu          sync.Mutex
+	runtimes    map[RuntimeType]Runtime
+	unavailable map[RuntimeType]struct{} // runtimes that failed initialization
+	defaultRT   Runtime
+	opts        RuntimeOptions
+	closed      bool
 }
 
 // NewRuntimePool creates a pool with the auto-detected default runtime.
@@ -72,8 +73,16 @@ func (p *RuntimePool) Get(typ RuntimeType) (Runtime, error) {
 		return rt, nil
 	}
 
+	if _, failed := p.unavailable[typ]; failed {
+		return nil, fmt.Errorf("runtime %s not available", typ)
+	}
+
 	rt, err := NewRuntimeByType(typ, p.opts)
 	if err != nil {
+		if p.unavailable == nil {
+			p.unavailable = make(map[RuntimeType]struct{})
+		}
+		p.unavailable[typ] = struct{}{}
 		return nil, fmt.Errorf("runtime %s not available: %w", typ, err)
 	}
 

--- a/internal/container/pool.go
+++ b/internal/container/pool.go
@@ -101,7 +101,7 @@ func (p *RuntimePool) ForEachAvailable(fn func(Runtime) error) error {
 	for _, typ := range AllRuntimeTypes() {
 		rt, err := p.Get(typ)
 		if err != nil {
-			continue // Runtime not available on this system
+			continue // Runtime not available (or pool closed)
 		}
 		if err := fn(rt); err != nil {
 			return err

--- a/internal/container/pool.go
+++ b/internal/container/pool.go
@@ -1,0 +1,126 @@
+package container
+
+import (
+	"fmt"
+	"sync"
+)
+
+// RuntimePool manages multiple container runtime instances, keyed by RuntimeType.
+// It lazily initializes runtimes on first access and provides a default runtime
+// for new run creation. Thread-safe for concurrent access.
+type RuntimePool struct {
+	mu       sync.Mutex
+	runtimes map[RuntimeType]Runtime
+	dflt     Runtime
+	opts     RuntimeOptions
+	closed   bool
+}
+
+// NewRuntimePool creates a pool with the auto-detected default runtime.
+// The default runtime is initialized immediately; other runtimes are
+// created lazily when first requested via Get().
+func NewRuntimePool(opts RuntimeOptions) (*RuntimePool, error) {
+	rt, err := NewRuntimeWithOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	pool := &RuntimePool{
+		runtimes: map[RuntimeType]Runtime{rt.Type(): rt},
+		dflt:     rt,
+		opts:     opts,
+	}
+	return pool, nil
+}
+
+// NewRuntimePoolWithDefault creates a pool with a pre-existing runtime as default.
+// Used in tests to inject a stub runtime.
+func NewRuntimePoolWithDefault(rt Runtime) *RuntimePool {
+	return &RuntimePool{
+		runtimes: map[RuntimeType]Runtime{rt.Type(): rt},
+		dflt:     rt,
+	}
+}
+
+// Default returns the auto-detected default runtime.
+// Used for creating new runs.
+func (p *RuntimePool) Default() Runtime {
+	return p.dflt
+}
+
+// Get returns the runtime for the given type, lazily initializing it if needed.
+// Returns the default runtime if typ is empty (legacy runs without a runtime field).
+func (p *RuntimePool) Get(typ RuntimeType) (Runtime, error) {
+	if typ == "" {
+		return p.dflt, nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("runtime pool is closed")
+	}
+
+	if rt, ok := p.runtimes[typ]; ok {
+		return rt, nil
+	}
+
+	rt, err := NewRuntimeByType(typ, p.opts)
+	if err != nil {
+		return nil, fmt.Errorf("runtime %s not available: %w", typ, err)
+	}
+
+	p.runtimes[typ] = rt
+	return rt, nil
+}
+
+// Available returns all runtimes that are currently initialized in the pool.
+// Does not probe for new runtimes — only returns what has been lazily created
+// via Get() or the default from construction.
+func (p *RuntimePool) Available() []Runtime {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	rts := make([]Runtime, 0, len(p.runtimes))
+	for _, rt := range p.runtimes {
+		rts = append(rts, rt)
+	}
+	return rts
+}
+
+// ForEachAvailable calls fn for each runtime type, initializing it if possible.
+// Errors from unavailable runtimes are silently skipped — fn is only called
+// for runtimes that can be successfully initialized.
+// Used by status/clean commands that need to query all runtimes.
+func (p *RuntimePool) ForEachAvailable(fn func(Runtime) error) error {
+	for _, typ := range AllRuntimeTypes() {
+		rt, err := p.Get(typ)
+		if err != nil {
+			continue // Runtime not available on this system
+		}
+		if err := fn(rt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Close closes all runtimes in the pool.
+func (p *RuntimePool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	var firstErr error
+	for _, rt := range p.runtimes {
+		if err := rt.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}

--- a/internal/container/pool.go
+++ b/internal/container/pool.go
@@ -9,11 +9,11 @@ import (
 // It lazily initializes runtimes on first access and provides a default runtime
 // for new run creation. Thread-safe for concurrent access.
 type RuntimePool struct {
-	mu       sync.Mutex
-	runtimes map[RuntimeType]Runtime
-	dflt     Runtime
-	opts     RuntimeOptions
-	closed   bool
+	mu        sync.Mutex
+	runtimes  map[RuntimeType]Runtime
+	defaultRT Runtime
+	opts      RuntimeOptions
+	closed    bool
 }
 
 // NewRuntimePool creates a pool with the auto-detected default runtime.
@@ -26,9 +26,9 @@ func NewRuntimePool(opts RuntimeOptions) (*RuntimePool, error) {
 	}
 
 	pool := &RuntimePool{
-		runtimes: map[RuntimeType]Runtime{rt.Type(): rt},
-		dflt:     rt,
-		opts:     opts,
+		runtimes:  map[RuntimeType]Runtime{rt.Type(): rt},
+		defaultRT: rt,
+		opts:      opts,
 	}
 	return pool, nil
 }
@@ -37,29 +37,35 @@ func NewRuntimePool(opts RuntimeOptions) (*RuntimePool, error) {
 // Used in tests to inject a stub runtime.
 func NewRuntimePoolWithDefault(rt Runtime) *RuntimePool {
 	return &RuntimePool{
-		runtimes: map[RuntimeType]Runtime{rt.Type(): rt},
-		dflt:     rt,
+		runtimes:  map[RuntimeType]Runtime{rt.Type(): rt},
+		defaultRT: rt,
 	}
 }
 
 // Default returns the auto-detected default runtime.
-// Used for creating new runs.
-func (p *RuntimePool) Default() Runtime {
-	return p.dflt
-}
-
-// Get returns the runtime for the given type, lazily initializing it if needed.
-// Returns the default runtime if typ is empty (legacy runs without a runtime field).
-func (p *RuntimePool) Get(typ RuntimeType) (Runtime, error) {
-	if typ == "" {
-		return p.dflt, nil
-	}
-
+// Used for creating new runs. Returns an error if the pool has been closed.
+func (p *RuntimePool) Default() (Runtime, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if p.closed {
 		return nil, fmt.Errorf("runtime pool is closed")
+	}
+	return p.defaultRT, nil
+}
+
+// Get returns the runtime for the given type, lazily initializing it if needed.
+// Returns the default runtime if typ is empty (legacy runs without a runtime field).
+func (p *RuntimePool) Get(typ RuntimeType) (Runtime, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, fmt.Errorf("runtime pool is closed")
+	}
+
+	if typ == "" {
+		return p.defaultRT, nil
 	}
 
 	if rt, ok := p.runtimes[typ]; ok {
@@ -75,24 +81,13 @@ func (p *RuntimePool) Get(typ RuntimeType) (Runtime, error) {
 	return rt, nil
 }
 
-// Available returns all runtimes that are currently initialized in the pool.
-// Does not probe for new runtimes — only returns what has been lazily created
-// via Get() or the default from construction.
-func (p *RuntimePool) Available() []Runtime {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	rts := make([]Runtime, 0, len(p.runtimes))
-	for _, rt := range p.runtimes {
-		rts = append(rts, rt)
-	}
-	return rts
-}
-
-// ForEachAvailable calls fn for each runtime type, initializing it if possible.
-// Errors from unavailable runtimes are silently skipped — fn is only called
-// for runtimes that can be successfully initialized.
-// Used by status/clean commands that need to query all runtimes.
+// ForEachAvailable calls fn for each runtime type that can be successfully
+// initialized, skipping unavailable runtimes. Iteration is sequential —
+// fn is never called concurrently, so closures may safely append to
+// external slices without synchronization.
+//
+// Note: this lazily initializes runtimes as a side effect. Runtimes
+// initialized here will be closed when the pool is closed.
 func (p *RuntimePool) ForEachAvailable(fn func(Runtime) error) error {
 	for _, typ := range AllRuntimeTypes() {
 		rt, err := p.Get(typ)
@@ -106,7 +101,8 @@ func (p *RuntimePool) ForEachAvailable(fn func(Runtime) error) error {
 	return nil
 }
 
-// Close closes all runtimes in the pool.
+// Close closes all runtimes in the pool. After Close, Get and Default
+// return errors.
 func (p *RuntimePool) Close() error {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/container/pool_test.go
+++ b/internal/container/pool_test.go
@@ -1,6 +1,9 @@
 package container
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"testing"
 )
 
@@ -18,7 +21,10 @@ func TestRuntimePoolGetDefault(t *testing.T) {
 	pool := newTestPool(t)
 	defer pool.Close()
 
-	rt := pool.Default()
+	rt, err := pool.Default()
+	if err != nil {
+		t.Fatalf("Default(): %v", err)
+	}
 	if rt == nil {
 		t.Fatal("Default() returned nil")
 	}
@@ -31,13 +37,14 @@ func TestRuntimePoolGet(t *testing.T) {
 	pool := newTestPool(t)
 	defer pool.Close()
 
-	defaultType := pool.Default().Type()
+	dflt, _ := pool.Default()
+	defaultType := dflt.Type()
 
 	rt, err := pool.Get(defaultType)
 	if err != nil {
 		t.Fatalf("Get(%s): %v", defaultType, err)
 	}
-	if rt != pool.Default() {
+	if rt != dflt {
 		t.Fatal("Get(default type) returned different instance than Default()")
 	}
 }
@@ -52,27 +59,6 @@ func TestRuntimePoolGetUnknownType(t *testing.T) {
 	}
 }
 
-func TestRuntimePoolAvailable(t *testing.T) {
-	pool := newTestPool(t)
-	defer pool.Close()
-
-	runtimes := pool.Available()
-	if len(runtimes) == 0 {
-		t.Fatal("Available() returned empty list")
-	}
-
-	found := false
-	for _, rt := range runtimes {
-		if rt.Type() == pool.Default().Type() {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Fatal("default runtime not in Available() list")
-	}
-}
-
 func TestRuntimePoolCloseIdempotent(t *testing.T) {
 	pool := newTestPool(t)
 
@@ -81,5 +67,144 @@ func TestRuntimePoolCloseIdempotent(t *testing.T) {
 	}
 	if err := pool.Close(); err != nil {
 		t.Fatalf("second Close: %v", err)
+	}
+}
+
+// --- Stub-based tests (run without a real container runtime) ---
+
+// poolStubRuntime is a minimal Runtime implementation for pool-level tests.
+// It only implements Type() and Close(); other methods panic if called.
+type poolStubRuntime struct {
+	closed bool
+}
+
+func (s *poolStubRuntime) Type() RuntimeType          { return RuntimeDocker }
+func (s *poolStubRuntime) Close() error               { s.closed = true; return nil }
+func (s *poolStubRuntime) Ping(context.Context) error { panic("not implemented") }
+func (s *poolStubRuntime) CreateContainer(context.Context, Config) (string, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) StartContainer(context.Context, string) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) StopContainer(context.Context, string) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) WaitContainer(context.Context, string) (int64, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) RemoveContainer(context.Context, string) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) ContainerLogs(context.Context, string) (io.ReadCloser, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) ContainerLogsAll(context.Context, string) ([]byte, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) GetPortBindings(context.Context, string) (map[int]int, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) GetHostAddress() string         { panic("not implemented") }
+func (s *poolStubRuntime) SupportsHostNetwork() bool      { panic("not implemented") }
+func (s *poolStubRuntime) NetworkManager() NetworkManager { return nil }
+func (s *poolStubRuntime) SidecarManager() SidecarManager { return nil }
+func (s *poolStubRuntime) BuildManager() BuildManager     { return nil }
+func (s *poolStubRuntime) ServiceManager() ServiceManager { return nil }
+func (s *poolStubRuntime) SetupFirewall(context.Context, string, string, int) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) ListImages(context.Context) ([]ImageInfo, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) ListContainers(context.Context) ([]Info, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) ContainerState(context.Context, string) (string, error) {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) RemoveImage(context.Context, string) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) StartAttached(context.Context, string, AttachOptions) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) ResizeTTY(context.Context, string, uint, uint) error {
+	panic("not implemented")
+}
+func (s *poolStubRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
+	panic("not implemented")
+}
+
+func newStubPool() *RuntimePool {
+	return NewRuntimePoolWithDefault(&poolStubRuntime{})
+}
+
+func TestRuntimePoolGetAfterClose(t *testing.T) {
+	pool := newStubPool()
+	pool.Close()
+
+	// Default() should return error after Close
+	_, err := pool.Default()
+	if err == nil {
+		t.Fatal("expected error from Default() after Close()")
+	}
+
+	// Get("") should return error after Close (legacy run path)
+	_, err = pool.Get("")
+	if err == nil {
+		t.Fatal("expected error from Get(\"\") after Close()")
+	}
+
+	// Get(type) should return error after Close
+	_, err = pool.Get(RuntimeDocker)
+	if err == nil {
+		t.Fatal("expected error from Get(RuntimeDocker) after Close()")
+	}
+}
+
+func TestRuntimePoolGetEmptyReturnsDefault(t *testing.T) {
+	pool := newStubPool()
+	defer pool.Close()
+
+	dflt, _ := pool.Default()
+	rt, err := pool.Get("")
+	if err != nil {
+		t.Fatalf("Get(\"\"): %v", err)
+	}
+	if rt != dflt {
+		t.Fatal("Get(\"\") should return the default runtime")
+	}
+}
+
+func TestRuntimePoolForEachAvailable(t *testing.T) {
+	pool := newStubPool()
+	defer pool.Close()
+
+	var visited []RuntimeType
+	err := pool.ForEachAvailable(func(rt Runtime) error {
+		visited = append(visited, rt.Type())
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("ForEachAvailable: %v", err)
+	}
+
+	// Should have visited at least the default runtime (stub returns RuntimeDocker)
+	if len(visited) == 0 {
+		t.Fatal("ForEachAvailable visited no runtimes")
+	}
+}
+
+func TestRuntimePoolForEachAvailablePropagatesError(t *testing.T) {
+	pool := newStubPool()
+	defer pool.Close()
+
+	testErr := fmt.Errorf("test callback error")
+	err := pool.ForEachAvailable(func(rt Runtime) error {
+		return testErr
+	})
+	if err != testErr {
+		t.Fatalf("expected ForEachAvailable to propagate callback error, got: %v", err)
 	}
 }

--- a/internal/container/pool_test.go
+++ b/internal/container/pool_test.go
@@ -1,0 +1,85 @@
+package container
+
+import (
+	"testing"
+)
+
+// newTestPool creates a RuntimePool for testing, skipping if no runtime is available.
+func newTestPool(t *testing.T) *RuntimePool {
+	t.Helper()
+	pool, err := NewRuntimePool(RuntimeOptions{Sandbox: false})
+	if err != nil {
+		t.Skipf("no container runtime available: %v", err)
+	}
+	return pool
+}
+
+func TestRuntimePoolGetDefault(t *testing.T) {
+	pool := newTestPool(t)
+	defer pool.Close()
+
+	rt := pool.Default()
+	if rt == nil {
+		t.Fatal("Default() returned nil")
+	}
+	if rt.Type() != RuntimeDocker && rt.Type() != RuntimeApple {
+		t.Fatalf("unexpected default runtime type: %s", rt.Type())
+	}
+}
+
+func TestRuntimePoolGet(t *testing.T) {
+	pool := newTestPool(t)
+	defer pool.Close()
+
+	defaultType := pool.Default().Type()
+
+	rt, err := pool.Get(defaultType)
+	if err != nil {
+		t.Fatalf("Get(%s): %v", defaultType, err)
+	}
+	if rt != pool.Default() {
+		t.Fatal("Get(default type) returned different instance than Default()")
+	}
+}
+
+func TestRuntimePoolGetUnknownType(t *testing.T) {
+	pool := newTestPool(t)
+	defer pool.Close()
+
+	_, err := pool.Get("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown runtime type")
+	}
+}
+
+func TestRuntimePoolAvailable(t *testing.T) {
+	pool := newTestPool(t)
+	defer pool.Close()
+
+	runtimes := pool.Available()
+	if len(runtimes) == 0 {
+		t.Fatal("Available() returned empty list")
+	}
+
+	found := false
+	for _, rt := range runtimes {
+		if rt.Type() == pool.Default().Type() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("default runtime not in Available() list")
+	}
+}
+
+func TestRuntimePoolCloseIdempotent(t *testing.T) {
+	pool := newTestPool(t)
+
+	if err := pool.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := pool.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+}

--- a/internal/container/pool_test.go
+++ b/internal/container/pool_test.go
@@ -196,6 +196,32 @@ func TestRuntimePoolForEachAvailable(t *testing.T) {
 	}
 }
 
+func TestRuntimePoolUnavailableCached(t *testing.T) {
+	pool := newStubPool()
+	defer pool.Close()
+
+	// First call: "apple" is not in the stub pool, so Get will try
+	// NewRuntimeByType, fail, and populate unavailable.
+	_, err1 := pool.Get(RuntimeApple)
+	if err1 == nil {
+		t.Fatal("expected error for unavailable runtime")
+	}
+
+	// Verify the unavailable map was populated.
+	pool.mu.Lock()
+	_, cached := pool.unavailable[RuntimeApple]
+	pool.mu.Unlock()
+	if !cached {
+		t.Fatal("failed runtime should be cached in unavailable map")
+	}
+
+	// Second call should return from cache (different error message — no wrapped cause).
+	_, err2 := pool.Get(RuntimeApple)
+	if err2 == nil {
+		t.Fatal("expected error on second Get for unavailable runtime")
+	}
+}
+
 func TestRuntimePoolForEachAvailablePropagatesError(t *testing.T) {
 	pool := newStubPool()
 	defer pool.Close()

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -364,19 +364,19 @@ type TmpfsMount struct {
 
 // ImageInfo contains information about a container image.
 type ImageInfo struct {
-	ID      string
-	Tag     string
-	Size    int64
-	Created time.Time
+	ID      string    `json:"id"`
+	Tag     string    `json:"tag"`
+	Size    int64     `json:"size"`
+	Created time.Time `json:"created"`
 }
 
 // Info contains information about a container.
 type Info struct {
-	ID      string
-	Name    string
-	Image   string
-	Status  string // "running", "exited", "created"
-	Created time.Time
+	ID      string    `json:"id"`
+	Name    string    `json:"name"`
+	Image   string    `json:"image"`
+	Status  string    `json:"status"` // "running", "exited", "created"
+	Created time.Time `json:"created"`
 }
 
 // BuildOptions configures image building.

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -27,6 +27,11 @@ const (
 	RuntimeApple  RuntimeType = "apple"
 )
 
+// AllRuntimeTypes returns all known runtime types.
+func AllRuntimeTypes() []RuntimeType {
+	return []RuntimeType{RuntimeDocker, RuntimeApple}
+}
+
 // DefaultAgentMemoryMB is the default memory limit for AI agent containers
 // (Claude Code, Codex, Gemini CLI) on Apple containers. Apple's system default
 // of 1024 MB is too low for AI coding agents. Applied only when moat.yaml

--- a/internal/run/edge_cases_test.go
+++ b/internal/run/edge_cases_test.go
@@ -867,6 +867,7 @@ func TestCaptureLogsSkipsInteractiveApple(t *testing.T) {
 		ID:          "run_apple_interactive",
 		Name:        "apple-interactive",
 		ContainerID: "ctr-apple",
+		Runtime:     string(container.RuntimeApple),
 		State:       StateStopped,
 		Interactive: true,
 		Store:       store,

--- a/internal/run/edge_cases_test.go
+++ b/internal/run/edge_cases_test.go
@@ -140,9 +140,9 @@ func newEdgeCaseManager(t *testing.T, rt container.Runtime) *Manager {
 		t.Fatal(err)
 	}
 	return &Manager{
-		runtime: rt,
-		runs:    make(map[string]*Run),
-		routes:  routes,
+		runtimePool: container.NewRuntimePoolWithDefault(rt),
+		runs:        make(map[string]*Run),
+		routes:      routes,
 	}
 }
 

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -83,6 +83,7 @@ func getWorkspaceOwner(workspace string) (uid, gid int) {
 // Manager handles run lifecycle operations.
 type Manager struct {
 	runtimePool    *container.RuntimePool
+	runtimeType    string // Cached at init; safe to read after Close()
 	runs           map[string]*Run
 	routes         *routing.RouteTable
 	proxyLifecycle *routing.Lifecycle
@@ -104,6 +105,18 @@ type Manager struct {
 // For legacy runs without a Runtime field, falls back to the default runtime.
 func (m *Manager) runtimeForRun(r *Run) (container.Runtime, error) {
 	return m.runtimePool.Get(container.RuntimeType(r.Runtime))
+}
+
+// defaultRuntime returns the default runtime for new run creation.
+// This is only called during Create/Start/StartAttached flows where the pool
+// is guaranteed to be open. Panics if the pool is closed, indicating a
+// programming error (these methods must not be called after Close).
+func (m *Manager) defaultRuntime() container.Runtime {
+	rt, err := m.runtimePool.Default()
+	if err != nil {
+		panic("bug: runtime pool closed during active operation: " + err.Error())
+	}
+	return rt
 }
 
 // ManagerOptions configures the run manager.
@@ -136,12 +149,15 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 
 	lifecycle, err := routing.NewLifecycle(proxyDir, proxyPort)
 	if err != nil {
+		_ = pool.Close()
 		return nil, fmt.Errorf("initializing proxy lifecycle: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defaultRT, _ := pool.Default()
 	m := &Manager{
 		runtimePool:    pool,
+		runtimeType:    string(defaultRT.Type()),
 		runs:           make(map[string]*Run),
 		routes:         lifecycle.Routes(),
 		proxyLifecycle: lifecycle,
@@ -272,9 +288,12 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 					// Preserve both run state and service containers from
 					// persisted metadata — if the runtime is unavailable,
 					// service container checks would also fail.
+					// Skip monitor: spawning one would also fail (same runtime issue)
+					// and incorrectly mark the run as failed.
 					results[idx] = checkedRun{
 						info:              info,
 						runState:          State(info.meta.State),
+						skipMonitor:       true,
 						serviceContainers: info.meta.ServiceContainers,
 					}
 					return
@@ -884,7 +903,7 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 
 		// Get proxy host address — needed for registration, proxy URL, and firewall.
 		// Must be set before buildRegisterRequest so HostGateway is included.
-		hostAddr = m.runtimePool.Default().GetHostAddress()
+		hostAddr = m.defaultRuntime().GetHostAddress()
 		runCtx.HostGateway = hostAddr
 
 		// Build RegisterRequest from the RunContext
@@ -1124,7 +1143,7 @@ region = %s
 		// For these cases, we use TCP instead: the host listens on TCP and the
 		// container's moat-init script uses socat to bridge TCP to a local Unix socket.
 		// For Docker on Linux, Unix sockets work fine via direct bind mounts.
-		usesTCP := !m.runtimePool.Default().SupportsHostNetwork()
+		usesTCP := !m.defaultRuntime().SupportsHostNetwork()
 
 		if usesTCP {
 			// Use TCP server - container will use socat to bridge.
@@ -1140,7 +1159,7 @@ region = %s
 			}
 
 			// Get the actual TCP address after binding.
-			// hostAddr is set earlier from m.runtimePool.Default().GetHostAddress() and may be
+			// hostAddr is set earlier from m.defaultRuntime().GetHostAddress() and may be
 			// rewritten later for custom networks (replaceHostInEnv).
 			tcpAddr := sshServer.TCPAddr()
 			containerSSHDir := "/run/moat/ssh"
@@ -1233,7 +1252,7 @@ region = %s
 	needsProxy := r.ProxyAuthToken != ""
 
 	if needsProxy || needsPorts {
-		if m.runtimePool.Default().SupportsHostNetwork() && !needsPorts {
+		if m.defaultRuntime().SupportsHostNetwork() && !needsPorts {
 			// Docker on Linux without ports: use host network so container can reach 127.0.0.1
 			networkMode = "host"
 		} else {
@@ -1244,7 +1263,7 @@ region = %s
 			// Desktop and Rancher Desktop resolve it via built-in DNS — adding
 			// host-gateway would override the correct IP with the bridge
 			// gateway (which is unreachable on Rancher Desktop).
-			if m.runtimePool.Default().Type() == container.RuntimeDocker && goruntime.GOOS == "linux" {
+			if m.defaultRuntime().Type() == container.RuntimeDocker && goruntime.GOOS == "linux" {
 				extraHosts = []string{"host.docker.internal:host-gateway"}
 			}
 		}
@@ -1372,7 +1391,7 @@ region = %s
 	// Resolve docker dependency if present
 	// This validates that Apple containers are not used with docker:host dependency,
 	// and returns the appropriate config for the mode (socket mount for host, privileged for dind).
-	dockerConfig, dockerErr := ResolveDockerDependency(depList, m.runtimePool.Default().Type())
+	dockerConfig, dockerErr := ResolveDockerDependency(depList, m.defaultRuntime().Type())
 	if dockerErr != nil {
 		cleanupDaemonRun()
 		cleanupSSH(sshServer)
@@ -1557,16 +1576,16 @@ region = %s
 		r.Agent = opts.Config.Agent
 	}
 	r.Image = containerImage
-	r.Runtime = string(m.runtimePool.Default().Type())
+	r.Runtime = string(m.defaultRuntime().Type())
 
 	needsCustomImage := imageSpec.NeedsCustomImage(hasDeps)
 
 	// Handle --rebuild: delete existing image to force fresh build
 	if opts.Rebuild && needsCustomImage {
-		exists, _ := m.runtimePool.Default().BuildManager().ImageExists(ctx, containerImage)
+		exists, _ := m.defaultRuntime().BuildManager().ImageExists(ctx, containerImage)
 		if exists {
 			fmt.Printf("Removing cached image %s...\n", containerImage)
-			if err := m.runtimePool.Default().RemoveImage(ctx, containerImage); err != nil {
+			if err := m.defaultRuntime().RemoveImage(ctx, containerImage); err != nil {
 				ui.Warnf("Failed to remove image: %v", err)
 			}
 		}
@@ -1584,7 +1603,7 @@ region = %s
 		}
 		generatedDockerfile = result.Dockerfile
 
-		exists, err := m.runtimePool.Default().BuildManager().ImageExists(ctx, containerImage)
+		exists, err := m.defaultRuntime().BuildManager().ImageExists(ctx, containerImage)
 		if err != nil {
 			cleanupDaemonRun()
 			return nil, fmt.Errorf("checking image: %w", err)
@@ -1630,10 +1649,10 @@ region = %s
 				buildOpts.DNS = opts.Config.Container.DNS
 			}
 
-			buildMgr := m.runtimePool.Default().BuildManager()
+			buildMgr := m.defaultRuntime().BuildManager()
 			if buildMgr == nil {
 				cleanupDaemonRun()
-				return nil, fmt.Errorf("cannot build image: runtime %s does not support building", m.runtimePool.Default().Type())
+				return nil, fmt.Errorf("cannot build image: runtime %s does not support building", m.defaultRuntime().Type())
 			}
 
 			// Merge pre-cloned marketplace files into build context.
@@ -1662,7 +1681,7 @@ region = %s
 	// - anthropic grant is configured (automatic Claude Code integration)
 	var containerHome string
 	if hostHome, err := os.UserHomeDir(); err == nil {
-		imageHome := m.runtimePool.Default().BuildManager().GetImageHomeDir(ctx, containerImage)
+		imageHome := m.defaultRuntime().BuildManager().GetImageHomeDir(ctx, containerImage)
 		containerHome = resolveContainerHome(needsCustomImage, imageHome)
 		if opts.Config != nil && opts.Config.ShouldSyncClaudeLogs() {
 			claudeDir := claude.WorkspaceToClaudeDir(opts.Workspace)
@@ -1774,7 +1793,7 @@ region = %s
 			// the container cannot reach directly.
 			mcpServers := make(map[string]provider.MCPServerConfig)
 			if opts.Config != nil && len(opts.Config.MCP) > 0 {
-				proxyAddr := fmt.Sprintf("%s:%d", m.runtimePool.Default().GetHostAddress(), r.ProxyPort)
+				proxyAddr := fmt.Sprintf("%s:%d", m.defaultRuntime().GetHostAddress(), r.ProxyPort)
 				for _, mcp := range opts.Config.MCP {
 					relayURL := fmt.Sprintf("http://%s/mcp/%s/%s", proxyAddr, r.ProxyAuthToken, mcp.Name)
 					mcpCfg := provider.MCPServerConfig{
@@ -2101,13 +2120,13 @@ region = %s
 	var networkID string
 	if buildkitCfg.Enabled {
 		log.Debug("creating network for buildkit sidecar", "network", buildkitCfg.NetworkName)
-		netMgr := m.runtimePool.Default().NetworkManager()
+		netMgr := m.defaultRuntime().NetworkManager()
 		if netMgr == nil {
 			cleanupDaemonRun()
 			cleanupSSH(sshServer)
 			cleanupAgentConfig(claudeConfig)
 			cleanupAgentConfig(codexConfig)
-			return nil, fmt.Errorf("BuildKit requires Docker runtime (networks not supported by %s)", m.runtimePool.Default().Type())
+			return nil, fmt.Errorf("BuildKit requires Docker runtime (networks not supported by %s)", m.defaultRuntime().Type())
 		}
 		netID, netErr := netMgr.CreateNetwork(ctx, buildkitCfg.NetworkName)
 		if netErr != nil {
@@ -2148,9 +2167,9 @@ region = %s
 			},
 		}
 
-		sidecarMgr := m.runtimePool.Default().SidecarManager()
+		sidecarMgr := m.defaultRuntime().SidecarManager()
 		if sidecarMgr == nil {
-			netMgr := m.runtimePool.Default().NetworkManager()
+			netMgr := m.defaultRuntime().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, networkID) //nolint:errcheck
 			}
@@ -2158,12 +2177,12 @@ region = %s
 			cleanupSSH(sshServer)
 			cleanupAgentConfig(claudeConfig)
 			cleanupAgentConfig(codexConfig)
-			return nil, fmt.Errorf("BuildKit requires Docker runtime (sidecars not supported by %s)", m.runtimePool.Default().Type())
+			return nil, fmt.Errorf("BuildKit requires Docker runtime (sidecars not supported by %s)", m.defaultRuntime().Type())
 		}
 		buildkitContainerID, sidecarErr := sidecarMgr.StartSidecar(ctx, sidecarCfg)
 		if sidecarErr != nil {
 			// Clean up network on failure
-			netMgr := m.runtimePool.Default().NetworkManager()
+			netMgr := m.defaultRuntime().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, networkID) //nolint:errcheck
 			}
@@ -2186,8 +2205,8 @@ region = %s
 			}
 		}
 		if !ready {
-			_ = m.runtimePool.Default().StopContainer(ctx, buildkitContainerID) //nolint:errcheck
-			netMgr := m.runtimePool.Default().NetworkManager()
+			_ = m.defaultRuntime().StopContainer(ctx, buildkitContainerID) //nolint:errcheck
+			netMgr := m.defaultRuntime().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, networkID) //nolint:errcheck
 			}
@@ -2208,7 +2227,7 @@ region = %s
 
 	// Start service dependencies
 	if len(serviceDeps) > 0 {
-		svcMgr := m.runtimePool.Default().ServiceManager()
+		svcMgr := m.defaultRuntime().ServiceManager()
 		if svcMgr == nil {
 			cleanupDaemonRun()
 			cleanupSSH(sshServer)
@@ -2236,7 +2255,7 @@ region = %s
 
 		// Ensure network exists (share with BuildKit if present)
 		if networkID == "" {
-			netMgr := m.runtimePool.Default().NetworkManager()
+			netMgr := m.defaultRuntime().NetworkManager()
 			if netMgr == nil {
 				cleanupDaemonRun()
 				cleanupSSH(sshServer)
@@ -2442,7 +2461,7 @@ region = %s
 	// all env vars that reference the old host address to use the custom
 	// network's gateway instead.
 	if networkID != "" && net.ParseIP(hostAddr) != nil {
-		netMgr := m.runtimePool.Default().NetworkManager()
+		netMgr := m.defaultRuntime().NetworkManager()
 		if netMgr != nil {
 			if gw := netMgr.NetworkGateway(ctx, networkID); gw != "" && gw != hostAddr {
 				log.Debug("rewriting proxy host for custom network",
@@ -2482,13 +2501,13 @@ region = %s
 	// AI agent, use the agent default (8 GB). Apple's system default of 1 GB is
 	// too low for Claude Code, Codex, and Gemini CLI.
 	// Docker containers are left unlimited unless explicitly configured.
-	if memoryMB == 0 && m.runtimePool.Default().Type() == container.RuntimeApple && isAIAgent(opts.Config) {
+	if memoryMB == 0 && m.defaultRuntime().Type() == container.RuntimeApple && isAIAgent(opts.Config) {
 		memoryMB = container.DefaultAgentMemoryMB
 		log.Debug("using default agent memory for Apple container", "memoryMB", memoryMB)
 	}
 
 	// Create container
-	containerID, err := m.runtimePool.Default().CreateContainer(ctx, container.Config{
+	containerID, err := m.defaultRuntime().CreateContainer(ctx, container.Config{
 		Name:         r.ID,
 		Image:        containerImage,
 		Cmd:          cmd,
@@ -2513,9 +2532,9 @@ region = %s
 	if err != nil {
 		// Clean up BuildKit resources on failure
 		if buildkitCfg.Enabled && r.BuildkitContainerID != "" {
-			_ = m.runtimePool.Default().StopContainer(ctx, r.BuildkitContainerID)   //nolint:errcheck
-			_ = m.runtimePool.Default().RemoveContainer(ctx, r.BuildkitContainerID) //nolint:errcheck
-			netMgr := m.runtimePool.Default().NetworkManager()
+			_ = m.defaultRuntime().StopContainer(ctx, r.BuildkitContainerID)   //nolint:errcheck
+			_ = m.defaultRuntime().RemoveContainer(ctx, r.BuildkitContainerID) //nolint:errcheck
+			netMgr := m.defaultRuntime().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, r.NetworkID) //nolint:errcheck
 			}
@@ -2554,7 +2573,7 @@ region = %s
 		// Enable TLS on the routing proxy
 		if _, tlsErr := m.proxyLifecycle.EnableTLS(); tlsErr != nil {
 			// Clean up container
-			if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
+			if rmErr := m.defaultRuntime().RemoveContainer(ctx, containerID); rmErr != nil {
 				log.Debug("failed to remove container during cleanup", "error", rmErr)
 			}
 			cleanupDaemonRun()
@@ -2564,7 +2583,7 @@ region = %s
 		}
 		if proxyErr := m.proxyLifecycle.EnsureRunning(); proxyErr != nil {
 			// Clean up container
-			if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
+			if rmErr := m.defaultRuntime().RemoveContainer(ctx, containerID); rmErr != nil {
 				log.Debug("failed to remove container during cleanup", "error", rmErr)
 			}
 			cleanupDaemonRun()
@@ -2580,7 +2599,7 @@ region = %s
 		runStore, storeErr := storage.NewRunStore(storage.DefaultBaseDir(), r.ID)
 		if storeErr != nil {
 			// Clean up container and proxy if storage creation fails
-			if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
+			if rmErr := m.defaultRuntime().RemoveContainer(ctx, containerID); rmErr != nil {
 				log.Debug("failed to remove container during cleanup", "error", rmErr)
 			}
 			cleanupDaemonRun()
@@ -2603,7 +2622,7 @@ region = %s
 	auditStore, err := audit.OpenStore(filepath.Join(r.Store.Dir(), "audit.db"))
 	if err != nil {
 		// Clean up container, proxy, and storage if audit store fails
-		if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
+		if rmErr := m.defaultRuntime().RemoveContainer(ctx, containerID); rmErr != nil {
 			log.Debug("failed to remove container during cleanup", "error", rmErr)
 		}
 		cleanupDaemonRun()
@@ -2727,7 +2746,7 @@ func (m *Manager) setupPortBindings(ctx context.Context, r *Run) {
 	var bindings map[int]int
 	var err error
 	for i := 0; i < 5; i++ {
-		bindings, err = m.runtimePool.Default().GetPortBindings(ctx, r.ContainerID)
+		bindings, err = m.defaultRuntime().GetPortBindings(ctx, r.ContainerID)
 		if err != nil || len(bindings) >= len(r.Ports) {
 			break
 		}
@@ -2770,9 +2789,9 @@ func (m *Manager) setupFirewall(ctx context.Context, r *Run) error {
 	if !r.FirewallEnabled || r.ProxyPort <= 0 {
 		return nil
 	}
-	if err := m.runtimePool.Default().SetupFirewall(ctx, r.ContainerID, r.ProxyHost, r.ProxyPort); err != nil {
+	if err := m.defaultRuntime().SetupFirewall(ctx, r.ContainerID, r.ProxyHost, r.ProxyPort); err != nil {
 		r.SetStateFailedAt(fmt.Sprintf("firewall setup failed: %v", err), time.Now())
-		if stopErr := m.runtimePool.Default().StopContainer(ctx, r.ContainerID); stopErr != nil {
+		if stopErr := m.defaultRuntime().StopContainer(ctx, r.ContainerID); stopErr != nil {
 			ui.Warnf("Failed to stop container after firewall error: %v", stopErr)
 		}
 		return fmt.Errorf("firewall setup failed (required for strict network policy): %w", err)
@@ -2792,7 +2811,7 @@ func (m *Manager) Start(ctx context.Context, runID string, opts StartOptions) er
 	r.SetState(StateStarting)
 	setLogContext(r)
 
-	if err := m.runtimePool.Default().StartContainer(ctx, r.ContainerID); err != nil {
+	if err := m.defaultRuntime().StartContainer(ctx, r.ContainerID); err != nil {
 		r.SetStateFailedAt(err.Error(), time.Now())
 		return err
 	}
@@ -2905,7 +2924,7 @@ func (m *Manager) StartAttached(ctx context.Context, runID string, stdin io.Read
 	attachDone := make(chan error, 1)
 
 	go func() {
-		attachDone <- m.runtimePool.Default().StartAttached(ctx, containerID, attachOpts)
+		attachDone <- m.defaultRuntime().StartAttached(ctx, containerID, attachOpts)
 	}()
 
 	// Give the container a moment to start before checking state.
@@ -2964,7 +2983,7 @@ func (m *Manager) StartAttached(ctx context.Context, runID string, stdin io.Read
 	// (Apple TTY output doesn't go through container runtime logs — captureLogs() returns
 	// early for Apple interactive runs, so this is the only path that writes logs.)
 	// Runs unconditionally: even on escape-stop the buffer holds all output up to that point.
-	if r.Interactive && r.Store != nil && m.runtimePool.Default().Type() == container.RuntimeApple {
+	if r.Interactive && r.Store != nil && container.RuntimeType(r.Runtime) == container.RuntimeApple {
 		// Use CompareAndSwap to ensure single write
 		if r.logsCaptured.CompareAndSwap(false, true) {
 			if lw, err := r.Store.LogWriter(); err == nil {
@@ -3683,8 +3702,16 @@ func lastNLines(s string, n int) string {
 }
 
 // RuntimeType returns the container runtime type (docker or apple).
+// Uses a value cached at init, so it is safe to call after Close().
 func (m *Manager) RuntimeType() string {
-	return string(m.runtimePool.Default().Type())
+	return m.runtimeType
+}
+
+// RuntimePool returns the manager's runtime pool. CLI commands that need
+// to query resources across runtimes (e.g., images, containers) should use
+// this instead of creating a separate pool.
+func (m *Manager) RuntimePool() *container.RuntimePool {
+	return m.runtimePool
 }
 
 // Close releases manager resources.

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -82,7 +82,7 @@ func getWorkspaceOwner(workspace string) (uid, gid int) {
 
 // Manager handles run lifecycle operations.
 type Manager struct {
-	runtime        container.Runtime
+	runtimePool    *container.RuntimePool
 	runs           map[string]*Run
 	routes         *routing.RouteTable
 	proxyLifecycle *routing.Lifecycle
@@ -97,6 +97,13 @@ type Manager struct {
 	// Close() waits on this before closing the runtime so that
 	// monitors can finish capturing logs and updating state.
 	monitorWg sync.WaitGroup
+}
+
+// runtimeForRun returns the correct container runtime for an existing run.
+// It uses the run's Runtime field to look up the matching runtime from the pool.
+// For legacy runs without a Runtime field, falls back to the default runtime.
+func (m *Manager) runtimeForRun(r *Run) (container.Runtime, error) {
+	return m.runtimePool.Get(container.RuntimeType(r.Runtime))
 }
 
 // ManagerOptions configures the run manager.
@@ -117,7 +124,7 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 		runtimeOpts = container.DefaultRuntimeOptions()
 	}
 
-	rt, err := container.NewRuntimeWithOptions(runtimeOpts)
+	pool, err := container.NewRuntimePool(runtimeOpts)
 	if err != nil {
 		return nil, fmt.Errorf("initializing container runtime: %w", err)
 	}
@@ -134,7 +141,7 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	m := &Manager{
-		runtime:        rt,
+		runtimePool:    pool,
 		runs:           make(map[string]*Run),
 		routes:         lifecycle.Routes(),
 		proxyLifecycle: lifecycle,
@@ -238,9 +245,11 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 				}
 				defer func() { <-sem }()
 
-				// Skip container state check for runs created with a different runtime.
-				if info.meta.Runtime != "" && info.meta.Runtime != string(m.runtime.Type()) {
-					log.Debug("skipping cross-runtime container check, preserving persisted state", "id", info.runID, "run_runtime", info.meta.Runtime, "current_runtime", m.runtime.Type())
+				// Look up the runtime for this run (lazy-init if needed).
+				rt, rtErr := m.runtimePool.Get(container.RuntimeType(info.meta.Runtime))
+				if rtErr != nil {
+					log.Debug("runtime not available, preserving persisted state",
+						"id", info.runID, "runtime", info.meta.Runtime, "error", rtErr)
 					results[idx] = checkedRun{
 						info:              info,
 						runState:          State(info.meta.State),
@@ -255,7 +264,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 
 				var runState State
 				var confirmed bool
-				containerState, csErr := m.runtime.ContainerState(callCtx, info.meta.ContainerID)
+				containerState, csErr := rt.ContainerState(callCtx, info.meta.ContainerID)
 				if csErr != nil {
 					log.Debug("container state check failed, preserving persisted state", "id", info.runID, "container", info.meta.ContainerID, "error", csErr)
 					// Preserve both run state and service containers from
@@ -289,7 +298,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 				serviceContainers := make(map[string]string, len(info.meta.ServiceContainers))
 				for svcName, id := range info.meta.ServiceContainers {
 					svcCtx, svcCancel := context.WithTimeout(ctx, 5*time.Second)
-					if _, scErr := m.runtime.ContainerState(svcCtx, id); scErr == nil {
+					if _, scErr := rt.ContainerState(svcCtx, id); scErr == nil {
 						serviceContainers[svcName] = id
 					}
 					svcCancel()
@@ -393,12 +402,9 @@ func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, meta
 	// These inherited monitors are NOT tracked by monitorWg — they may block
 	// indefinitely on long-running containers from previous CLI invocations.
 	// Only monitors started via Start() are tracked so Close() doesn't hang.
-	//
-	// Skip cross-runtime runs: monitorContainerExit calls m.runtime.WaitContainer
-	// which would fail immediately for a container from a different runtime,
-	// then write "failed" state to disk — re-triggering the corruption bug.
-	crossRuntime := meta.Runtime != "" && meta.Runtime != string(m.runtime.Type())
-	if runState == StateRunning && !crossRuntime {
+	// monitorContainerExit resolves the correct runtime via runtimeForRun,
+	// so it works for runs from any runtime type.
+	if runState == StateRunning {
 		go m.monitorContainerExit(r)
 	}
 }
@@ -872,7 +878,7 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 
 		// Get proxy host address — needed for registration, proxy URL, and firewall.
 		// Must be set before buildRegisterRequest so HostGateway is included.
-		hostAddr = m.runtime.GetHostAddress()
+		hostAddr = m.runtimePool.Default().GetHostAddress()
 		runCtx.HostGateway = hostAddr
 
 		// Build RegisterRequest from the RunContext
@@ -1112,7 +1118,7 @@ region = %s
 		// For these cases, we use TCP instead: the host listens on TCP and the
 		// container's moat-init script uses socat to bridge TCP to a local Unix socket.
 		// For Docker on Linux, Unix sockets work fine via direct bind mounts.
-		usesTCP := !m.runtime.SupportsHostNetwork()
+		usesTCP := !m.runtimePool.Default().SupportsHostNetwork()
 
 		if usesTCP {
 			// Use TCP server - container will use socat to bridge.
@@ -1128,7 +1134,7 @@ region = %s
 			}
 
 			// Get the actual TCP address after binding.
-			// hostAddr is set earlier from m.runtime.GetHostAddress() and may be
+			// hostAddr is set earlier from m.runtimePool.Default().GetHostAddress() and may be
 			// rewritten later for custom networks (replaceHostInEnv).
 			tcpAddr := sshServer.TCPAddr()
 			containerSSHDir := "/run/moat/ssh"
@@ -1221,7 +1227,7 @@ region = %s
 	needsProxy := r.ProxyAuthToken != ""
 
 	if needsProxy || needsPorts {
-		if m.runtime.SupportsHostNetwork() && !needsPorts {
+		if m.runtimePool.Default().SupportsHostNetwork() && !needsPorts {
 			// Docker on Linux without ports: use host network so container can reach 127.0.0.1
 			networkMode = "host"
 		} else {
@@ -1232,7 +1238,7 @@ region = %s
 			// Desktop and Rancher Desktop resolve it via built-in DNS — adding
 			// host-gateway would override the correct IP with the bridge
 			// gateway (which is unreachable on Rancher Desktop).
-			if m.runtime.Type() == container.RuntimeDocker && goruntime.GOOS == "linux" {
+			if m.runtimePool.Default().Type() == container.RuntimeDocker && goruntime.GOOS == "linux" {
 				extraHosts = []string{"host.docker.internal:host-gateway"}
 			}
 		}
@@ -1360,7 +1366,7 @@ region = %s
 	// Resolve docker dependency if present
 	// This validates that Apple containers are not used with docker:host dependency,
 	// and returns the appropriate config for the mode (socket mount for host, privileged for dind).
-	dockerConfig, dockerErr := ResolveDockerDependency(depList, m.runtime.Type())
+	dockerConfig, dockerErr := ResolveDockerDependency(depList, m.runtimePool.Default().Type())
 	if dockerErr != nil {
 		cleanupDaemonRun()
 		cleanupSSH(sshServer)
@@ -1545,16 +1551,16 @@ region = %s
 		r.Agent = opts.Config.Agent
 	}
 	r.Image = containerImage
-	r.Runtime = string(m.runtime.Type())
+	r.Runtime = string(m.runtimePool.Default().Type())
 
 	needsCustomImage := imageSpec.NeedsCustomImage(hasDeps)
 
 	// Handle --rebuild: delete existing image to force fresh build
 	if opts.Rebuild && needsCustomImage {
-		exists, _ := m.runtime.BuildManager().ImageExists(ctx, containerImage)
+		exists, _ := m.runtimePool.Default().BuildManager().ImageExists(ctx, containerImage)
 		if exists {
 			fmt.Printf("Removing cached image %s...\n", containerImage)
-			if err := m.runtime.RemoveImage(ctx, containerImage); err != nil {
+			if err := m.runtimePool.Default().RemoveImage(ctx, containerImage); err != nil {
 				ui.Warnf("Failed to remove image: %v", err)
 			}
 		}
@@ -1572,7 +1578,7 @@ region = %s
 		}
 		generatedDockerfile = result.Dockerfile
 
-		exists, err := m.runtime.BuildManager().ImageExists(ctx, containerImage)
+		exists, err := m.runtimePool.Default().BuildManager().ImageExists(ctx, containerImage)
 		if err != nil {
 			cleanupDaemonRun()
 			return nil, fmt.Errorf("checking image: %w", err)
@@ -1618,10 +1624,10 @@ region = %s
 				buildOpts.DNS = opts.Config.Container.DNS
 			}
 
-			buildMgr := m.runtime.BuildManager()
+			buildMgr := m.runtimePool.Default().BuildManager()
 			if buildMgr == nil {
 				cleanupDaemonRun()
-				return nil, fmt.Errorf("cannot build image: runtime %s does not support building", m.runtime.Type())
+				return nil, fmt.Errorf("cannot build image: runtime %s does not support building", m.runtimePool.Default().Type())
 			}
 
 			// Merge pre-cloned marketplace files into build context.
@@ -1650,7 +1656,7 @@ region = %s
 	// - anthropic grant is configured (automatic Claude Code integration)
 	var containerHome string
 	if hostHome, err := os.UserHomeDir(); err == nil {
-		imageHome := m.runtime.BuildManager().GetImageHomeDir(ctx, containerImage)
+		imageHome := m.runtimePool.Default().BuildManager().GetImageHomeDir(ctx, containerImage)
 		containerHome = resolveContainerHome(needsCustomImage, imageHome)
 		if opts.Config != nil && opts.Config.ShouldSyncClaudeLogs() {
 			claudeDir := claude.WorkspaceToClaudeDir(opts.Workspace)
@@ -1762,7 +1768,7 @@ region = %s
 			// the container cannot reach directly.
 			mcpServers := make(map[string]provider.MCPServerConfig)
 			if opts.Config != nil && len(opts.Config.MCP) > 0 {
-				proxyAddr := fmt.Sprintf("%s:%d", m.runtime.GetHostAddress(), r.ProxyPort)
+				proxyAddr := fmt.Sprintf("%s:%d", m.runtimePool.Default().GetHostAddress(), r.ProxyPort)
 				for _, mcp := range opts.Config.MCP {
 					relayURL := fmt.Sprintf("http://%s/mcp/%s/%s", proxyAddr, r.ProxyAuthToken, mcp.Name)
 					mcpCfg := provider.MCPServerConfig{
@@ -2089,13 +2095,13 @@ region = %s
 	var networkID string
 	if buildkitCfg.Enabled {
 		log.Debug("creating network for buildkit sidecar", "network", buildkitCfg.NetworkName)
-		netMgr := m.runtime.NetworkManager()
+		netMgr := m.runtimePool.Default().NetworkManager()
 		if netMgr == nil {
 			cleanupDaemonRun()
 			cleanupSSH(sshServer)
 			cleanupAgentConfig(claudeConfig)
 			cleanupAgentConfig(codexConfig)
-			return nil, fmt.Errorf("BuildKit requires Docker runtime (networks not supported by %s)", m.runtime.Type())
+			return nil, fmt.Errorf("BuildKit requires Docker runtime (networks not supported by %s)", m.runtimePool.Default().Type())
 		}
 		netID, netErr := netMgr.CreateNetwork(ctx, buildkitCfg.NetworkName)
 		if netErr != nil {
@@ -2136,9 +2142,9 @@ region = %s
 			},
 		}
 
-		sidecarMgr := m.runtime.SidecarManager()
+		sidecarMgr := m.runtimePool.Default().SidecarManager()
 		if sidecarMgr == nil {
-			netMgr := m.runtime.NetworkManager()
+			netMgr := m.runtimePool.Default().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, networkID) //nolint:errcheck
 			}
@@ -2146,12 +2152,12 @@ region = %s
 			cleanupSSH(sshServer)
 			cleanupAgentConfig(claudeConfig)
 			cleanupAgentConfig(codexConfig)
-			return nil, fmt.Errorf("BuildKit requires Docker runtime (sidecars not supported by %s)", m.runtime.Type())
+			return nil, fmt.Errorf("BuildKit requires Docker runtime (sidecars not supported by %s)", m.runtimePool.Default().Type())
 		}
 		buildkitContainerID, sidecarErr := sidecarMgr.StartSidecar(ctx, sidecarCfg)
 		if sidecarErr != nil {
 			// Clean up network on failure
-			netMgr := m.runtime.NetworkManager()
+			netMgr := m.runtimePool.Default().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, networkID) //nolint:errcheck
 			}
@@ -2174,8 +2180,8 @@ region = %s
 			}
 		}
 		if !ready {
-			_ = m.runtime.StopContainer(ctx, buildkitContainerID) //nolint:errcheck
-			netMgr := m.runtime.NetworkManager()
+			_ = m.runtimePool.Default().StopContainer(ctx, buildkitContainerID) //nolint:errcheck
+			netMgr := m.runtimePool.Default().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, networkID) //nolint:errcheck
 			}
@@ -2196,7 +2202,7 @@ region = %s
 
 	// Start service dependencies
 	if len(serviceDeps) > 0 {
-		svcMgr := m.runtime.ServiceManager()
+		svcMgr := m.runtimePool.Default().ServiceManager()
 		if svcMgr == nil {
 			cleanupDaemonRun()
 			cleanupSSH(sshServer)
@@ -2224,7 +2230,7 @@ region = %s
 
 		// Ensure network exists (share with BuildKit if present)
 		if networkID == "" {
-			netMgr := m.runtime.NetworkManager()
+			netMgr := m.runtimePool.Default().NetworkManager()
 			if netMgr == nil {
 				cleanupDaemonRun()
 				cleanupSSH(sshServer)
@@ -2430,7 +2436,7 @@ region = %s
 	// all env vars that reference the old host address to use the custom
 	// network's gateway instead.
 	if networkID != "" && net.ParseIP(hostAddr) != nil {
-		netMgr := m.runtime.NetworkManager()
+		netMgr := m.runtimePool.Default().NetworkManager()
 		if netMgr != nil {
 			if gw := netMgr.NetworkGateway(ctx, networkID); gw != "" && gw != hostAddr {
 				log.Debug("rewriting proxy host for custom network",
@@ -2470,13 +2476,13 @@ region = %s
 	// AI agent, use the agent default (8 GB). Apple's system default of 1 GB is
 	// too low for Claude Code, Codex, and Gemini CLI.
 	// Docker containers are left unlimited unless explicitly configured.
-	if memoryMB == 0 && m.runtime.Type() == container.RuntimeApple && isAIAgent(opts.Config) {
+	if memoryMB == 0 && m.runtimePool.Default().Type() == container.RuntimeApple && isAIAgent(opts.Config) {
 		memoryMB = container.DefaultAgentMemoryMB
 		log.Debug("using default agent memory for Apple container", "memoryMB", memoryMB)
 	}
 
 	// Create container
-	containerID, err := m.runtime.CreateContainer(ctx, container.Config{
+	containerID, err := m.runtimePool.Default().CreateContainer(ctx, container.Config{
 		Name:         r.ID,
 		Image:        containerImage,
 		Cmd:          cmd,
@@ -2501,9 +2507,9 @@ region = %s
 	if err != nil {
 		// Clean up BuildKit resources on failure
 		if buildkitCfg.Enabled && r.BuildkitContainerID != "" {
-			_ = m.runtime.StopContainer(ctx, r.BuildkitContainerID)   //nolint:errcheck
-			_ = m.runtime.RemoveContainer(ctx, r.BuildkitContainerID) //nolint:errcheck
-			netMgr := m.runtime.NetworkManager()
+			_ = m.runtimePool.Default().StopContainer(ctx, r.BuildkitContainerID)   //nolint:errcheck
+			_ = m.runtimePool.Default().RemoveContainer(ctx, r.BuildkitContainerID) //nolint:errcheck
+			netMgr := m.runtimePool.Default().NetworkManager()
 			if netMgr != nil {
 				_ = netMgr.RemoveNetwork(ctx, r.NetworkID) //nolint:errcheck
 			}
@@ -2542,7 +2548,7 @@ region = %s
 		// Enable TLS on the routing proxy
 		if _, tlsErr := m.proxyLifecycle.EnableTLS(); tlsErr != nil {
 			// Clean up container
-			if rmErr := m.runtime.RemoveContainer(ctx, containerID); rmErr != nil {
+			if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
 				log.Debug("failed to remove container during cleanup", "error", rmErr)
 			}
 			cleanupDaemonRun()
@@ -2552,7 +2558,7 @@ region = %s
 		}
 		if proxyErr := m.proxyLifecycle.EnsureRunning(); proxyErr != nil {
 			// Clean up container
-			if rmErr := m.runtime.RemoveContainer(ctx, containerID); rmErr != nil {
+			if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
 				log.Debug("failed to remove container during cleanup", "error", rmErr)
 			}
 			cleanupDaemonRun()
@@ -2568,7 +2574,7 @@ region = %s
 		runStore, storeErr := storage.NewRunStore(storage.DefaultBaseDir(), r.ID)
 		if storeErr != nil {
 			// Clean up container and proxy if storage creation fails
-			if rmErr := m.runtime.RemoveContainer(ctx, containerID); rmErr != nil {
+			if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
 				log.Debug("failed to remove container during cleanup", "error", rmErr)
 			}
 			cleanupDaemonRun()
@@ -2591,7 +2597,7 @@ region = %s
 	auditStore, err := audit.OpenStore(filepath.Join(r.Store.Dir(), "audit.db"))
 	if err != nil {
 		// Clean up container, proxy, and storage if audit store fails
-		if rmErr := m.runtime.RemoveContainer(ctx, containerID); rmErr != nil {
+		if rmErr := m.runtimePool.Default().RemoveContainer(ctx, containerID); rmErr != nil {
 			log.Debug("failed to remove container during cleanup", "error", rmErr)
 		}
 		cleanupDaemonRun()
@@ -2715,7 +2721,7 @@ func (m *Manager) setupPortBindings(ctx context.Context, r *Run) {
 	var bindings map[int]int
 	var err error
 	for i := 0; i < 5; i++ {
-		bindings, err = m.runtime.GetPortBindings(ctx, r.ContainerID)
+		bindings, err = m.runtimePool.Default().GetPortBindings(ctx, r.ContainerID)
 		if err != nil || len(bindings) >= len(r.Ports) {
 			break
 		}
@@ -2758,9 +2764,9 @@ func (m *Manager) setupFirewall(ctx context.Context, r *Run) error {
 	if !r.FirewallEnabled || r.ProxyPort <= 0 {
 		return nil
 	}
-	if err := m.runtime.SetupFirewall(ctx, r.ContainerID, r.ProxyHost, r.ProxyPort); err != nil {
+	if err := m.runtimePool.Default().SetupFirewall(ctx, r.ContainerID, r.ProxyHost, r.ProxyPort); err != nil {
 		r.SetStateFailedAt(fmt.Sprintf("firewall setup failed: %v", err), time.Now())
-		if stopErr := m.runtime.StopContainer(ctx, r.ContainerID); stopErr != nil {
+		if stopErr := m.runtimePool.Default().StopContainer(ctx, r.ContainerID); stopErr != nil {
 			ui.Warnf("Failed to stop container after firewall error: %v", stopErr)
 		}
 		return fmt.Errorf("firewall setup failed (required for strict network policy): %w", err)
@@ -2780,7 +2786,7 @@ func (m *Manager) Start(ctx context.Context, runID string, opts StartOptions) er
 	r.SetState(StateStarting)
 	setLogContext(r)
 
-	if err := m.runtime.StartContainer(ctx, r.ContainerID); err != nil {
+	if err := m.runtimePool.Default().StartContainer(ctx, r.ContainerID); err != nil {
 		r.SetStateFailedAt(err.Error(), time.Now())
 		return err
 	}
@@ -2893,7 +2899,7 @@ func (m *Manager) StartAttached(ctx context.Context, runID string, stdin io.Read
 	attachDone := make(chan error, 1)
 
 	go func() {
-		attachDone <- m.runtime.StartAttached(ctx, containerID, attachOpts)
+		attachDone <- m.runtimePool.Default().StartAttached(ctx, containerID, attachOpts)
 	}()
 
 	// Give the container a moment to start before checking state.
@@ -2952,7 +2958,7 @@ func (m *Manager) StartAttached(ctx context.Context, runID string, stdin io.Read
 	// (Apple TTY output doesn't go through container runtime logs — captureLogs() returns
 	// early for Apple interactive runs, so this is the only path that writes logs.)
 	// Runs unconditionally: even on escape-stop the buffer holds all output up to that point.
-	if r.Interactive && r.Store != nil && m.runtime.Type() == container.RuntimeApple {
+	if r.Interactive && r.Store != nil && m.runtimePool.Default().Type() == container.RuntimeApple {
 		// Use CompareAndSwap to ensure single write
 		if r.logsCaptured.CompareAndSwap(false, true) {
 			if lw, err := r.Store.LogWriter(); err == nil {
@@ -3012,8 +3018,13 @@ func (m *Manager) Stop(ctx context.Context, runID string) error {
 	r.SetState(StateStopping)
 	m.mu.Unlock()
 
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+
 	// Stop the main container
-	if err := m.runtime.StopContainer(ctx, r.ContainerID); err != nil {
+	if err := rt.StopContainer(ctx, r.ContainerID); err != nil {
 		ui.Warnf("%v", err)
 		log.Debug("failed to stop container", "container_id", r.ContainerID, "error", err)
 	}
@@ -3098,7 +3109,7 @@ func (m *Manager) captureLogs(r *Run) {
 	// - Docker: Container runtime logs work even in TTY mode, so use ContainerLogsAll
 	// - Apple: TTY output doesn't go to container logs, so StartAttached uses tee
 	// Only skip container logs for Apple containers in interactive mode.
-	if r.Interactive && m.runtime.Type() == container.RuntimeApple {
+	if r.Interactive && container.RuntimeType(r.Runtime) == container.RuntimeApple {
 		return
 	}
 
@@ -3127,7 +3138,12 @@ func (m *Manager) captureLogs(r *Run) {
 	// Use a background context with timeout since the container may already be stopped.
 	logCtx, logCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer logCancel()
-	allLogs, logErr := m.runtime.ContainerLogsAll(logCtx, r.ContainerID)
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		log.Warn("cannot resolve runtime for log capture", "runID", r.ID, "error", rtErr)
+		return
+	}
+	allLogs, logErr := rt.ContainerLogsAll(logCtx, r.ContainerID)
 	if logErr != nil {
 		log.Warn("failed to fetch container logs - creating empty logs.jsonl for audit", "runID", r.ID, "error", logErr)
 		// Still create empty logs.jsonl for audit completeness
@@ -3211,6 +3227,13 @@ func (m *Manager) cleanupResources(ctx context.Context, r *Run) {
 	m.mu.RUnlock()
 
 	r.cleanupOnce.Do(func() {
+		// Resolve runtime for this run. If unavailable, skip container cleanup
+		// but still clean up proxy, SSH, routes, and temp dirs.
+		rt, rtErr := m.runtimeForRun(r)
+		if rtErr != nil {
+			log.Debug("cleanup: cannot resolve runtime, skipping container cleanup", "run", r.ID, "error", rtErr)
+		}
+
 		// Cancel token refresh and unregister run from proxy daemon
 		if err := r.stopProxyServer(ctx); err != nil {
 			log.Debug("cleanup: stopping proxy", "error", err)
@@ -3227,8 +3250,8 @@ func (m *Manager) cleanupResources(ctx context.Context, r *Run) {
 		}
 
 		// Stop service containers
-		if len(r.ServiceContainers) > 0 {
-			svcMgr := m.runtime.ServiceManager()
+		if rt != nil && len(r.ServiceContainers) > 0 {
+			svcMgr := rt.ServiceManager()
 			if svcMgr != nil {
 				for svcName, svcContainerID := range r.ServiceContainers {
 					log.Debug("cleanup: stopping service", "service", svcName, "container_id", svcContainerID)
@@ -3241,26 +3264,26 @@ func (m *Manager) cleanupResources(ctx context.Context, r *Run) {
 
 		// Remove BuildKit sidecar before network (Docker requires containers
 		// disconnected before network removal, see #131).
-		if r.BuildkitContainerID != "" {
+		if rt != nil && r.BuildkitContainerID != "" {
 			log.Debug("cleanup: removing buildkit sidecar", "container_id", r.BuildkitContainerID)
-			if err := m.runtime.StopContainer(ctx, r.BuildkitContainerID); err != nil {
+			if err := rt.StopContainer(ctx, r.BuildkitContainerID); err != nil {
 				log.Debug("cleanup: failed to stop buildkit sidecar", "error", err)
 			}
-			if err := m.runtime.RemoveContainer(ctx, r.BuildkitContainerID); err != nil {
+			if err := rt.RemoveContainer(ctx, r.BuildkitContainerID); err != nil {
 				log.Debug("cleanup: failed to remove buildkit sidecar", "error", err)
 			}
 		}
 
 		// Remove main container unless --keep was specified
-		if !r.KeepContainer {
-			if err := m.runtime.RemoveContainer(ctx, r.ContainerID); err != nil {
+		if rt != nil && !r.KeepContainer {
+			if err := rt.RemoveContainer(ctx, r.ContainerID); err != nil {
 				log.Debug("cleanup: failed to remove container", "error", err)
 			}
 		}
 
 		// Remove network (with force-disconnect fallback)
-		if r.NetworkID != "" {
-			netMgr := m.runtime.NetworkManager()
+		if rt != nil && r.NetworkID != "" {
+			netMgr := rt.NetworkManager()
 			if netMgr != nil {
 				if err := netMgr.RemoveNetwork(ctx, r.NetworkID); err != nil {
 					log.Debug("cleanup: network removal failed, trying force", "network", r.NetworkID, "error", err)
@@ -3305,11 +3328,21 @@ func (m *Manager) cleanupResources(ctx context.Context, r *Run) {
 // (interactive, non-interactive, Stop) caused the container to exit.
 // It's safe to call multiple times - captureLogs is idempotent.
 func (m *Manager) monitorContainerExit(r *Run) {
+	// Resolve the correct runtime for this run.
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		log.Debug("cannot resolve runtime for container monitor", "run", r.ID, "error", rtErr)
+		r.SetStateFailedAt("runtime unavailable: "+rtErr.Error(), time.Now())
+		_ = r.SaveMetadata()
+		close(r.exitCh)
+		return
+	}
+
 	// Wait for container to exit (no timeout - let it run as long as needed).
 	// This is the ONLY place that calls WaitContainer to avoid race conditions.
 	// Uses context.Background() so this goroutine is not canceled by Close().
 	// Close() waits on monitorWg before closing the runtime.
-	exitCode, err := m.runtime.WaitContainer(context.Background(), r.ContainerID)
+	exitCode, err := rt.WaitContainer(context.Background(), r.ContainerID)
 
 	// CRITICAL: Capture logs IMMEDIATELY after container exits, BEFORE signaling.
 	// Docker may start removing/cleaning the container at any moment after exit.
@@ -3491,7 +3524,11 @@ func (m *Manager) ResizeTTY(ctx context.Context, runID string, height, width uin
 	containerID := r.ContainerID
 	m.mu.RUnlock()
 
-	return m.runtime.ResizeTTY(ctx, containerID, height, width)
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+	return rt.ResizeTTY(ctx, containerID, height, width)
 }
 
 // validXclipTargets is the set of X selection targets allowed in shell commands.
@@ -3541,7 +3578,12 @@ func (m *Manager) Exec(ctx context.Context, runID string, cmd []string, stdin []
 		return fmt.Errorf("run %s is not running (state: %s)", runID, state)
 	}
 
-	execErr := m.runtime.Exec(ctx, containerID, cmd, stdin, stdout, stderr)
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+
+	execErr := rt.Exec(ctx, containerID, cmd, stdin, stdout, stderr)
 
 	if auditStore != nil {
 		exitCode := 0
@@ -3571,7 +3613,12 @@ func (m *Manager) FollowLogs(ctx context.Context, runID string, w io.Writer) err
 	containerID := r.ContainerID
 	m.mu.RUnlock()
 
-	logs, err := m.runtime.ContainerLogs(ctx, containerID)
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+
+	logs, err := rt.ContainerLogs(ctx, containerID)
 	if err != nil {
 		return fmt.Errorf("getting container logs: %w", err)
 	}
@@ -3593,8 +3640,13 @@ func (m *Manager) RecentLogs(runID string, lines int) (string, error) {
 	containerID := r.ContainerID
 	m.mu.RUnlock()
 
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return "", fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+
 	// Get all logs (non-following)
-	allLogs, err := m.runtime.ContainerLogsAll(context.Background(), containerID)
+	allLogs, err := rt.ContainerLogsAll(context.Background(), containerID)
 	if err != nil {
 		return "", err
 	}
@@ -3626,7 +3678,7 @@ func lastNLines(s string, n int) string {
 
 // RuntimeType returns the container runtime type (docker or apple).
 func (m *Manager) RuntimeType() string {
-	return string(m.runtime.Type())
+	return string(m.runtimePool.Default().Type())
 }
 
 // Close releases manager resources.
@@ -3665,7 +3717,7 @@ func (m *Manager) Close() error {
 	}
 	m.mu.RUnlock()
 
-	return m.runtime.Close()
+	return m.runtimePool.Close()
 }
 
 // isAIAgent returns true if the config specifies an AI coding agent

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -207,7 +207,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 		// Pass stateConfirmed=true because the owning process authoritatively
 		// wrote this terminal state — it's safe to clean up stale routes.
 		if meta.State == string(StateStopped) || meta.State == string(StateFailed) {
-			m.registerPersistedRun(State(meta.State), true, meta, store, runID, nil)
+			m.registerPersistedRun(State(meta.State), true, false, meta, store, runID, nil)
 			continue
 		}
 
@@ -221,6 +221,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 			info              persistedRunInfo
 			runState          State
 			stateConfirmed    bool // true when state was confirmed by a successful container check
+			skipMonitor       bool // true when the runtime is unavailable (cross-runtime runs)
 			serviceContainers map[string]string
 		}
 
@@ -253,6 +254,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 					results[idx] = checkedRun{
 						info:              info,
 						runState:          State(info.meta.State),
+						skipMonitor:       true,
 						serviceContainers: info.meta.ServiceContainers,
 					}
 					return
@@ -316,7 +318,7 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 		wg.Wait()
 
 		for _, cr := range results {
-			m.registerPersistedRun(cr.runState, cr.stateConfirmed, cr.info.meta, cr.info.store, cr.info.runID, cr.serviceContainers)
+			m.registerPersistedRun(cr.runState, cr.stateConfirmed, cr.skipMonitor, cr.info.meta, cr.info.store, cr.info.runID, cr.serviceContainers)
 		}
 	}
 
@@ -326,9 +328,11 @@ func (m *Manager) loadPersistedRuns(ctx context.Context) error {
 // registerPersistedRun creates and registers a Run from persisted metadata.
 // stateConfirmed indicates whether runState was determined by a successful container
 // state check (true) or inferred from persisted state / error fallback (false).
+// skipMonitor prevents spawning a background monitor goroutine (used when the
+// runtime is unavailable, e.g. cross-runtime runs from a different host).
 // If serviceContainers is nil, it is loaded directly from metadata (for terminal-state runs
 // that skip live container checks).
-func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, meta storage.Metadata, store *storage.RunStore, runID string, serviceContainers map[string]string) {
+func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, skipMonitor bool, meta storage.Metadata, store *storage.RunStore, runID string, serviceContainers map[string]string) {
 	if serviceContainers == nil {
 		serviceContainers = meta.ServiceContainers
 	}
@@ -404,7 +408,9 @@ func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, meta
 	// Only monitors started via Start() are tracked so Close() doesn't hang.
 	// monitorContainerExit resolves the correct runtime via runtimeForRun,
 	// so it works for runs from any runtime type.
-	if runState == StateRunning {
+	// skipMonitor is set for cross-runtime runs where the runtime is unavailable —
+	// spawning a monitor would immediately fail and corrupt the persisted state.
+	if runState == StateRunning && !skipMonitor {
 		go m.monitorContainerExit(r)
 	}
 }

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -941,9 +941,9 @@ func TestLoadPersistedRunsCleansStaleRoutes(t *testing.T) {
 
 	// Create a manager with a stub runtime that reports the container as exited
 	m := &Manager{
-		runtime: &stubRuntime{
+		runtimePool: container.NewRuntimePoolWithDefault(&stubRuntime{
 			states: map[string]string{"container-abc": "exited"},
-		},
+		}),
 		runs:   make(map[string]*Run),
 		routes: routes,
 	}
@@ -1010,10 +1010,10 @@ func TestLoadPersistedRunsKeepsRoutesForRunningContainers(t *testing.T) {
 	}
 
 	m := &Manager{
-		runtime: &stubRuntime{
+		runtimePool: container.NewRuntimePoolWithDefault(&stubRuntime{
 			states: map[string]string{"container-live": "running"},
 			done:   make(chan struct{}),
-		},
+		}),
 		runs:   make(map[string]*Run),
 		routes: routes,
 	}
@@ -1078,10 +1078,10 @@ func TestLoadPersistedRunsPreservesStateOnContainerError(t *testing.T) {
 	// when a container exits, but here we only test that reconciliation itself
 	// doesn't corrupt state during the read path.
 	m := &Manager{
-		runtime: &stubRuntime{
+		runtimePool: container.NewRuntimePoolWithDefault(&stubRuntime{
 			states: map[string]string{},
 			done:   make(chan struct{}),
-		},
+		}),
 		runs:   make(map[string]*Run),
 		routes: routes,
 	}
@@ -1143,9 +1143,9 @@ func TestLoadPersistedRunsDoesNotModifyMetadata(t *testing.T) {
 
 	// Runtime reports container as exited — state differs from persisted "running"
 	m := &Manager{
-		runtime: &stubRuntime{
+		runtimePool: container.NewRuntimePoolWithDefault(&stubRuntime{
 			states: map[string]string{"container-xyz": "exited"},
-		},
+		}),
 		runs:   make(map[string]*Run),
 		routes: routes,
 	}
@@ -1218,10 +1218,10 @@ func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
 	done := make(chan struct{})
 	close(done)
 	m := &Manager{
-		runtime: &stubRuntime{
+		runtimePool: container.NewRuntimePoolWithDefault(&stubRuntime{
 			states: map[string]string{},
 			done:   done,
-		},
+		}),
 		runs:   make(map[string]*Run),
 		routes: routes,
 	}
@@ -1299,9 +1299,9 @@ func TestLoadPersistedRunsCleansRoutesForPersistedTerminalState(t *testing.T) {
 
 	// Runtime is irrelevant — persisted terminal state skips live container checks
 	m := &Manager{
-		runtime: &stubRuntime{
+		runtimePool: container.NewRuntimePoolWithDefault(&stubRuntime{
 			states: map[string]string{},
-		},
+		}),
 		runs:   make(map[string]*Run),
 		routes: routes,
 	}


### PR DESCRIPTION
## Summary

- Introduces `RuntimePool` abstraction (`internal/container/pool.go`) that manages multiple container runtimes (Docker + Apple) keyed by type, with lazy initialization and thread-safe access
- Migrates `Manager` from a single `container.Runtime` to `RuntimePool` — new runs use the default runtime, operations on existing runs resolve the correct runtime via `runtimeForRun()`
- Updates CLI commands (`status`, `clean`, `list`, `system images`, `system containers`) to query all available runtimes via `ForEachAvailable()`, with per-runtime failure tracking
- Adds RUNTIME column to `moat list`, `moat system images`, `moat system containers` output
- Adds `runtime` field to `--json` output for status, system containers, and system images
- Updates CLI reference documentation for all changed output formats

Fixes the problem where `moat status`, `moat clean`, etc. only showed resources from the auto-detected default runtime, making it impossible to manage resources across both Docker and Apple containers on the same machine.

## Test plan

- [x] `make test-unit` passes (race detector enabled)
- [x] `make lint` clean (0 issues)
- [x] New stub-based pool tests run without a container runtime (CI-safe)
- [x] Existing manager tests updated and passing
- [ ] Manual: `moat list` shows RUNTIME column
- [ ] Manual: `moat system images` / `moat system containers` show RUNTIME column
- [ ] Manual: `moat status` shows all available runtimes
- [ ] Manual: `moat clean` handles resources from both runtimes
- [ ] Manual: `moat system images --json` includes runtime field

🤖 Generated with [Claude Code](https://claude.com/claude-code)