### PR TITLE
ci(e2e): add step-level timeout so artifact upload runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
     name: E2E Tests
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
 
@@ -113,6 +113,7 @@ jobs:
           go test -tags=e2e -c -o /tmp/moat-e2e-bin/e2e.test ./internal/e2e/
 
       - name: Run E2E tests
+        timeout-minutes: 20
         run: |
           /tmp/moat-e2e-bin/e2e.test -test.v -test.timeout=15m 2>&1 | tee /tmp/e2e-output.log
         env:


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 20` at the **step** level for "Run E2E tests" so the job continues after test kill
- Raise job-level timeout from 30 to 45 minutes so the upload step has time to run
- Fixes the issue where `timeout-minutes` on the job kills everything without running `if: always()` steps

The previous CI run (24589052781) confirmed that job-level `timeout-minutes` completely discards output and skips `if: always()` steps. The `tee` + artifact upload approach from #329 is correct, it just needs the step to be killed independently of the job.

**Timeout layering:**
- `15m` — Go `-test.timeout` panics with goroutine stacks (ideal — most diagnostic output)
- `20m` — Step timeout kills the process, job continues to upload step  
- `45m` — Job timeout as final safety net

## Test plan

- [ ] CI E2E job times out as expected
- [ ] `e2e-test-logs` artifact is uploaded after the test step is killed
- [ ] Artifact contains test output showing which test is hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)