### PR TITLE
fix(proxy): reach host from custom networks on Docker Desktop

### DIFF
--- a/internal/deps/scripts/moat-init.sh
+++ b/internal/deps/scripts/moat-init.sh
@@ -11,31 +11,79 @@
 set -e
 
 # Configuration constants
-SSH_SOCKET_WAIT_ITERS=20     # iterations * 0.1s = 2 second timeout for SSH socket
-DIND_TIMEOUT_SECONDS=30      # timeout for Docker daemon startup in dind mode
+SSH_SOCKET_WAIT_ITERS=20        # iterations * 0.1s = 2 second timeout for SSH socket
+DIND_TIMEOUT_SECONDS=30         # timeout for Docker daemon startup in dind mode
+MOAT_DNS_WAIT_ITERS=25          # iterations * 0.2s = 5 second timeout for container DNS
 
 # Synthetic Host Entries
-# When MOAT_EXTRA_HOSTS is set, append space-separated "name:ip" pairs to
-# /etc/hosts. Used on runtimes (Apple containers) that lack a --add-host flag
-# at container-create time. Must run before any process that resolves these
-# hostnames (e.g. the user's command, which sees MOAT_HOST_GATEWAY).
+# When MOAT_EXTRA_HOSTS is set, append space-separated "name:target" pairs to
+# /etc/hosts. Used on runtimes where the host side cannot supply a usable IP
+# via --add-host: Apple containers (no such flag) and Docker Desktop on
+# macOS/Windows (host-gateway resolves to the docker0 bridge, which is
+# unreachable from custom bridge networks created for services).
 #
-# Fail-closed: if we cannot write to /etc/hosts (non-root container without
-# CAP_DAC_OVERRIDE), we must not start the user command. Silent failure would
-# leave moat-proxy/moat-host unresolvable, HTTP_PROXY broken, and network
-# policy silently degraded. The clear error here is preferable to a seemingly
+# target may be a literal IP (e.g. "192.168.64.1") or a hostname prefixed
+# with "@" (e.g. "@host.docker.internal"). The "@" form tells us to resolve
+# the hostname via the container's DNS at startup — this is how we reach
+# Docker Desktop's host, which is only addressable by the container-only
+# DNS name host.docker.internal. DNS resolution is retried briefly because
+# Docker Desktop's embedded DNS may not be ready the instant the ENTRYPOINT
+# runs.
+#
+# Must run before any process that resolves these hostnames (e.g. the user's
+# command, which sees MOAT_HOST_GATEWAY).
+#
+# Fail-closed: if we cannot resolve the target or write to /etc/hosts, we
+# must not start the user command. Silent failure would leave
+# moat-proxy/moat-host unresolvable, HTTP_PROXY broken, and network policy
+# silently degraded. The clear error here is preferable to a seemingly
 # working container that bypasses policy.
 if [ -n "$MOAT_EXTRA_HOSTS" ]; then
   for entry in $MOAT_EXTRA_HOSTS; do
     name=${entry%%:*}
-    ip=${entry#*:}
-    if [ -n "$name" ] && [ -n "$ip" ] && [ "$name" != "$ip" ]; then
-      if ! printf '%s %s\n' "$ip" "$name" >> /etc/hosts 2>/dev/null; then
-        echo "Error: moat-init.sh cannot write $name to /etc/hosts (required for moat proxy resolution)." >&2
-        echo "The container user (UID $(id -u)) lacks permission to modify /etc/hosts." >&2
-        echo "Rebuild the base image so moat-init.sh runs as root, or grant CAP_DAC_OVERRIDE." >&2
-        exit 1
-      fi
+    target=${entry#*:}
+    if [ -z "$name" ] || [ -z "$target" ] || [ "$name" = "$target" ]; then
+      continue
+    fi
+
+    case "$target" in
+      @*)
+        hostname=${target#@}
+        ip=""
+        i=0
+        while [ "$i" -lt "$MOAT_DNS_WAIT_ITERS" ]; do
+          # Prefer IPv4 because the host is reached via Docker Desktop's
+          # IPv4-only mapping; an IPv6 entry like "::1" would resolve to the
+          # container's own loopback and silently not reach the host. Fall
+          # back to any address if the name has only IPv6 records.
+          candidate=$(getent ahostsv4 "$hostname" 2>/dev/null | awk '{print $1; exit}')
+          if [ -z "$candidate" ]; then
+            candidate=$(getent hosts "$hostname" 2>/dev/null | awk '{print $1; exit}')
+          fi
+          if [ -n "$candidate" ]; then
+            ip="$candidate"
+            break
+          fi
+          sleep 0.2
+          i=$((i + 1))
+        done
+        if [ -z "$ip" ]; then
+          echo "Error: moat-init.sh could not resolve '$hostname' for /etc/hosts entry '$name'." >&2
+          echo "The container's DNS should answer this name. On Docker Desktop, verify that" >&2
+          echo "'getent hosts $hostname' works inside this container." >&2
+          exit 1
+        fi
+        ;;
+      *)
+        ip=$target
+        ;;
+    esac
+
+    if ! printf '%s %s\n' "$ip" "$name" >> /etc/hosts 2>/dev/null; then
+      echo "Error: moat-init.sh cannot write $name to /etc/hosts (required for moat proxy resolution)." >&2
+      echo "The container user (UID $(id -u)) lacks permission to modify /etc/hosts." >&2
+      echo "Rebuild the base image so moat-init.sh runs as root, or grant CAP_DAC_OVERRIDE." >&2
+      exit 1
     fi
   done
 fi

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -3977,6 +3977,16 @@ func ensureCACertOnlyDir(caDir, certOnlyDir string) error {
 //     sentinel. Docker's daemon substitutes the host's gateway IP at
 //     container-create time, and Linux's routing reaches it from any bridge.
 //
+//     NOTE: "Docker on Linux" here means native Docker Engine. Docker
+//     Desktop for Linux runs Docker Engine inside a VM and exhibits the
+//     same docker0-unreachable-from-custom-network behavior as Docker
+//     Desktop on macOS/Windows — those users would still hit the bug this
+//     strategy exists to avoid. Distinguishing Docker Desktop from native
+//     Engine requires a `docker info` probe (Docker Desktop reports
+//     OperatingSystem "Docker Desktop") or a host-side resolvability
+//     check for host.docker.internal; both are out of scope here. Known
+//     gap — tracked as a follow-up.
+//
 //   - Docker Desktop on macOS / Windows — entries via MOAT_EXTRA_HOSTS,
 //     processed by moat-init.sh at container start. --add-host:host-gateway
 //     resolves to the docker0 bridge gateway (e.g. 172.17.0.1), which is

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -981,8 +981,6 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 		}
 
 		// Build proxy environment using synthetic hostnames on all runtimes.
-		// Docker resolves them via --add-host; Apple via moat-init.sh writing
-		// to /etc/hosts (MOAT_EXTRA_HOSTS, set below).
 		// Host-network mode is used on Docker Linux when no ports need publishing.
 		// In that mode, the container shares the host loopback, so localhost
 		// must NOT be in NO_PROXY (otherwise it bypasses network.host enforcement).
@@ -990,10 +988,15 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 		proxyEnv = buildProxyEnv(regResp.AuthToken, regResp.ProxyPort, isHostNet)
 		proxyHost := syntheticProxyHost + ":" + strconv.Itoa(regResp.ProxyPort)
 
-		// On runtimes without --add-host (Apple), pass the host map via env so
-		// moat-init.sh can write /etc/hosts before the user command runs.
-		if m.defaultRuntime().Type() != container.RuntimeDocker {
-			proxyEnv = append(proxyEnv, "MOAT_EXTRA_HOSTS="+syntheticProxyHost+":"+hostAddr+" "+syntheticHostGateway+":"+hostAddr)
+		// Docker-on-Linux resolves the synthetic hostnames via --add-host (set
+		// further down). Every other runtime (Apple; Docker Desktop on macOS
+		// and Windows) cannot use --add-host for this: Apple has no such flag,
+		// and on Docker Desktop --add-host:host-gateway resolves to the
+		// docker0 bridge IP which is unreachable from a custom bridge network
+		// (created whenever moat.yaml defines services). For those runtimes
+		// we pass the host map via env so moat-init.sh writes /etc/hosts.
+		if _, env := synthHostStrategy(m.defaultRuntime().Type(), goruntime.GOOS, hostAddr); env != "" {
+			proxyEnv = append(proxyEnv, "MOAT_EXTRA_HOSTS="+env)
 		}
 
 		// Mount CA certificate (not the private key) for container to trust.
@@ -1300,16 +1303,19 @@ region = %s
 				extraHosts = []string{"host.docker.internal:host-gateway"}
 			}
 		}
-		// Add synthetic hostnames that resolve to the host-gateway IP, only on
-		// runtimes that support --add-host. Apple's container CLI has no
-		// equivalent flag, so on Apple we configured the proxy URL above to use
-		// the actual gateway IP instead.
+		// Add synthetic hostnames to --add-host on runtimes where Docker's
+		// "host-gateway" substitution produces a reachable IP (Docker on
+		// Linux). Apple has no --add-host equivalent, and Docker Desktop on
+		// macOS/Windows must not use this path — "host-gateway" resolves to
+		// the docker0 bridge gateway, which is unreachable from containers on
+		// custom networks (those created by `services:`). Those runtimes
+		// instead rely on MOAT_EXTRA_HOSTS written by moat-init.sh (see above).
+		//
 		// "moat-proxy" is used for proxy traffic (in NO_PROXY).
 		// "moat-host" is used for host service traffic (NOT in NO_PROXY,
 		// so it flows through the proxy for network policy enforcement).
-		if m.defaultRuntime().Type() == container.RuntimeDocker {
-			extraHosts = append(extraHosts, syntheticProxyHost+":host-gateway", syntheticHostGateway+":host-gateway")
-		}
+		synthHosts, _ := synthHostStrategy(m.defaultRuntime().Type(), goruntime.GOOS, hostAddr)
+		extraHosts = append(extraHosts, synthHosts...)
 	}
 
 	// Add config env vars, filtering out proxy-related variables that would
@@ -3957,6 +3963,51 @@ func ensureCACertOnlyDir(caDir, certOnlyDir string) error {
 	}
 
 	return nil
+}
+
+// synthHostStrategy decides how the container learns the IP addresses for
+// the synthetic moat-proxy and moat-host hostnames. It returns the entries
+// to append to Docker's --add-host flag and, separately, the value for the
+// MOAT_EXTRA_HOSTS env var (empty when not used). Exactly one of the two is
+// non-empty per call.
+//
+// Strategy by runtime + OS:
+//
+//   - Docker on Linux — entries via --add-host with the "host-gateway"
+//     sentinel. Docker's daemon substitutes the host's gateway IP at
+//     container-create time, and Linux's routing reaches it from any bridge.
+//
+//   - Docker Desktop on macOS / Windows — entries via MOAT_EXTRA_HOSTS,
+//     processed by moat-init.sh at container start. --add-host:host-gateway
+//     resolves to the docker0 bridge gateway (e.g. 172.17.0.1), which is
+//     unreachable from a custom bridge network (one is created whenever the
+//     moat.yaml defines `services:`). host.docker.internal is the correct
+//     target, but it is a container-only DNS name — the host side cannot
+//     resolve it, so --add-host cannot consume it. We pass the name through
+//     with an "@" prefix; moat-init.sh resolves it inside the container
+//     where Docker Desktop's embedded DNS answers.
+//
+//   - Apple runtime — entries via MOAT_EXTRA_HOSTS. Apple's container CLI
+//     has no --add-host equivalent, and Apple's GetHostAddress() already
+//     returns a literal IP, so the env carries it directly (no sentinel).
+//
+// hostAddr is whatever the runtime's GetHostAddress() returns; it may be an
+// IP or a hostname. If it's an IP we emit it literally; if it's a hostname
+// we prefix it with "@" so moat-init.sh knows to resolve it.
+func synthHostStrategy(runtimeType container.RuntimeType, goos, hostAddr string) (dockerExtraHosts []string, extraHostsEnv string) {
+	if runtimeType == container.RuntimeDocker && goos == "linux" {
+		return []string{
+			syntheticProxyHost + ":host-gateway",
+			syntheticHostGateway + ":host-gateway",
+		}, ""
+	}
+	// For MOAT_EXTRA_HOSTS: literal IPs pass through, hostnames get the
+	// resolve sentinel so moat-init.sh defers resolution to container DNS.
+	target := hostAddr
+	if net.ParseIP(hostAddr) == nil {
+		target = "@" + hostAddr
+	}
+	return nil, syntheticProxyHost + ":" + target + " " + syntheticHostGateway + ":" + target
 }
 
 // buildProxyEnv constructs the environment variables that configure the container's

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -1808,6 +1808,92 @@ func TestIsMoatOwnedProxyVar(t *testing.T) {
 	}
 }
 
+// TestSynthHostStrategy verifies that the per-runtime mapping strategy for
+// the synthetic moat-proxy/moat-host hostnames produces the correct outputs:
+//
+//   - Docker on Linux uses --add-host (the kernel routes docker0 → host
+//     correctly even across custom bridge networks).
+//   - Docker Desktop on macOS/Windows uses MOAT_EXTRA_HOSTS with a resolve
+//     sentinel so moat-init.sh resolves host.docker.internal inside the
+//     container, where Docker Desktop's embedded DNS can answer. Using
+//     --add-host:host-gateway here resolves to docker0 bridge's gateway
+//     (unreachable from custom bridge networks created for services).
+//   - Apple runtime has no --add-host equivalent and already receives a
+//     literal IP from GetHostAddress(), so MOAT_EXTRA_HOSTS uses the IP
+//     directly — no resolve sentinel.
+func TestSynthHostStrategy(t *testing.T) {
+	tests := []struct {
+		name           string
+		runtimeType    container.RuntimeType
+		goos           string
+		hostAddr       string
+		wantExtraHosts []string
+		wantEnv        string
+	}{
+		{
+			name:        "docker linux uses --add-host",
+			runtimeType: container.RuntimeDocker,
+			goos:        "linux",
+			hostAddr:    "127.0.0.1",
+			wantExtraHosts: []string{
+				syntheticProxyHost + ":host-gateway",
+				syntheticHostGateway + ":host-gateway",
+			},
+			wantEnv: "",
+		},
+		{
+			name:           "docker darwin uses env with resolve sentinel",
+			runtimeType:    container.RuntimeDocker,
+			goos:           "darwin",
+			hostAddr:       "host.docker.internal",
+			wantExtraHosts: nil,
+			wantEnv:        syntheticProxyHost + ":@host.docker.internal " + syntheticHostGateway + ":@host.docker.internal",
+		},
+		{
+			name:           "docker windows uses env with resolve sentinel",
+			runtimeType:    container.RuntimeDocker,
+			goos:           "windows",
+			hostAddr:       "host.docker.internal",
+			wantExtraHosts: nil,
+			wantEnv:        syntheticProxyHost + ":@host.docker.internal " + syntheticHostGateway + ":@host.docker.internal",
+		},
+		{
+			name:           "apple uses env with literal IP",
+			runtimeType:    container.RuntimeApple,
+			goos:           "darwin",
+			hostAddr:       "192.168.64.1",
+			wantExtraHosts: nil,
+			wantEnv:        syntheticProxyHost + ":192.168.64.1 " + syntheticHostGateway + ":192.168.64.1",
+		},
+		{
+			name:           "docker darwin with IP hostAddr skips sentinel",
+			runtimeType:    container.RuntimeDocker,
+			goos:           "darwin",
+			hostAddr:       "10.0.0.5",
+			wantExtraHosts: nil,
+			wantEnv:        syntheticProxyHost + ":10.0.0.5 " + syntheticHostGateway + ":10.0.0.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotExtraHosts, gotEnv := synthHostStrategy(tt.runtimeType, tt.goos, tt.hostAddr)
+			if gotEnv != tt.wantEnv {
+				t.Errorf("env = %q, want %q", gotEnv, tt.wantEnv)
+			}
+			if len(gotExtraHosts) != len(tt.wantExtraHosts) {
+				t.Errorf("extraHosts len = %d, want %d (got %v)", len(gotExtraHosts), len(tt.wantExtraHosts), gotExtraHosts)
+				return
+			}
+			for i := range gotExtraHosts {
+				if gotExtraHosts[i] != tt.wantExtraHosts[i] {
+					t.Errorf("extraHosts[%d] = %q, want %q", i, gotExtraHosts[i], tt.wantExtraHosts[i])
+				}
+			}
+		})
+	}
+}
+
 // TestRewriteExtraHostsForCustomNetwork verifies that synthetic hostname
 // entries in extraHosts are rewritten when a custom network gateway differs.
 // Tests both Docker-style (host-gateway pseudo-address) and Apple-style (actual IP).

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -1873,6 +1874,19 @@ func TestSynthHostStrategy(t *testing.T) {
 			wantExtraHosts: nil,
 			wantEnv:        syntheticProxyHost + ":10.0.0.5 " + syntheticHostGateway + ":10.0.0.5",
 		},
+		{
+			// Documents behavior if GetHostAddress() ever returns empty on a
+			// runtime that uses the env path: we emit "name:@" pairs. The
+			// empty hostname will fail resolution inside moat-init.sh, which
+			// fails closed with an explicit error — preferable to silently
+			// writing bad /etc/hosts entries.
+			name:           "empty hostAddr on env path fails closed via sentinel",
+			runtimeType:    container.RuntimeDocker,
+			goos:           "darwin",
+			hostAddr:       "",
+			wantExtraHosts: nil,
+			wantEnv:        syntheticProxyHost + ":@ " + syntheticHostGateway + ":@",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1881,14 +1895,8 @@ func TestSynthHostStrategy(t *testing.T) {
 			if gotEnv != tt.wantEnv {
 				t.Errorf("env = %q, want %q", gotEnv, tt.wantEnv)
 			}
-			if len(gotExtraHosts) != len(tt.wantExtraHosts) {
-				t.Errorf("extraHosts len = %d, want %d (got %v)", len(gotExtraHosts), len(tt.wantExtraHosts), gotExtraHosts)
-				return
-			}
-			for i := range gotExtraHosts {
-				if gotExtraHosts[i] != tt.wantExtraHosts[i] {
-					t.Errorf("extraHosts[%d] = %q, want %q", i, gotExtraHosts[i], tt.wantExtraHosts[i])
-				}
+			if !reflect.DeepEqual(gotExtraHosts, tt.wantExtraHosts) {
+				t.Errorf("extraHosts = %#v, want %#v", gotExtraHosts, tt.wantExtraHosts)
 			}
 		})
 	}


### PR DESCRIPTION
Without this PR any prompt in my project fails with an error:
```
is this working?                                                                                                                                                                     
  ⎿  Unable to connect to API (ConnectionRefused)
```
PR description by Claude Code below.

## Summary                                                                                                                                                                           
                                                                                                                                                                                       
  - On Docker Desktop (macOS/Windows), `--add-host moat-proxy:host-gateway` resolves to the `docker0` bridge gateway IP, which is unreachable from containers on a custom bridge       
  network — the kind created whenever `moat.yaml` defines `services:`. Agent shows "Unable to connect to API (ConnectionRefused)".                                                     
  - Regression from #321 (d707c86): that commit added the synthetic-host `--add-host` entries unconditionally for Docker, even though the comment 15 lines above already warned the    
  same pattern is broken on Docker Desktop for `host.docker.internal`.                                                                                                                 
  - Fix: on Docker Desktop, route the synthetic hostname mapping through the existing `MOAT_EXTRA_HOSTS` → `moat-init.sh` path (same path Apple already uses). A new `@hostname`       
  sentinel tells the script to resolve the name via the container's DNS at startup, where Docker Desktop's embedded DNS can answer for `host.docker.internal`. Short retry covers the  
  DNS-readiness race.                        
  - Docker on Linux is unchanged (still uses `--add-host`, which resolves correctly there). Apple is unchanged in shape.                                                               
                                                                                                                                                                                       
  ## Test plan                           
                                                                                                                                                                                       
  - [x] New unit test `TestSynthHostStrategy` covers Docker Linux / Docker macOS / Docker Windows / Apple / Docker-with-IP-hostAddr                                                    
  - [x] `go test ./... -race` passes across all packages
  - [x] `golangci-lint run --new-from-rev=origin/main` reports 0 new issues                                                                                                            
  - [x] `moat-init.sh` smoke-tested against `debian:bookworm-slim` and `alpine:3.20` — literal IPs, `@hostname` resolution, IPv4 preference (via `getent ahostsv4`), and fail-closed   
  error path all behave correctly                                                                                                                                                      
  - [x] Manual repro on Docker Desktop Mac with a `services: { postgres: ... }` moat.yaml: before, `curl http://moat-proxy:19080/` from inside the container returns `Connection       
  refused`; after, `/etc/hosts` contains the correct Docker Desktop host IP (e.g. `192.168.5.2 moat-proxy`) and the agent reaches the API on first try                                 
                                             