### PR TITLE
ci(release): add workflow_dispatch for manual gatekeeper builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag to build from (e.g. v0.5.0)"
+        required: true
 
 permissions:
   contents: read
@@ -11,6 +16,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -42,6 +48,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
         with:
           images: ghcr.io/majorcontext/moat-gatekeeper
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.tag || github.ref }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag || github.ref }}
             type=sha
 
       - uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to the release workflow with a `tag` input
- GoReleaser job skipped on manual dispatch (only runs on tag push)
- Gatekeeper image job checks out the specified tag

This lets us publish the gatekeeper image for existing tags without cutting a new release:
```
gh workflow run release.yml -f tag=v0.5.0
```

## Test plan
- [ ] Merge, then run `gh workflow run release.yml -f tag=v0.5.0`
- [ ] Verify only the gatekeeper image job runs (not GoReleaser)
- [ ] Verify image appears at `ghcr.io/majorcontext/moat-gatekeeper:0.5.0`