### PR TITLE
fix: correct error message to suggest command that actually exists

### DIFF
--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -918,7 +918,7 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 				}
 			}
 			if !hasKeepPolicy {
-				return nil, fmt.Errorf("proxy daemon does not support Keep policies (missing 'keep-policy' capability); run 'moat proxy restart' to upgrade")
+				return nil, fmt.Errorf("proxy daemon does not support Keep policies (missing 'keep-policy' capability); run 'moat proxy stop' to upgrade (the next command will start a fresh daemon)")
 			}
 		}
 
@@ -936,7 +936,7 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 			}
 		}
 		if !hasHostGatewayV2 {
-			return nil, fmt.Errorf("proxy daemon is too old for this CLI (missing 'host-gateway-v2' capability); run 'moat proxy restart' to upgrade")
+			return nil, fmt.Errorf("proxy daemon is too old for this CLI (missing 'host-gateway-v2' capability); run 'moat proxy stop' to upgrade (the next command will start a fresh daemon)")
 		}
 
 		// Get proxy host address — needed for registration, proxy URL, and firewall.


### PR DESCRIPTION
## Summary
- Two capability-check error paths in `internal/run/manager.go` told users to run `moat proxy restart`, but that subcommand does not exist — `cmd/moat/cli/proxy.go` only registers `start`, `stop`, and `status`. When cobra receives an unknown subcommand and the parent has `RunE` set, it falls through to status and silently does nothing, leaving the user stuck with no actionable path.
- Point both messages at `moat proxy stop` and note that the next command will spawn a fresh daemon, which is the actual working sequence.

## Test plan
- [x] `go build ./...` succeeds
- [x] Trigger a capability mismatch (e.g. run an older daemon against a newer CLI) and confirm the new error message shows
- [x] Run `moat proxy stop` and confirm the next `moat run` spawns a fresh daemon that passes the capability check