### PR TITLE
feat(config): honor MOAT_HOME to relocate moat state directory

### DIFF
--- a/cmd/moat/cli/audit.go
+++ b/cmd/moat/cli/audit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/majorcontext/moat/internal/audit"
 	"github.com/majorcontext/moat/internal/run"
+	"github.com/majorcontext/moat/internal/storage"
 	"github.com/majorcontext/moat/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -64,11 +65,7 @@ func runAudit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Find run directory
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("finding home directory: %w", err)
-	}
-	runDir := filepath.Join(homeDir, ".moat", "runs", runID)
+	runDir := filepath.Join(storage.DefaultBaseDir(), runID)
 	dbPath := filepath.Join(runDir, "audit.db")
 
 	if _, statErr := os.Stat(dbPath); os.IsNotExist(statErr) {

--- a/cmd/moat/cli/doctor.go
+++ b/cmd/moat/cli/doctor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/doctor"
 	"github.com/majorcontext/moat/internal/providers/codex"
+	"github.com/majorcontext/moat/internal/storage"
 	"github.com/majorcontext/moat/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -410,7 +411,7 @@ func (s *claudeSection) Print(w io.Writer) error {
 	}
 
 	// 3. Moat-specific user defaults
-	moatUserSettingsPath := filepath.Join(home, ".moat", "claude", "settings.json")
+	moatUserSettingsPath := filepath.Join(config.GlobalConfigDir(), "claude", "settings.json")
 	if _, err := os.Stat(moatUserSettingsPath); err == nil {
 		fmt.Fprintf(tw, "  3. Moat user defaults:\t%s %s\n", moatUserSettingsPath, ui.OKTag())
 	} else {
@@ -452,13 +453,8 @@ type storageSection struct{}
 func (s *storageSection) Name() string { return "Storage" }
 
 func (s *storageSection) Print(w io.Writer) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return nil
-	}
-
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	moatDir := filepath.Join(home, ".moat")
+	moatDir := config.GlobalConfigDir()
 	fmt.Fprintf(tw, "Moat directory:\t%s\n", moatDir)
 
 	if info, err := os.Stat(moatDir); err == nil {
@@ -495,12 +491,7 @@ type runsSection struct{}
 func (s *runsSection) Name() string { return "Recent Runs" }
 
 func (s *runsSection) Print(w io.Writer) error {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return err
-	}
-
-	runsDir := filepath.Join(home, ".moat", "runs")
+	runsDir := storage.DefaultBaseDir()
 	entries, err := os.ReadDir(runsDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/cmd/moat/cli/grant_oauth.go
+++ b/cmd/moat/cli/grant_oauth.go
@@ -3,6 +3,7 @@ package cli
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/majorcontext/moat/internal/config"
@@ -121,12 +122,13 @@ func runGrantOAuth(cmd *cobra.Command, args []string) error {
 	}
 
 	if cfg == nil {
+		cfgPath := filepath.Join(oauth.DefaultConfigDir(), name+".yaml")
 		return fmt.Errorf("no OAuth configuration found for %q\n\n"+
 			"Provide one of:\n"+
 			"  1. CLI flags: --auth-url, --token-url, --client-id\n"+
-			"  2. Config file: ~/.moat/oauth/%s.yaml\n"+
+			"  2. Config file: %s\n"+
 			"  3. MCP server URL: --url <mcp-server-url>\n\n"+
-			"See: https://majorcontext.com/moat/guides/mcp", name, name)
+			"See: https://majorcontext.com/moat/guides/mcp", name, cfgPath)
 	}
 
 	// Run the OAuth flow (includes DCR if RegistrationEndpoint is set)

--- a/cmd/moat/cli/grant_providers.go
+++ b/cmd/moat/cli/grant_providers.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"text/tabwriter"
 
+	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/provider"
 	"github.com/spf13/cobra"
 )
@@ -93,7 +95,7 @@ func runGrantProviders(cmd *cobra.Command, args []string) error {
 	}
 	w.Flush()
 
-	fmt.Println("\nCustom providers can be added at ~/.moat/providers/")
+	fmt.Printf("\nCustom providers can be added at %s\n", filepath.Join(config.GlobalConfigDir(), "providers"))
 
 	return nil
 }

--- a/cmd/moat/cli/grant_show_test.go
+++ b/cmd/moat/cli/grant_show_test.go
@@ -107,6 +107,7 @@ func TestShowSSHCredential(t *testing.T) {
 	t.Setenv("MOAT_KEYRING_SERVICE", "moat-test")
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MOAT_HOME", "")
 
 	key, err := credential.DefaultEncryptionKey()
 	if err != nil {
@@ -146,6 +147,7 @@ func TestGrantShowEmptySSHHost(t *testing.T) {
 	t.Setenv("MOAT_KEYRING_SERVICE", "moat-test")
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MOAT_HOME", "")
 
 	cmd := rootCmd
 	cmd.SetArgs([]string{"grant", "show", "ssh:"})
@@ -162,6 +164,7 @@ func TestGrantShowNotFound(t *testing.T) {
 	t.Setenv("MOAT_KEYRING_SERVICE", "moat-test")
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MOAT_HOME", "")
 
 	cmd := rootCmd
 	cmd.SetArgs([]string{"grant", "show", "nonexistent"})
@@ -181,6 +184,7 @@ func TestGrantShowIntegration(t *testing.T) {
 	t.Setenv("MOAT_KEYRING_SERVICE", "moat-test")
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MOAT_HOME", "")
 
 	// Store a credential
 	key, err := credential.DefaultEncryptionKey()

--- a/cmd/moat/cli/grant_test.go
+++ b/cmd/moat/cli/grant_test.go
@@ -33,6 +33,7 @@ func TestGrantMCP(t *testing.T) {
 	// Set up temporary credential store
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MOAT_HOME", "")
 
 	// Run grant command
 	cmd := rootCmd

--- a/cmd/moat/cli/volumes.go
+++ b/cmd/moat/cli/volumes.go
@@ -4,9 +4,11 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -60,12 +62,7 @@ func listVolumes(cmd *cobra.Command, args []string) error {
 }
 
 func listVolumeDirs() error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("getting home directory: %w", err)
-	}
-
-	volumesDir := homeDir + "/.moat/volumes"
+	volumesDir := filepath.Join(config.GlobalConfigDir(), "volumes")
 	agents, err := os.ReadDir(volumesDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -100,12 +97,7 @@ func removeVolumes(cmd *cobra.Command, args []string) error {
 }
 
 func removeVolumeDirs(agentName string) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("getting home directory: %w", err)
-	}
-
-	agentDir := homeDir + "/.moat/volumes/" + agentName
+	agentDir := filepath.Join(config.GlobalConfigDir(), "volumes", agentName)
 	if _, err := os.Stat(agentDir); os.IsNotExist(err) {
 		fmt.Printf("No volumes found for agent %q.\n", agentName)
 		return nil
@@ -135,12 +127,7 @@ func removeVolumeDirs(agentName string) error {
 }
 
 func pruneVolumes(cmd *cobra.Command, args []string) error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("getting home directory: %w", err)
-	}
-
-	volumesDir := homeDir + "/.moat/volumes"
+	volumesDir := filepath.Join(config.GlobalConfigDir(), "volumes")
 	agents, err := os.ReadDir(volumesDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/docs/content/reference/03-environment.md
+++ b/docs/content/reference/03-environment.md
@@ -112,6 +112,21 @@ See [Credential profiles](./04-grants.md#credential-profiles) for details.
 
 Override the default worktree base path (`~/.moat/worktrees/`).
 
+### MOAT_HOME
+
+Override the Moat configuration directory. By default, Moat stores runs, credentials, and daemon state under `~/.moat/`. Set `MOAT_HOME` to an absolute path to relocate everything — the value is used as the complete directory (no `.moat` suffix is appended).
+
+```bash
+export MOAT_HOME=/tmp/moat-test
+```
+
+Primarily useful for:
+
+- Hermetic test runs that must not share a daemon or credential store with the developer's live install.
+- Running two versions of Moat side-by-side, where each version must see only its own state.
+
+`MOAT_HOME` is inherited by spawned daemon processes, so the daemon socket, lock file, and logs all land under the override path. The real `$HOME` is still used for reading third-party state like `~/.claude/` and `~/.config/gh/`.
+
 ### AWS credentials
 
 For AWS SSM secrets, standard AWS environment variables are used:

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -39,43 +39,45 @@ func DefaultGlobalConfig() *GlobalConfig {
 	}
 }
 
-// LoadGlobal reads ~/.moat/config.yaml and applies environment overrides.
+// LoadGlobal reads the moat global config file and applies environment overrides.
+// The config path is <GlobalConfigDir>/config.yaml — by default ~/.moat/config.yaml,
+// or $MOAT_HOME/config.yaml when MOAT_HOME is set.
 func LoadGlobal() (*GlobalConfig, error) {
 	cfg := DefaultGlobalConfig()
 
-	// Try to load from file
-	homeDir, err := os.UserHomeDir()
-	if err == nil {
-		configPath := filepath.Join(homeDir, ".moat", "config.yaml")
-		if data, err := os.ReadFile(configPath); err == nil {
-			_ = yaml.Unmarshal(data, cfg) // Ignore unmarshal errors, use defaults
-		}
-
-		// Validate global mounts: require absolute source paths and read-only mode.
-		var validMounts []MountEntry
-		for i, m := range cfg.Mounts {
-			// Expand ~ in source path
-			if strings.HasPrefix(m.Source, "~/") {
-				m.Source = filepath.Join(homeDir, m.Source[2:])
-			}
-
-			if !filepath.IsAbs(m.Source) {
-				return nil, fmt.Errorf("global mount %d: source %q must be an absolute path (no workspace to resolve relative paths against)", i+1, m.Source)
-			}
-
-			// Enforce read-only
-			m.ReadOnly = true
-			m.Mode = "ro"
-
-			// Excludes not supported on global mounts
-			if len(m.Exclude) > 0 {
-				return nil, fmt.Errorf("global mount %d: excludes are not supported on global mounts", i+1)
-			}
-
-			validMounts = append(validMounts, m)
-		}
-		cfg.Mounts = validMounts
+	configPath := filepath.Join(GlobalConfigDir(), "config.yaml")
+	if data, err := os.ReadFile(configPath); err == nil {
+		_ = yaml.Unmarshal(data, cfg) // Ignore unmarshal errors, use defaults
 	}
+
+	// Tilde expansion in mount sources resolves against the real user home,
+	// not MOAT_HOME — `~/foo` is a user-facing alias for the OS home dir.
+	homeDir, _ := os.UserHomeDir()
+
+	// Validate global mounts: require absolute source paths and read-only mode.
+	var validMounts []MountEntry
+	for i, m := range cfg.Mounts {
+		// Expand ~ in source path
+		if strings.HasPrefix(m.Source, "~/") && homeDir != "" {
+			m.Source = filepath.Join(homeDir, m.Source[2:])
+		}
+
+		if !filepath.IsAbs(m.Source) {
+			return nil, fmt.Errorf("global mount %d: source %q must be an absolute path (no workspace to resolve relative paths against)", i+1, m.Source)
+		}
+
+		// Enforce read-only
+		m.ReadOnly = true
+		m.Mode = "ro"
+
+		// Excludes not supported on global mounts
+		if len(m.Exclude) > 0 {
+			return nil, fmt.Errorf("global mount %d: excludes are not supported on global mounts", i+1)
+		}
+
+		validMounts = append(validMounts, m)
+	}
+	cfg.Mounts = validMounts
 
 	// Apply environment overrides
 	if portStr := os.Getenv("MOAT_PROXY_PORT"); portStr != "" {
@@ -87,8 +89,17 @@ func LoadGlobal() (*GlobalConfig, error) {
 	return cfg, nil
 }
 
-// GlobalConfigDir returns the path to ~/.moat.
+// GlobalConfigDir returns the path to the moat configuration directory.
+//
+// By default this is ~/.moat, but the MOAT_HOME environment variable may
+// override it to an absolute path. MOAT_HOME is the complete moat directory,
+// not a parent containing .moat — set it to e.g. /tmp/moat-test, not /tmp.
+// Primarily used for hermetic test runs and rare multi-version setups where
+// one daemon must not see another's state.
 func GlobalConfigDir() string {
+	if override := os.Getenv("MOAT_HOME"); override != "" {
+		return override
+	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".", ".moat")

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -13,6 +13,7 @@ func TestLoadGlobalConfig(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpHome)
 	defer os.Setenv("HOME", origHome)
+	t.Setenv("MOAT_HOME", "")
 
 	// Create config file
 	configDir := filepath.Join(tmpHome, ".moat")
@@ -40,6 +41,7 @@ func TestLoadGlobalConfigDefaults(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpHome)
 	defer os.Setenv("HOME", origHome)
+	t.Setenv("MOAT_HOME", "")
 
 	cfg, err := LoadGlobal()
 	if err != nil {
@@ -55,6 +57,7 @@ func TestLoadGlobalConfigEnvOverride(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpHome)
 	defer os.Setenv("HOME", origHome)
+	t.Setenv("MOAT_HOME", "")
 
 	os.Setenv("MOAT_PROXY_PORT", "7000")
 	defer os.Unsetenv("MOAT_PROXY_PORT")
@@ -81,6 +84,7 @@ func TestLoadGlobal_DebugConfig(t *testing.T) {
 	origHome := os.Getenv("HOME")
 	os.Setenv("HOME", tmpDir)
 	defer os.Setenv("HOME", origHome)
+	t.Setenv("MOAT_HOME", "")
 
 	// Create .moat directory and move config
 	moatDir := filepath.Join(tmpDir, ".moat")
@@ -100,6 +104,7 @@ func TestLoadGlobal_DebugConfig(t *testing.T) {
 func TestLoadGlobal_Mounts(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
 	os.MkdirAll(moatDir, 0755)
@@ -145,6 +150,7 @@ mounts:
 func TestLoadGlobal_MountsRelativeSourceRejected(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
 	os.MkdirAll(moatDir, 0755)
@@ -168,6 +174,7 @@ mounts:
 func TestLoadGlobal_MountsExcludeRejected(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
 	os.MkdirAll(moatDir, 0755)
@@ -193,6 +200,7 @@ mounts:
 func TestLoadGlobal_MountsTildeExpansion(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
 	os.MkdirAll(moatDir, 0755)
@@ -222,6 +230,7 @@ mounts:
 func TestLoadGlobal_MountsEnforcesReadOnly(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
 	os.MkdirAll(moatDir, 0755)

--- a/internal/credential/keyring/keyring.go
+++ b/internal/credential/keyring/keyring.go
@@ -5,13 +5,15 @@
 //   - Linux: Requires libsecret (GNOME), kwallet (KDE), or pass (CLI)
 //   - Windows: Uses Windows Credential Manager (works out of the box)
 //   - Headless/CI: Automatically falls back to file-based storage at ~/.moat/encryption.key
+//     (or $MOAT_HOME/encryption.key when MOAT_HOME is set)
 //
 // The package attempts to store keys in the system keychain first for better security.
 // If the keychain is unavailable (e.g., in CI, headless servers, or containers),
 // it silently falls back to file-based storage with restricted permissions (0600).
 //
 // Concurrency: All key creation operations are protected by a global file lock
-// (~/.moat/key.lock) to prevent race conditions when multiple processes attempt
+// (~/.moat/key.lock, or $MOAT_HOME/key.lock when MOAT_HOME is set) to prevent race
+// conditions when multiple processes attempt
 // to create a key simultaneously. Both keychain and file backends check for
 // existing keys before writing to avoid overwriting keys created by other processes.
 // On Windows, file locking is a no-op, but Windows Credential Manager is the primary

--- a/internal/credential/keyring/keyring.go
+++ b/internal/credential/keyring/keyring.go
@@ -332,11 +332,17 @@ func getOrCreateKeyWithBackends(primary, fallback Backend) ([]byte, error) {
 	slog.Info("system keychain unavailable, using file-based key storage",
 		"fallback", fallback.Name())
 	if fallbackErr := fallback.Set(key); fallbackErr != nil {
+		// fallback.Name() returns a display string like "file (/path/to/key)",
+		// so extract the raw directory from the concrete backend when possible.
+		dir := "moat key directory"
+		if fb, ok := fallback.(*fileBackend); ok {
+			dir = filepath.Dir(fb.path)
+		}
 		return nil, fmt.Errorf("storing encryption key failed.\n"+
 			"  Keychain (%s): %v\n"+
 			"  File (%s): %v\n"+
 			"Remediation: Ensure %s is writable and check system keychain access settings",
-			primary.Name(), primaryErr, fallback.Name(), fallbackErr, filepath.Dir(fallback.Name()))
+			primary.Name(), primaryErr, fallback.Name(), fallbackErr, dir)
 	}
 
 	// Re-read the key from fallback to ensure we return the actual stored key.

--- a/internal/credential/keyring/keyring.go
+++ b/internal/credential/keyring/keyring.go
@@ -217,6 +217,12 @@ func DefaultKeyFilePath() (string, error) {
 		filename = name + ".key"
 	}
 
+	// MOAT_HOME overrides the default ~/.moat location. Set by tests and
+	// multi-version setups; treated as the complete moat directory.
+	if override := os.Getenv("MOAT_HOME"); override != "" {
+		return filepath.Join(override, filename), nil
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		// UserHomeDir failed - try $HOME directly (Unix).
@@ -243,6 +249,10 @@ func generateKey() ([]byte, error) {
 // This lock is used to serialize all key creation operations across both
 // keychain and file backends, preventing race conditions.
 func globalLockPath() string {
+	// MOAT_HOME overrides the default ~/.moat location (tests, multi-version).
+	if override := os.Getenv("MOAT_HOME"); override != "" {
+		return filepath.Join(override, "key.lock")
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		if envHome := os.Getenv("HOME"); envHome != "" {

--- a/internal/credential/keyring/keyring.go
+++ b/internal/credential/keyring/keyring.go
@@ -250,31 +250,37 @@ func generateKey() ([]byte, error) {
 // globalLockPath returns the path for the global key operation lock file.
 // This lock is used to serialize all key creation operations across both
 // keychain and file backends, preventing race conditions.
-func globalLockPath() string {
+// Mirrors DefaultKeyFilePath's MOAT_HOME-aware resolution and refuses to
+// fall back to os.TempDir when home is unreachable — a stray lock file
+// in /tmp would mask a real misconfiguration and create cross-user
+// synchronization hazards.
+func globalLockPath() (string, error) {
 	// MOAT_HOME overrides the default ~/.moat location (tests, multi-version).
 	if override := os.Getenv("MOAT_HOME"); override != "" {
-		return filepath.Join(override, "key.lock")
+		return filepath.Join(override, "key.lock"), nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		if envHome := os.Getenv("HOME"); envHome != "" {
-			home = envHome
-		} else {
-			home = os.TempDir()
+			return filepath.Join(envHome, ".moat", "key.lock"), nil
 		}
+		return "", fmt.Errorf("%w: set $HOME environment variable or ensure user home is configured", ErrNoHomeDirectory)
 	}
-	return filepath.Join(home, ".moat", "key.lock")
+	return filepath.Join(home, ".moat", "key.lock"), nil
 }
 
 // withGlobalKeyLock executes fn while holding the global key lock.
 // This ensures that only one process at a time can create or modify the encryption key,
 // preventing race conditions between keychain and file backend operations.
 func withGlobalKeyLock(fn func() ([]byte, error)) ([]byte, error) {
-	lockPath := globalLockPath()
+	lockPath, err := globalLockPath()
+	if err != nil {
+		return nil, err
+	}
 
 	// Ensure lock directory exists
-	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
-		return nil, fmt.Errorf("creating lock directory: %w", err)
+	if mkErr := os.MkdirAll(filepath.Dir(lockPath), 0700); mkErr != nil {
+		return nil, fmt.Errorf("creating lock directory: %w", mkErr)
 	}
 
 	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)

--- a/internal/credential/keyring/keyring.go
+++ b/internal/credential/keyring/keyring.go
@@ -327,8 +327,8 @@ func getOrCreateKeyWithBackends(primary, fallback Backend) ([]byte, error) {
 		return nil, fmt.Errorf("storing encryption key failed.\n"+
 			"  Keychain (%s): %v\n"+
 			"  File (%s): %v\n"+
-			"Remediation: Ensure ~/.moat directory is writable and check system keychain access settings",
-			primary.Name(), primaryErr, fallback.Name(), fallbackErr)
+			"Remediation: Ensure %s is writable and check system keychain access settings",
+			primary.Name(), primaryErr, fallback.Name(), fallbackErr, filepath.Dir(fallback.Name()))
 	}
 
 	// Re-read the key from fallback to ensure we return the actual stored key.

--- a/internal/credential/keyring/keyring_test.go
+++ b/internal/credential/keyring/keyring_test.go
@@ -394,6 +394,9 @@ func TestFileBackendTrimsWhitespace(t *testing.T) {
 }
 
 func TestDefaultKeyFilePath(t *testing.T) {
+	// Clear MOAT_HOME so the default ~/.moat/encryption.key path is exercised.
+	t.Setenv("MOAT_HOME", "")
+
 	path, err := DefaultKeyFilePath()
 	if err != nil {
 		t.Fatalf("DefaultKeyFilePath failed: %v", err)
@@ -413,6 +416,21 @@ func TestDefaultKeyFilePath(t *testing.T) {
 	dir := filepath.Dir(path)
 	if filepath.Base(dir) != ".moat" {
 		t.Errorf("path should be in .moat directory, got %s", dir)
+	}
+}
+
+func TestDefaultKeyFilePath_MoatHomeOverride(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv("MOAT_HOME", override)
+
+	path, err := DefaultKeyFilePath()
+	if err != nil {
+		t.Fatalf("DefaultKeyFilePath failed: %v", err)
+	}
+
+	expected := filepath.Join(override, "encryption.key")
+	if path != expected {
+		t.Errorf("DefaultKeyFilePath = %q, want %q", path, expected)
 	}
 }
 

--- a/internal/credential/store.go
+++ b/internal/credential/store.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/credential/keyring"
 	"github.com/majorcontext/moat/internal/log"
 )
@@ -144,16 +145,11 @@ func (s *FileStore) List() ([]Credential, error) {
 var ActiveProfile string
 
 // DefaultStoreDir returns the credential store directory for the active profile.
-// When ActiveProfile is set, returns ~/.moat/credentials/profiles/<name>/.
-// Otherwise returns the default ~/.moat/credentials/.
+// When ActiveProfile is set, returns <moat-home>/credentials/profiles/<name>/.
+// Otherwise returns the default <moat-home>/credentials/. See config.GlobalConfigDir
+// for how MOAT_HOME overrides the default ~/.moat location.
 func DefaultStoreDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		// Fall back to temp directory to avoid dumping credentials in the working directory.
-		log.Warn("could not determine home directory, using temp directory for credentials", "error", err)
-		home = os.TempDir()
-	}
-	base := filepath.Join(home, ".moat", "credentials")
+	base := filepath.Join(config.GlobalConfigDir(), "credentials")
 	if ActiveProfile != "" {
 		return filepath.Join(base, "profiles", ActiveProfile)
 	}
@@ -176,12 +172,7 @@ func ValidateProfile(name string) error {
 // ListProfiles returns the names of all credential profiles.
 // Does not include the default (unscoped) profile.
 func ListProfiles() ([]string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Warn("cannot determine home directory for credential profiles", "error", err)
-		return nil, nil
-	}
-	profilesDir := filepath.Join(home, ".moat", "credentials", "profiles")
+	profilesDir := filepath.Join(config.GlobalConfigDir(), "credentials", "profiles")
 	entries, err := os.ReadDir(profilesDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/credential/store_test.go
+++ b/internal/credential/store_test.go
@@ -119,6 +119,9 @@ func TestNewFileStore_InvalidKeyLength(t *testing.T) {
 }
 
 func TestDefaultStoreDir_NoProfile(t *testing.T) {
+	// Clear MOAT_HOME so the default ~/.moat/credentials path is exercised.
+	t.Setenv("MOAT_HOME", "")
+
 	orig := ActiveProfile
 	ActiveProfile = ""
 	defer func() { ActiveProfile = orig }()
@@ -133,6 +136,9 @@ func TestDefaultStoreDir_NoProfile(t *testing.T) {
 }
 
 func TestDefaultStoreDir_WithProfile(t *testing.T) {
+	// Clear MOAT_HOME so the default ~/.moat/credentials path is exercised.
+	t.Setenv("MOAT_HOME", "")
+
 	orig := ActiveProfile
 	ActiveProfile = "myproject"
 	defer func() { ActiveProfile = orig }()
@@ -226,6 +232,7 @@ func TestListProfiles(t *testing.T) {
 	// Create temp home with profile directories
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	// No profiles dir yet
 	profiles, err := ListProfiles()
@@ -284,6 +291,8 @@ func TestDefaultStoreDir_BackwardCompatibility(t *testing.T) {
 	// When no profile is set, credentials stored in the default directory
 	// must remain accessible. This verifies the zero-value of ActiveProfile
 	// produces the same directory path that a pre-profiles installation uses.
+	t.Setenv("MOAT_HOME", "")
+
 	orig := ActiveProfile
 	defer func() { ActiveProfile = orig }()
 
@@ -457,6 +466,7 @@ func TestListProfiles_IgnoresFiles(t *testing.T) {
 	// ListProfiles should only return directories, not regular files.
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	profilesDir := filepath.Join(tmpHome, ".moat", "credentials", "profiles")
 	os.MkdirAll(filepath.Join(profilesDir, "real-profile"), 0700)
@@ -550,6 +560,8 @@ func TestValidateProfile_SingleChar(t *testing.T) {
 
 func TestDefaultStoreDir_ProfileSubdirectoryStructure(t *testing.T) {
 	// Verify the exact directory structure for profiles.
+	t.Setenv("MOAT_HOME", "")
+
 	orig := ActiveProfile
 	defer func() { ActiveProfile = orig }()
 

--- a/internal/deps/versions/cache.go
+++ b/internal/deps/versions/cache.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/majorcontext/moat/internal/config"
 )
 
 // DefaultCacheTTL is the default time-to-live for cached version resolutions.
@@ -206,15 +208,11 @@ func (c *Cache) saveData(data []byte) error {
 	return os.Rename(tmpFile, c.path)
 }
 
-// DefaultCache returns a cache using the default moat cache directory.
+// DefaultCache returns a cache using the default moat cache directory
+// (<moat-home>/cache/versions.json). See config.GlobalConfigDir for how
+// MOAT_HOME overrides the default ~/.moat location.
 func DefaultCache() *Cache {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		// Fall back to in-memory only
-		return NewCache(DefaultCacheTTL, "")
-	}
-
-	path := filepath.Join(home, ".moat", "cache", "versions.json")
+	path := filepath.Join(config.GlobalConfigDir(), "cache", "versions.json")
 	return NewCache(DefaultCacheTTL, path)
 }
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -76,6 +76,20 @@ func TestMain(m *testing.M) {
 	// isn't available in test containers.
 	os.Setenv("MOAT_SKIP_HOST_CLAUDE_SETTINGS", "1")
 
+	// Isolate tests from the developer's real ~/.moat directory. Without this,
+	// tests share the user's daemon, credential store, run storage, and locks
+	// with any live moat session — which means an older daemon from a previous
+	// install can serve test requests (and fail on missing capabilities), and
+	// the test's cleanup (killTestDaemon) can kill the user's working daemon.
+	// MOAT_HOME is inherited by the spawned daemon subprocess so all state
+	// lands in the same isolated directory.
+	tmpMoatHome, err := os.MkdirTemp("", "moat-e2e-home-*")
+	if err != nil {
+		os.Stderr.WriteString("Failed to create temp MOAT_HOME for E2E tests: " + err.Error() + "\n")
+		os.Exit(1)
+	}
+	os.Setenv("MOAT_HOME", tmpMoatHome)
+
 	// Build the moat binary so the daemon can self-exec.
 	// Test binaries don't have the _daemon cobra command, so
 	// EnsureRunning needs a real moat binary (via MOAT_EXECUTABLE).
@@ -112,6 +126,9 @@ func TestMain(m *testing.M) {
 
 	if tmpBinDir != "" {
 		os.RemoveAll(tmpBinDir)
+	}
+	if tmpMoatHome != "" {
+		os.RemoveAll(tmpMoatHome)
 	}
 
 	os.Exit(code)

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -90,6 +90,15 @@ func TestMain(m *testing.M) {
 	}
 	os.Setenv("MOAT_HOME", tmpMoatHome)
 
+	// Tell the routing proxy to bind an OS-assigned port instead of the
+	// default 8080. MOAT_HOME isolates state but the routing proxy's listen
+	// port is still global: if the developer has a live moat routing proxy
+	// on 8080, the test's fresh proxy cannot bind it. The tests read the
+	// actual port back from the routing proxy lock file (getRoutingProxyPort),
+	// so any port is fine. The daemon's credential proxy (19080 default)
+	// already has its own fallback-to-OS-port logic, so it doesn't need this.
+	os.Setenv("MOAT_PROXY_PORT", "0")
+
 	// Build the moat binary so the daemon can self-exec.
 	// Test binaries don't have the _daemon cobra command, so
 	// EnsureRunning needs a real moat binary (via MOAT_EXECUTABLE).

--- a/internal/providers/aws/endpoint.go
+++ b/internal/providers/aws/endpoint.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	moatconfig "github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/provider"
 	"github.com/majorcontext/moat/internal/ui"
@@ -193,6 +195,7 @@ func (h *EndpointHandler) RoleARN() string {
 // user to diagnose the problem without leaking sensitive details.
 func classifyAWSError(err error, roleARN string) string {
 	msg := err.Error()
+	daemonLog := filepath.Join(moatconfig.GlobalConfigDir(), "debug", "daemon.log")
 
 	switch {
 	case strings.Contains(msg, "AccessDenied"):
@@ -204,7 +207,7 @@ Check that:
   2. Your IAM user/role has sts:AssumeRole permission
 
 Run 'moat grant aws' to reconfigure, or check the daemon log:
-  ~/.moat/debug/daemon.log`, roleARN)
+  %s`, roleARN, daemonLog)
 
 	case strings.Contains(msg, "no EC2 IMDS role found") ||
 		strings.Contains(msg, "failed to refresh cached credentials"):
@@ -234,6 +237,6 @@ Then retry — the daemon will pick up the new credentials automatically.`
 		return "AWS credential error: request canceled or timed out. Retry or check network connectivity."
 
 	default:
-		return "AWS credential error: unexpected error assuming role.\n\nCheck the daemon log for details: ~/.moat/debug/daemon.log"
+		return fmt.Sprintf("AWS credential error: unexpected error assuming role.\n\nCheck the daemon log for details: %s", daemonLog)
 	}
 }

--- a/internal/providers/claude/settings.go
+++ b/internal/providers/claude/settings.go
@@ -21,10 +21,13 @@ type SettingSource string
 
 const (
 	SourceClaudeUser SettingSource = "~/.claude/settings.json"
-	SourceMoatUser   SettingSource = "~/.moat/claude/settings.json"
-	SourceProject    SettingSource = ".claude/settings.json"
-	SourceMoatYAML   SettingSource = "moat.yaml"
-	SourceUnknown    SettingSource = "unknown"
+	// SourceMoatUser is a stable attribution label, not a live path. The
+	// actual file lives at <MOAT_HOME>/claude/settings.json, which defaults
+	// to ~/.moat/claude/settings.json but relocates when MOAT_HOME is set.
+	SourceMoatUser SettingSource = "moat user settings"
+	SourceProject  SettingSource = ".claude/settings.json"
+	SourceMoatYAML SettingSource = "moat.yaml"
+	SourceUnknown  SettingSource = "unknown"
 )
 
 // Settings represents Claude's native settings.json format.

--- a/internal/providers/claude/settings.go
+++ b/internal/providers/claude/settings.go
@@ -414,8 +414,8 @@ func LoadAllSettings(workspacePath string, cfg *config.Config) (*Settings, error
 		}
 		result = MergeSettings(result, claudeUserSettings, SourceClaudeUser)
 
-		// 3. Load moat-specific user defaults from ~/.moat/claude/settings.json
-		moatUserSettingsPath := filepath.Join(homeDir, ".moat", "claude", "settings.json")
+		// 3. Load moat-specific user defaults from <MOAT_HOME>/claude/settings.json
+		moatUserSettingsPath := filepath.Join(config.GlobalConfigDir(), "claude", "settings.json")
 		moatUserSettings, loadErr := LoadSettings(moatUserSettingsPath)
 		if loadErr != nil {
 			return nil, loadErr

--- a/internal/providers/claude/settings_test.go
+++ b/internal/providers/claude/settings_test.go
@@ -366,6 +366,7 @@ func TestLoadAllSettingsSkipHostSettings(t *testing.T) {
 
 	// Redirect HOME so LoadAllSettings would find the host settings.
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("MOAT_HOME", "")
 
 	// Without skip: host settings should be loaded.
 	t.Setenv("MOAT_SKIP_HOST_CLAUDE_SETTINGS", "")
@@ -922,6 +923,7 @@ func TestLoadAllSettingsPreservesMoatUserExtras(t *testing.T) {
 	// Set up fake home with moat-user settings containing unknown fields.
 	fakeHome := t.TempDir()
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("MOAT_HOME", "")
 	t.Setenv("MOAT_SKIP_HOST_CLAUDE_SETTINGS", "")
 
 	moatClaudeDir := filepath.Join(fakeHome, ".moat", "claude")

--- a/internal/providers/configprovider/loader.go
+++ b/internal/providers/configprovider/loader.go
@@ -68,7 +68,7 @@ func loadEmbedded() map[string]ProviderDef {
 	return defs
 }
 
-// loadUserDir loads provider definitions from ~/.moat/providers/.
+// loadUserDir loads provider definitions from <MOAT_HOME>/providers/ (default ~/.moat/providers/).
 // User definitions override embedded defaults with the same name.
 // Returns the set of provider names that came from the user directory.
 func loadUserDir(defs map[string]ProviderDef) map[string]bool {

--- a/internal/providers/configprovider/loader.go
+++ b/internal/providers/configprovider/loader.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/provider"
@@ -73,12 +74,7 @@ func loadEmbedded() map[string]ProviderDef {
 func loadUserDir(defs map[string]ProviderDef) map[string]bool {
 	userNames := make(map[string]bool)
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return userNames
-	}
-
-	userDir := filepath.Join(homeDir, ".moat", "providers")
+	userDir := filepath.Join(config.GlobalConfigDir(), "providers")
 	entries, err := os.ReadDir(userDir)
 	if err != nil {
 		// Directory doesn't exist — normal case

--- a/internal/providers/oauth/config.go
+++ b/internal/providers/oauth/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/majorcontext/moat/internal/config"
 )
 
 // Config holds the OAuth provider configuration for a named grant.
@@ -56,13 +58,11 @@ func requireHTTPS(raw, field string) error {
 	return nil
 }
 
-// DefaultConfigDir returns the default directory for OAuth configs (~/.moat/oauth/).
+// DefaultConfigDir returns the default directory for OAuth configs
+// (<moat-home>/oauth/). See config.GlobalConfigDir for how MOAT_HOME
+// overrides the default ~/.moat location.
 func DefaultConfigDir() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".moat", "oauth")
-	}
-	return filepath.Join(home, ".moat", "oauth")
+	return filepath.Join(config.GlobalConfigDir(), "oauth")
 }
 
 // LoadConfig loads an OAuth config from <dir>/<name>.yaml.

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -582,11 +582,11 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 		}
 	}
 
-	// Add global mounts from ~/.moat/config.yaml.
+	// Add global mounts from <MOAT_HOME>/config.yaml.
 	// These are personal read-only mounts that apply to every run.
 	globalCfg, globalErr := config.LoadGlobal()
 	if globalErr != nil {
-		ui.Warnf("Failed to load global config (~/.moat/config.yaml): %v", globalErr)
+		ui.Warnf("Failed to load global config (%s): %v", filepath.Join(config.GlobalConfigDir(), "config.yaml"), globalErr)
 	} else if len(globalCfg.Mounts) > 0 {
 		for _, gm := range globalCfg.Mounts {
 			mounts = append(mounts, container.MountConfig{

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1218,8 +1218,7 @@ region = %s
 				"keys", len(sshMappings))
 		} else {
 			// Use Unix socket - can be mounted directly
-			homeDir, _ := os.UserHomeDir()
-			sshSocketDir = filepath.Join(homeDir, ".moat", "sockets", r.ID)
+			sshSocketDir = filepath.Join(config.GlobalConfigDir(), "sockets", r.ID)
 			if err := os.MkdirAll(sshSocketDir, 0755); err != nil {
 				upstreamAgent.Close()
 				cleanupDaemonRun()

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -903,6 +903,7 @@ func (s *stubRuntime) Exec(context.Context, string, []string, []byte, io.Writer,
 func TestLoadPersistedRunsCleansStaleRoutes(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	// Set up persisted run metadata on disk
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
@@ -981,6 +982,7 @@ func TestLoadPersistedRunsKeepsRoutesForRunningContainers(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
 	store, err := storage.NewRunStore(baseDir, "run_livebeef1234")
@@ -1043,6 +1045,7 @@ func TestLoadPersistedRunsPreservesStateOnContainerError(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
 	runID := "run_gone12345678"
@@ -1109,6 +1112,7 @@ func TestLoadPersistedRunsPreservesStateOnContainerError(t *testing.T) {
 func TestLoadPersistedRunsDoesNotModifyMetadata(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
 	runID := "run_nodeadbeef12"
@@ -1178,6 +1182,7 @@ func TestLoadPersistedRunsDoesNotModifyMetadata(t *testing.T) {
 func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
 	runID := "run_applerun1234"
@@ -1267,6 +1272,7 @@ func TestLoadPersistedRunsSkipsCrossRuntimeCheck(t *testing.T) {
 func TestLoadPersistedRunsCleansRoutesForPersistedTerminalState(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("MOAT_HOME", "")
 
 	baseDir := filepath.Join(tmpHome, ".moat", "runs")
 	runID := "run_stoppedbeef12"

--- a/internal/run/services.go
+++ b/internal/run/services.go
@@ -217,11 +217,7 @@ func buildServiceConfig(dep deps.Dependency, runID string, userSpec *config.Serv
 	// Resolve cache host path
 	var cacheHostPath string
 	if spec.Service.CachePath != "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return container.ServiceConfig{}, fmt.Errorf("resolving home directory for cache: %w", err)
-		}
-		cacheHostPath = filepath.Join(homeDir, ".moat", "cache", dep.Name)
+		cacheHostPath = filepath.Join(config.GlobalConfigDir(), "cache", dep.Name)
 	}
 
 	var memoryMB int

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/majorcontext/moat/internal/config"
 )
 
 // Metadata holds information about an agent run.
@@ -110,14 +112,10 @@ func (s *RunStore) LoadMetadata() (Metadata, error) {
 }
 
 // DefaultBaseDir returns the default base directory for run storage.
-// This is ~/.moat/runs.
+// This is <GlobalConfigDir>/runs — by default ~/.moat/runs, or $MOAT_HOME/runs
+// when MOAT_HOME is set.
 func DefaultBaseDir() string {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		// Fallback to current directory if home dir cannot be determined
-		return filepath.Join(".", ".moat", "runs")
-	}
-	return filepath.Join(homeDir, ".moat", "runs")
+	return filepath.Join(config.GlobalConfigDir(), "runs")
 }
 
 // ListRunDirs returns all run IDs that have stored metadata.

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -61,6 +61,10 @@ func TestRunStoreDir(t *testing.T) {
 }
 
 func TestDefaultBaseDir(t *testing.T) {
+	// Clear MOAT_HOME so the default ~/.moat/runs path is exercised regardless
+	// of the shell environment.
+	t.Setenv("MOAT_HOME", "")
+
 	baseDir := DefaultBaseDir()
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
@@ -68,6 +72,17 @@ func TestDefaultBaseDir(t *testing.T) {
 	}
 
 	expected := filepath.Join(homeDir, ".moat", "runs")
+	if baseDir != expected {
+		t.Errorf("DefaultBaseDir = %q, want %q", baseDir, expected)
+	}
+}
+
+func TestDefaultBaseDir_MoatHomeOverride(t *testing.T) {
+	override := t.TempDir()
+	t.Setenv("MOAT_HOME", override)
+
+	baseDir := DefaultBaseDir()
+	expected := filepath.Join(override, "runs")
 	if baseDir != expected {
 		t.Errorf("DefaultBaseDir = %q, want %q", baseDir, expected)
 	}

--- a/internal/worktree/repo.go
+++ b/internal/worktree/repo.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/majorcontext/moat/internal/config"
 )
 
 // FindRepoRoot returns the root of the git repository containing dir.
@@ -63,16 +65,13 @@ func ParseRemoteURL(rawURL string) (string, error) {
 }
 
 // BasePath returns the root directory for worktrees.
-// Checks MOAT_WORKTREE_BASE env var, defaults to ~/.moat/worktrees.
+// MOAT_WORKTREE_BASE takes precedence; otherwise worktrees live under the
+// moat state directory (respecting MOAT_HOME via config.GlobalConfigDir).
 func BasePath() string {
 	if base := os.Getenv("MOAT_WORKTREE_BASE"); base != "" {
 		return base
 	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".moat", "worktrees")
-	}
-	return filepath.Join(home, ".moat", "worktrees")
+	return filepath.Join(config.GlobalConfigDir(), "worktrees")
 }
 
 // Path returns the expected path for a worktree given a repo ID and branch.


### PR DESCRIPTION
## Summary

Introduces `MOAT_HOME` as the single override for the moat configuration directory (default `~/.moat`). When set, it replaces `~/.moat` as the root for runs, credentials, daemon socket/lock, keyring key file, per-run SSH sockets, and the routing proxy state.

Third-party state (`~/.claude`, `~/.config/gh`, etc.) still resolves against the real `$HOME` — this is only about **moat-owned** paths.

## Motivation

Two narrow use cases, both rare:

1. **Hermetic e2e tests.** Without isolation, tests share the developer's daemon, credential store, run storage, and lock files with any live moat session. An older daemon from a previous install can serve test requests and fail on missing capabilities; test cleanup (`killTestDaemon`) can kill the user's working daemon. The e2e `TestMain` now creates a temp `MOAT_HOME` so all daemon/proxy/credential state lands in an isolated directory that's deleted on exit.
2. **Running two versions of moat side-by-side**, each with its own state.

## Design

- Single entry point: `config.GlobalConfigDir()` honors `MOAT_HOME` if set, otherwise falls back to `$HOME/.moat`.
- Every moat-owned path lookup routes through it: `storage.DefaultBaseDir`, `credential.DefaultStoreDir`, credential keyring paths, oauth config, deps/versions cache, configprovider loader, `run.manager` SSH socket dir, and CLI commands (audit, doctor, volumes).
- The daemon subprocess inherits `os.Environ()`, so `MOAT_HOME` propagates across the fork.
- Keyring preserves its no-tempdir-fallback security invariant — `MOAT_HOME` is layered as an early return above the existing error chain.
- Tests that pin `HOME` to a tempdir now also clear `MOAT_HOME` (via `t.Setenv`) so a leaked override from the parent environment cannot redirect assertions.

## e2e port isolation

Second commit: the routing proxy defaults to port 8080, a global listen port that is **not** covered by `MOAT_HOME` state isolation. When a developer has a live moat routing proxy on 8080, the e2e test harness's fresh proxy cannot bind it. Setting `MOAT_PROXY_PORT=0` in `TestMain` tells the routing proxy to let the OS pick a free port. Tests already read the actual port from the routing proxy lock file, so whichever port lands is transparent. The daemon's credential proxy (19080 default) already has fallback-to-OS-port logic when its port is taken.

## Test plan

- [x] Unit tests pass on every touched package (config, storage, credential, credential/keyring, providers/oauth, providers/configprovider, deps/versions, run, cmd/moat/cli)
- [x] Unit tests pass with `MOAT_HOME=/tmp/leaked` leaked into the parent environment (no cross-test leakage)
- [x] `make lint` — 0 issues
- [x] Previously-failing e2e endpoint routing tests now pass: `TestEndpointRouteRegistration`, `TestEndpointRoutingBasic`, `TestEndpointRoutingMultiEndpoint`, `TestEndpointRoutingWithTLS`, `TestEndpointRoutingWithGrants`
- [x] New unit tests verify `MOAT_HOME` override for `storage.DefaultBaseDir` and `keyring.DefaultKeyFilePath`
- [x] Docs updated (`docs/content/reference/03-environment.md` — new `### MOAT_HOME` section)