### PR TITLE
fix(ci): prevent E2E test hang on CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     name: E2E Tests
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -100,8 +101,16 @@ jobs:
           docker pull golang:1.22
           docker pull ubuntu:22.04
 
+      - name: Pre-build moat binary
+        run: |
+          # Build the moat binary ahead of time so TestMain doesn't need to
+          # compile it (which produces no output and can appear to hang).
+          mkdir -p /tmp/moat-e2e-bin
+          go build -o /tmp/moat-e2e-bin/moat github.com/majorcontext/moat/cmd/moat
+          echo "MOAT_EXECUTABLE=/tmp/moat-e2e-bin/moat" >> "$GITHUB_ENV"
+
       - name: Run E2E tests
-        run: go test -tags=e2e -timeout=15m -p=1 ./internal/e2e/
+        run: go test -tags=e2e -v -timeout=15m -p=1 ./internal/e2e/
         env:
           MOAT_DISABLE_BUILDKIT: "1"
           MOAT_NO_SANDBOX: "1"

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -32,6 +32,7 @@ package e2e
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -102,8 +103,10 @@ func TestMain(m *testing.M) {
 	// Build the moat binary so the daemon can self-exec.
 	// Test binaries don't have the _daemon cobra command, so
 	// EnsureRunning needs a real moat binary (via MOAT_EXECUTABLE).
+	// In CI, the binary is pre-built and MOAT_EXECUTABLE is set to skip this.
 	var tmpBinDir string
 	if os.Getenv("MOAT_EXECUTABLE") == "" {
+		fmt.Fprintln(os.Stderr, "e2e: building moat binary...")
 		var err error
 		tmpBinDir, err = os.MkdirTemp("", "moat-e2e-bin-*")
 		if err != nil {
@@ -119,6 +122,9 @@ func TestMain(m *testing.M) {
 			os.Exit(1)
 		}
 		os.Setenv("MOAT_EXECUTABLE", moatBin)
+		fmt.Fprintln(os.Stderr, "e2e: moat binary built")
+	} else {
+		fmt.Fprintf(os.Stderr, "e2e: using pre-built moat binary: %s\n", os.Getenv("MOAT_EXECUTABLE"))
 	}
 
 	// Kill any pre-existing daemon so the tests spawn a fresh one from the
@@ -127,6 +133,7 @@ func TestMain(m *testing.M) {
 	// confusing failures when the daemon API surface has changed.
 	killTestDaemon()
 
+	fmt.Fprintln(os.Stderr, "e2e: starting tests")
 	code := m.Run()
 
 	// Kill any daemon process spawned during the test run.


### PR DESCRIPTION
## Summary

- Pre-build the moat binary as a separate CI step (`Pre-build moat binary`) so `TestMain` skips its internal `go build`, which produces no stdout and can appear to hang indefinitely
- Add `-v` to `go test` so test output streams in real time instead of being buffered until completion
- Add `timeout-minutes: 30` to the E2E job so it doesn't run for 6 hours (GitHub Actions default) when something hangs
- Add progress messages to `TestMain` for debuggability

The E2E tests have been hanging on every CI run since April 15 — the "Run E2E tests" step produces zero output for ~2 hours until GitHub Actions kills the job. This affects `main` and all branches.

## Test plan

- [x] E2E test binary compiles cleanly
- [x] Lint clean
- [ ] CI run on this PR should show real-time test output and either pass or fail with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)