### PR TITLE
feat(deps): add Python 3.13/3.14 and bump uv to 0.11.6

### DIFF
--- a/internal/deps/registry.yaml
+++ b/internal/deps/registry.yaml
@@ -17,7 +17,7 @@ python:
   description: Python programming language
   type: runtime
   default: "3.11"
-  versions: ["3.9", "3.10", "3.11", "3.12"]
+  versions: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 rust:
   description: Rust programming language
@@ -43,7 +43,7 @@ uv:
   repo: astral-sh/uv
   asset: "uv-{target}.tar.gz"
   bin: "uv-{target}/uv"
-  default: "0.5.14"
+  default: "0.11.6"
   tag-prefix: none
   requires: [python]
   targets:


### PR DESCRIPTION
## Summary
- Add Python 3.13 and 3.14 to the supported versions list in `registry.yaml`
- Bump uv default from 0.5.14 to 0.11.6

## Motivation
Python 3.13 and 3.14 are now widely used — projects with `requires-python = ">=3.13"` or `">=3.14"` in their `pyproject.toml` cannot use moat today because `python@3.13` is rejected by the version validator.

The bundled uv 0.5.14 doesn't support features now common in `pyproject.toml` configs, such as:
- `exclude-newer = "14 days"` (relative dates, added in uv 0.7)
- `exclude-newer-package` (added in uv 0.6)

## Changes
- `internal/deps/registry.yaml`: Added `"3.13"` and `"3.14"` to Python `versions` array
- `internal/deps/registry.yaml`: Changed uv `default` from `"0.5.14"` to `"0.11.6"`

## Test plan
- [ ] `moat claude` with `python@3.14` in `moat.yaml` — should install Python 3.14 and succeed
- [ ] `uv sync --locked` on a project using `exclude-newer = "14 days"` — should parse without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)