### PR TITLE
fix(ci): pre-compile E2E test binary and capture output on timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,16 +101,28 @@ jobs:
           docker pull golang:1.22
           docker pull ubuntu:22.04
 
-      - name: Pre-build moat binary
+      - name: Pre-build moat binary and test binary
         run: |
           # Build the moat binary ahead of time so TestMain doesn't need to
           # compile it (which produces no output and can appear to hang).
           mkdir -p /tmp/moat-e2e-bin
           go build -o /tmp/moat-e2e-bin/moat github.com/majorcontext/moat/cmd/moat
           echo "MOAT_EXECUTABLE=/tmp/moat-e2e-bin/moat" >> "$GITHUB_ENV"
+          # Pre-compile the test binary so `go test` doesn't hang during
+          # compilation (which produces no output and bypasses -timeout).
+          go test -tags=e2e -c -o /tmp/moat-e2e-bin/e2e.test ./internal/e2e/
 
       - name: Run E2E tests
-        run: go test -tags=e2e -v -timeout=15m -p=1 ./internal/e2e/
+        run: |
+          /tmp/moat-e2e-bin/e2e.test -test.v -test.timeout=15m 2>&1 | tee /tmp/e2e-output.log
         env:
           MOAT_DISABLE_BUILDKIT: "1"
           MOAT_NO_SANDBOX: "1"
+
+      - name: Upload E2E test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-logs
+          path: /tmp/e2e-output.log
+          retention-days: 7


### PR DESCRIPTION
## Summary

- Pre-compile the E2E test binary alongside the moat binary so `go test` doesn't hang during compilation (which produces no output and bypasses `-timeout`)
- Run the pre-compiled binary directly instead of through `go test`
- Pipe output through `tee` to capture to a file
- Upload the output file as an artifact with `if: always()` so we get diagnostic output even when the job is killed by `timeout-minutes`

## Context

CI run on main after merging #327 and #328 showed E2E tests still hanging with zero diagnostic output. The `-v` flag from #328 wasn't helping because GitHub Actions discards output from steps killed by `timeout-minutes`. This PR ensures we always get test output to identify which specific test is hanging.

## Test plan

- [ ] CI E2E job captures output to artifact even if tests time out
- [ ] Artifact shows which test is running when the hang occurs
- [ ] Pre-build step compiles both moat binary and test binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)