### PR TITLE
fix(proxy): prevent ip6tables hang on hosts without IPv6 kernel module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 - **IPv6 egress firewall** — containers on dual-stack hosts could bypass `network.policy: strict` by using IPv6 addresses (e.g. AAAA DNS records). The firewall now installs ip6tables rules mirroring the existing iptables rules. No user action required; the fix applies automatically on upgrade. If ip6tables is unavailable in the container image, a diagnostic warning is logged. ([#324](https://github.com/majorcontext/moat/pull/324))
 
+### Fixed
+
+- Fix ip6tables hanging indefinitely on hosts without the `ip6_tables` kernel module — previously, `ip6tables -w` (wait forever) blocked the firewall setup, hanging the container start and E2E tests on CI. Now uses a 5-second timeout and treats ip6tables failure as non-fatal with partial-rule cleanup. ([#325](https://github.com/majorcontext/moat/pull/325))
+
 ## v0.5.0 — 2026-04-07
 
 v0.5 hardens network isolation and introduces operation-level policy enforcement on MCP tool calls and HTTP traffic. Host traffic is now blocked by default in every network policy mode — including `permissive` — and must be opted into per-port with `network.host`. Keep policy integration adds allow/deny/redact rules for MCP tool calls and REST API requests, with starter packs for common services and an LLM response policy that evaluates `tool_use` blocks before forwarding to the container. The credential-injecting proxy is now also available as a standalone `gatekeeper` binary that runs without the moat runtime. Other additions include multi-credential per host, custom base images, OAuth grants for MCP servers, sandbox-local MCP servers, and global mounts in `~/.moat/config.yaml`.

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -607,6 +607,9 @@ func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, pr
 			   $IP6T -w 5 -A OUTPUT -j DROP; then
 				: # IPv6 firewall installed
 			else
+				# Flush partial rules so the container isn't left with an
+				# incomplete policy (e.g. ACCEPT lo without a final DROP).
+				$IP6T -w 5 -F OUTPUT 2>/dev/null || true
 				echo "WARN: ip6tables rules failed — IPv6 traffic will not be firewalled" >&2
 			fi
 		fi

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -596,12 +596,19 @@ func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, pr
 			IP6T=""
 		fi
 		if [ -n "$IP6T" ]; then
-			$IP6T -w -F OUTPUT 2>/dev/null || true
-			$IP6T -w -A OUTPUT -o lo -j ACCEPT
-			$IP6T -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-			$IP6T -w -A OUTPUT -p udp --dport 53 -j ACCEPT
-			$IP6T -w -A OUTPUT -p tcp --dport %d -j ACCEPT
-			$IP6T -w -A OUTPUT -j DROP
+			# Use -w 5 (5-second timeout) instead of bare -w (wait forever).
+			# On some CI hosts the ip6_tables kernel module is absent, causing
+			# ip6tables to block indefinitely on the xtables lock.
+			if $IP6T -w 5 -F OUTPUT 2>/dev/null &&
+			   $IP6T -w 5 -A OUTPUT -o lo -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -p udp --dport 53 -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -p tcp --dport %d -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -j DROP; then
+				: # IPv6 firewall installed
+			else
+				echo "WARN: ip6tables rules failed — IPv6 traffic will not be firewalled" >&2
+			fi
 		fi
 	`, proxyPort, proxyPort)
 
@@ -615,8 +622,8 @@ func (r *AppleRuntime) SetupFirewall(ctx context.Context, containerID string, pr
 	}
 
 	// Surface ip6tables warnings so they appear in moat's diagnostic logs.
-	if strings.Contains(stderr.String(), "WARN: ip6tables not found") {
-		log.Warn("ip6tables not found in container — IPv6 egress is not firewalled", "container", containerID)
+	if strings.Contains(stderr.String(), "WARN: ip6tables") {
+		log.Warn("ip6tables unavailable in container — IPv6 egress is not firewalled", "container", containerID)
 	}
 
 	return nil

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -562,12 +562,19 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 			IP6T=""
 		fi
 		if [ -n "$IP6T" ]; then
-			$IP6T -w -F OUTPUT 2>/dev/null || true
-			$IP6T -w -A OUTPUT -o lo -j ACCEPT
-			$IP6T -w -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-			$IP6T -w -A OUTPUT -p udp --dport 53 -j ACCEPT
-			$IP6T -w -A OUTPUT -p tcp --dport %d -j ACCEPT
-			$IP6T -w -A OUTPUT -j DROP
+			# Use -w 5 (5-second timeout) instead of bare -w (wait forever).
+			# On some CI hosts the ip6_tables kernel module is absent, causing
+			# ip6tables to block indefinitely on the xtables lock.
+			if $IP6T -w 5 -F OUTPUT 2>/dev/null &&
+			   $IP6T -w 5 -A OUTPUT -o lo -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -p udp --dport 53 -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -p tcp --dport %d -j ACCEPT &&
+			   $IP6T -w 5 -A OUTPUT -j DROP; then
+				: # IPv6 firewall installed
+			else
+				echo "WARN: ip6tables rules failed — IPv6 traffic will not be firewalled" >&2
+			fi
 		fi
 	`, proxyPort, proxyPort)
 
@@ -604,8 +611,8 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 	}
 
 	// Surface ip6tables warnings so they appear in moat's diagnostic logs.
-	if strings.Contains(output.String(), "WARN: ip6tables not found") {
-		log.Warn("ip6tables not found in container — IPv6 egress is not firewalled", "container", containerID)
+	if strings.Contains(output.String(), "WARN: ip6tables") {
+		log.Warn("ip6tables unavailable in container — IPv6 egress is not firewalled", "container", containerID)
 	}
 
 	return nil

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -573,6 +573,9 @@ func (r *DockerRuntime) SetupFirewall(ctx context.Context, containerID string, p
 			   $IP6T -w 5 -A OUTPUT -j DROP; then
 				: # IPv6 firewall installed
 			else
+				# Flush partial rules so the container isn't left with an
+				# incomplete policy (e.g. ACCEPT lo without a final DROP).
+				$IP6T -w 5 -F OUTPUT 2>/dev/null || true
 				echo "WARN: ip6tables rules failed — IPv6 traffic will not be firewalled" >&2
 			fi
 		fi


### PR DESCRIPTION
## Summary

- Use `ip6tables -w 5` (5-second timeout) instead of bare `-w` (wait forever) in both Docker and Apple container firewall setup
- On CI hosts where the `ip6_tables` kernel module is absent, `ip6tables -w` blocks indefinitely on the xtables lock, hanging the entire E2E test suite
- If ip6tables rules fail (timeout or missing module), emit a warning and continue — the IPv4 firewall is still enforced
- Broadens the warning pattern match to catch both "not found" and "rules failed" variants

## Test plan

- [ ] `go build ./...` passes
- [ ] `make lint` passes
- [ ] E2E tests no longer hang on CI (this was the root cause of the E2E hang in #324's merge CI run)

Follow-up to #324.