### PR TITLE
fix(proxy): install ip6tables rules to block IPv6 egress bypass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Moat runs AI coding agents in isolated containers with credential injection, net
 
 Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between minor versions. Breaking changes are listed under **Breaking** headings below.
 
+## Unreleased
+
+### Security
+
+- **IPv6 egress firewall** — containers on dual-stack hosts could bypass `network.policy: strict` by using IPv6 addresses (e.g. AAAA DNS records). The firewall now installs ip6tables rules mirroring the existing iptables rules. No user action required; the fix applies automatically on upgrade. If ip6tables is unavailable in the container image, a diagnostic warning is logged. ([#324](https://github.com/majorcontext/moat/pull/324))
+
 ## v0.5.0 — 2026-04-07
 
 v0.5 hardens network isolation and introduces operation-level policy enforcement on MCP tool calls and HTTP traffic. Host traffic is now blocked by default in every network policy mode — including `permissive` — and must be opted into per-port with `network.host`. Keep policy integration adds allow/deny/redact rules for MCP tool calls and REST API requests, with starter packs for common services and an LLM response policy that evaluates `tool_use` blocks before forwarding to the container. The credential-injecting proxy is now also available as a standalone `gatekeeper` binary that runs without the moat runtime. Other additions include multi-credential per host, custom base images, OAuth grants for MCP servers, sandbox-local MCP servers, and global mounts in `~/.moat/config.yaml`.

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -534,12 +534,15 @@ func (r *AppleRuntime) Close() error {
 	return nil
 }
 
-// SetupFirewall configures iptables to block all outbound traffic except to the proxy.
+// SetupFirewall configures iptables and ip6tables to block all outbound traffic
+// except to the proxy, covering both IPv4 and IPv6.
 // The proxyHost parameter is accepted for interface consistency but not used in the
 // iptables rules. This is intentional: the gateway IP can vary between container
 // networks. The security model relies on per-run proxy authentication (cryptographic
 // token in HTTP_PROXY URL) rather than IP filtering. This is more robust than IP-based
 // filtering and prevents unauthorized access even if another service runs on the same port.
+// If ip6tables is not available (minimal images), a warning is emitted to stderr
+// but the setup does not fail — the container may not have IPv6 connectivity.
 func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, proxyHost string, proxyPort int) error {
 	// Validate port range
 	if proxyPort < 1 || proxyPort > 65535 {
@@ -578,7 +581,26 @@ func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, pr
 
 		# Drop all other outbound traffic
 		$IPT -w -A OUTPUT -j DROP
-	`, proxyPort)
+
+		# Mirror rules for IPv6 to prevent bypass via AAAA records.
+		# Prefer ip6tables-legacy on Apple containers for the same nf_tables reason.
+		if command -v ip6tables-legacy >/dev/null 2>&1; then
+			IP6T=ip6tables-legacy
+		elif command -v ip6tables >/dev/null 2>&1; then
+			IP6T=ip6tables
+		else
+			echo "WARN: ip6tables not found - IPv6 traffic will not be firewalled" >&2
+			IP6T=""
+		fi
+		if [ -n "$IP6T" ]; then
+			$IP6T -w -F OUTPUT 2>/dev/null || true
+			$IP6T -w -A OUTPUT -o lo -j ACCEPT
+			$IP6T -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+			$IP6T -w -A OUTPUT -p udp --dport 53 -j ACCEPT
+			$IP6T -w -A OUTPUT -p tcp --dport %d -j ACCEPT
+			$IP6T -w -A OUTPUT -j DROP
+		fi
+	`, proxyPort, proxyPort)
 
 	// Run as root since iptables requires root privileges
 	cmd := exec.CommandContext(ctx, r.containerBin, "exec", "--user", "root", containerID, "sh", "-c", script)

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -584,6 +584,9 @@ func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, pr
 
 		# Mirror rules for IPv6 to prevent bypass via AAAA records.
 		# Prefer ip6tables-legacy on Apple containers for the same nf_tables reason.
+		# The DROP-all rule also blocks ICMPv6 Neighbor Solicitation, which
+		# effectively disables IPv6 for the container — this is intentional;
+		# fully blocked is better than partially open.
 		if command -v ip6tables-legacy >/dev/null 2>&1; then
 			IP6T=ip6tables-legacy
 		elif command -v ip6tables >/dev/null 2>&1; then
@@ -609,6 +612,11 @@ func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, pr
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("firewall setup failed: %w: %s (iptables may not be available)", err, stderr.String())
+	}
+
+	// Surface ip6tables warnings so they appear in moat's diagnostic logs.
+	if strings.Contains(stderr.String(), "WARN: ip6tables not found") {
+		log.Warn("ip6tables not found in container — IPv6 egress is not firewalled", "container", containerID)
 	}
 
 	return nil

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -548,17 +548,26 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 		iptables -w -A OUTPUT -j DROP
 
 		# Mirror rules for IPv6 to prevent bypass via AAAA records.
-		# ip6tables may be absent in minimal images — warn but don't fail,
-		# since the container may not have IPv6 connectivity at all.
-		if command -v ip6tables >/dev/null 2>&1; then
-			ip6tables -w -F OUTPUT 2>/dev/null || true
-			ip6tables -w -A OUTPUT -o lo -j ACCEPT
-			ip6tables -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-			ip6tables -w -A OUTPUT -p udp --dport 53 -j ACCEPT
-			ip6tables -w -A OUTPUT -p tcp --dport %d -j ACCEPT
-			ip6tables -w -A OUTPUT -j DROP
+		# Prefer ip6tables-legacy for the same nf_tables compatibility reason
+		# as the IPv4 path on some container kernels.
+		# The DROP-all rule also blocks ICMPv6 Neighbor Solicitation, which
+		# effectively disables IPv6 for the container — this is intentional;
+		# fully blocked is better than partially open.
+		if command -v ip6tables-legacy >/dev/null 2>&1; then
+			IP6T=ip6tables-legacy
+		elif command -v ip6tables >/dev/null 2>&1; then
+			IP6T=ip6tables
 		else
 			echo "WARN: ip6tables not found - IPv6 traffic will not be firewalled" >&2
+			IP6T=""
+		fi
+		if [ -n "$IP6T" ]; then
+			$IP6T -w -F OUTPUT 2>/dev/null || true
+			$IP6T -w -A OUTPUT -o lo -j ACCEPT
+			$IP6T -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+			$IP6T -w -A OUTPUT -p udp --dport 53 -j ACCEPT
+			$IP6T -w -A OUTPUT -p tcp --dport %d -j ACCEPT
+			$IP6T -w -A OUTPUT -j DROP
 		fi
 	`, proxyPort, proxyPort)
 
@@ -592,6 +601,11 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 
 	if inspect.ExitCode != 0 {
 		return fmt.Errorf("firewall setup failed with exit code %d: %s", inspect.ExitCode, output.String())
+	}
+
+	// Surface ip6tables warnings so they appear in moat's diagnostic logs.
+	if strings.Contains(output.String(), "WARN: ip6tables not found") {
+		log.Warn("ip6tables not found in container — IPv6 egress is not firewalled", "container", containerID)
 	}
 
 	return nil

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -495,13 +495,16 @@ func (r *DockerRuntime) gvisorAvailable() bool {
 	return r.gvisorAvail
 }
 
-// SetupFirewall configures iptables to block all outbound traffic except to the proxy.
+// SetupFirewall configures iptables and ip6tables to block all outbound traffic
+// except to the proxy, covering both IPv4 and IPv6.
 // The proxyHost parameter is accepted for interface consistency but not used in the
 // iptables rules. This is intentional: host.docker.internal resolves to a dynamic IP
 // that varies per Docker installation, and resolving it inside the container would
 // add complexity. The security model relies on the proxy port being unique (randomly
 // assigned per-run) rather than IP filtering. Combined with the proxy's authentication
 // for Apple containers, this provides sufficient protection.
+// If ip6tables is not available (minimal images), a warning is emitted to stderr
+// but the setup does not fail — the container may not have IPv6 connectivity.
 func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, proxyHost string, proxyPort int) error {
 	// Validate port range
 	if proxyPort < 1 || proxyPort > 65535 {
@@ -543,7 +546,21 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 
 		# Drop all other outbound traffic
 		iptables -w -A OUTPUT -j DROP
-	`, proxyPort)
+
+		# Mirror rules for IPv6 to prevent bypass via AAAA records.
+		# ip6tables may be absent in minimal images — warn but don't fail,
+		# since the container may not have IPv6 connectivity at all.
+		if command -v ip6tables >/dev/null 2>&1; then
+			ip6tables -w -F OUTPUT 2>/dev/null || true
+			ip6tables -w -A OUTPUT -o lo -j ACCEPT
+			ip6tables -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+			ip6tables -w -A OUTPUT -p udp --dport 53 -j ACCEPT
+			ip6tables -w -A OUTPUT -p tcp --dport %d -j ACCEPT
+			ip6tables -w -A OUTPUT -j DROP
+		else
+			echo "WARN: ip6tables not found - IPv6 traffic will not be firewalled" >&2
+		fi
+	`, proxyPort, proxyPort)
 
 	execConfig := container.ExecOptions{
 		Cmd:          []string{"sh", "-c", script},

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -548,8 +548,8 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 		iptables -w -A OUTPUT -j DROP
 
 		# Mirror rules for IPv6 to prevent bypass via AAAA records.
-		# Prefer ip6tables-legacy for the same nf_tables compatibility reason
-		# as the IPv4 path on some container kernels.
+		# Prefer ip6tables-legacy for nf_tables compatibility on some
+		# container kernels that lack nf_tables modules.
 		# The DROP-all rule also blocks ICMPv6 Neighbor Solicitation, which
 		# effectively disables IPv6 for the container — this is intentional;
 		# fully blocked is better than partially open.

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -102,10 +102,10 @@ type Runtime interface {
 	// Close releases runtime resources.
 	Close() error
 
-	// SetupFirewall configures iptables to only allow traffic to the proxy.
+	// SetupFirewall configures iptables and ip6tables to only allow traffic to the proxy.
 	// proxyHost is the address the container uses to reach the proxy (e.g., "host.docker.internal").
 	// proxyPort is the proxy's port number.
-	// This blocks all other outbound traffic, forcing everything through the proxy.
+	// This blocks all other outbound IPv4 and IPv6 traffic, forcing everything through the proxy.
 	SetupFirewall(ctx context.Context, id string, proxyHost string, proxyPort int) error
 
 	// ListImages returns all moat-managed images.


### PR DESCRIPTION
## Summary

- Mirror all iptables OUTPUT chain rules with ip6tables equivalents in both Docker and Apple container runtimes
- Without this, containers on dual-stack hosts could bypass `network.policy: strict` by resolving AAAA records and using IPv6 addresses
- ip6tables is best-effort: if the binary is absent (minimal images), a warning is emitted but setup succeeds since the container likely has no IPv6 connectivity
- On Apple containers, `ip6tables-legacy` is preferred for nf_tables kernel compatibility, matching the IPv4 path

## Test plan

- [ ] `go build ./...` passes
- [ ] `make lint` passes (0 issues)
- [ ] Unit tests pass (`go test -race ./internal/container/`)
- [ ] E2E: `moat run` with `network.policy: strict` on a dual-stack Docker host blocks `curl -6 https://example.com`
- [ ] E2E: Verify warning appears in container stderr when ip6tables is not installed

Closes #317