### PR TITLE
fix(run): auto-include MCP auth grants in credential loading

### DIFF
--- a/docs/content/guides/09-mcp.md
+++ b/docs/content/guides/09-mcp.md
@@ -85,7 +85,7 @@ mcp:
 moat claude ./my-project
 ```
 
-No additional flags are needed. Moat reads the `mcp:` section from `moat.yaml` and configures the proxy relay automatically.
+No additional flags are needed. Moat reads the `mcp:` section from `moat.yaml` and configures the proxy relay automatically. Grants referenced by `mcp[].auth.grant` are included automatically -- you do not need to list them in the top-level `grants:` field.
 
 ### Multiple remote servers
 

--- a/internal/credential/store.go
+++ b/internal/credential/store.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/credential/keyring"
@@ -75,6 +76,9 @@ func (s *FileStore) Save(cred Credential) error {
 
 // Get retrieves a credential for the given provider.
 func (s *FileStore) Get(provider Provider) (*Credential, error) {
+	if strings.ContainsAny(string(provider), "/\\") || strings.Contains(string(provider), "..") {
+		return nil, fmt.Errorf("invalid provider name: %s", provider)
+	}
 	encrypted, err := os.ReadFile(s.path(provider))
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/credential/store.go
+++ b/internal/credential/store.go
@@ -54,8 +54,21 @@ func (s *FileStore) path(provider Provider) string {
 	return filepath.Join(s.dir, string(provider)+".enc")
 }
 
+// validateProvider rejects provider names that contain path separators
+// or ".." components to prevent path traversal in file operations.
+func validateProvider(provider Provider) error {
+	name := string(provider)
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return fmt.Errorf("invalid provider name: %s", provider)
+	}
+	return nil
+}
+
 // Save stores a credential encrypted on disk.
 func (s *FileStore) Save(cred Credential) error {
+	if err := validateProvider(cred.Provider); err != nil {
+		return err
+	}
 	data, err := json.Marshal(cred)
 	if err != nil {
 		return fmt.Errorf("marshaling credential: %w", err)
@@ -76,8 +89,8 @@ func (s *FileStore) Save(cred Credential) error {
 
 // Get retrieves a credential for the given provider.
 func (s *FileStore) Get(provider Provider) (*Credential, error) {
-	if strings.ContainsAny(string(provider), "/\\") || strings.Contains(string(provider), "..") {
-		return nil, fmt.Errorf("invalid provider name: %s", provider)
+	if err := validateProvider(provider); err != nil {
+		return nil, err
 	}
 	encrypted, err := os.ReadFile(s.path(provider))
 	if err != nil {
@@ -111,6 +124,9 @@ func (s *FileStore) Get(provider Provider) (*Credential, error) {
 
 // Delete removes a credential for the given provider.
 func (s *FileStore) Delete(provider Provider) error {
+	if err := validateProvider(provider); err != nil {
+		return err
+	}
 	if err := os.Remove(s.path(provider)); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("deleting credential: %w", err)
 	}

--- a/internal/credential/store_test.go
+++ b/internal/credential/store_test.go
@@ -1,6 +1,7 @@
 package credential
 
 import (
+	"crypto/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -115,6 +116,59 @@ func TestNewFileStore_InvalidKeyLength(t *testing.T) {
 	_, err := NewFileStore(dir, []byte("short-key"))
 	if err == nil {
 		t.Error("expected error for invalid key length")
+	}
+}
+
+func TestValidateProvider(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider Provider
+		wantErr  bool
+	}{
+		{"valid name", Provider("mcp-render"), false},
+		{"valid with colon", Provider("oauth:notion"), false},
+		{"forward slash", Provider("../evil"), true},
+		{"deep traversal", Provider("../../etc/passwd"), true},
+		{"backslash", Provider(`..\..\etc`), true},
+		{"dot-dot only", Provider(".."), true},
+		{"embedded traversal", Provider("foo/../bar"), true},
+		{"absolute path", Provider("/etc/passwd"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateProvider(tt.provider)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateProvider(%q) should return error", tt.provider)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("validateProvider(%q) unexpected error: %v", tt.provider, err)
+			}
+		})
+	}
+}
+
+func TestFileStore_PathTraversalBlocked(t *testing.T) {
+	dir := t.TempDir()
+	key := make([]byte, 32)
+	rand.Read(key)
+	store, _ := NewFileStore(dir, key)
+
+	// Get should reject traversal
+	_, err := store.Get(Provider("../evil"))
+	if err == nil {
+		t.Error("Get with path traversal should return error")
+	}
+
+	// Save should reject traversal
+	err = store.Save(Credential{Provider: Provider("../evil"), Token: "x"})
+	if err == nil {
+		t.Error("Save with path traversal should return error")
+	}
+
+	// Delete should reject traversal
+	err = store.Delete(Provider("../evil"))
+	if err == nil {
+		t.Error("Delete with path traversal should return error")
 	}
 }
 

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -471,6 +471,11 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 		}
 	}
 
+	// Auto-include MCP auth grants so the credential processing loop loads
+	// them into the RunContext. Without this, users would need to duplicate
+	// each mcp[].auth.grant in the top-level grants: list.
+	opts.Grants = appendMCPGrants(opts.Grants, opts.Config)
+
 	// Validate grants before allocating any resources (proxy, container, etc.)
 	needsGrantValidation := len(opts.Grants) > 0 || (opts.Config != nil && len(opts.Config.MCP) > 0)
 	if needsGrantValidation {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -316,6 +317,24 @@ func grantToCommand(grant string) string {
 		return "mcp " + after
 	}
 	return grant
+}
+
+// appendMCPGrants adds any MCP auth grants that are not already present in
+// the grant list. This ensures credentials for remote MCP servers are loaded
+// without requiring users to duplicate grant names in the top-level grants: list.
+func appendMCPGrants(grants []string, cfg *config.Config) []string {
+	if cfg == nil {
+		return grants
+	}
+	// Copy to avoid mutating the caller's backing array.
+	result := make([]string, len(grants), len(grants)+len(cfg.MCP))
+	copy(result, grants)
+	for _, mcp := range cfg.MCP {
+		if mcp.Auth != nil && mcp.Auth.Grant != "" && !slices.Contains(result, mcp.Auth.Grant) {
+			result = append(result, mcp.Auth.Grant)
+		}
+	}
+	return result
 }
 
 // validateMCPGrants checks that all required MCP grants exist.

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -409,6 +409,146 @@ func TestValidateMCPGrants(t *testing.T) {
 	}
 }
 
+func TestAppendMCPGrants(t *testing.T) {
+	tests := []struct {
+		name   string
+		grants []string
+		cfg    *config.Config
+		want   []string
+	}{
+		{
+			name:   "nil config",
+			grants: []string{"github"},
+			cfg:    nil,
+			want:   []string{"github"},
+		},
+		{
+			name:   "no MCP servers",
+			grants: []string{"github"},
+			cfg:    &config.Config{},
+			want:   []string{"github"},
+		},
+		{
+			name:   "MCP server without auth",
+			grants: []string{"github"},
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{Name: "public", URL: "https://public.example.com"},
+				},
+			},
+			want: []string{"github"},
+		},
+		{
+			name:   "MCP auth with empty grant",
+			grants: []string{"github"},
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{
+						Name: "svc",
+						URL:  "https://example.com",
+						Auth: &config.MCPAuthConfig{Grant: "", Header: "Authorization"},
+					},
+				},
+			},
+			want: []string{"github"},
+		},
+		{
+			name:   "MCP auth grant auto-included",
+			grants: []string{"github"},
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{
+						Name: "render",
+						URL:  "https://mcp.render.com/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-render", Header: "Authorization"},
+					},
+				},
+			},
+			want: []string{"github", "mcp-render"},
+		},
+		{
+			name:   "MCP auth grant already present",
+			grants: []string{"github", "mcp-render"},
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{
+						Name: "render",
+						URL:  "https://mcp.render.com/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-render", Header: "Authorization"},
+					},
+				},
+			},
+			want: []string{"github", "mcp-render"},
+		},
+		{
+			name:   "multiple MCP servers",
+			grants: []string{"claude"},
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{
+						Name: "render",
+						URL:  "https://mcp.render.com/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-render", Header: "Authorization"},
+					},
+					{
+						Name: "linear",
+						URL:  "https://mcp.linear.app/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-linear", Header: "Authorization"},
+					},
+				},
+			},
+			want: []string{"claude", "mcp-render", "mcp-linear"},
+		},
+		{
+			name:   "duplicate grant across MCP servers",
+			grants: []string{"claude"},
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{
+						Name: "render",
+						URL:  "https://mcp.render.com/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-shared", Header: "Authorization"},
+					},
+					{
+						Name: "linear",
+						URL:  "https://mcp.linear.app/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-shared", Header: "Authorization"},
+					},
+				},
+			},
+			want: []string{"claude", "mcp-shared"},
+		},
+		{
+			name:   "empty grants with MCP",
+			grants: nil,
+			cfg: &config.Config{
+				MCP: []config.MCPServerConfig{
+					{
+						Name: "render",
+						URL:  "https://mcp.render.com/mcp",
+						Auth: &config.MCPAuthConfig{Grant: "mcp-render", Header: "Authorization"},
+					},
+				},
+			},
+			want: []string{"mcp-render"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendMCPGrants(tt.grants, tt.cfg)
+			if len(got) != len(tt.want) {
+				t.Fatalf("appendMCPGrants() = %v, want %v", got, tt.want)
+			}
+			for i, g := range got {
+				if g != tt.want[i] {
+					t.Errorf("appendMCPGrants()[%d] = %q, want %q", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 // TestBuildProxyEnv_LoopbackNotBypassed verifies that under host-network mode,
 // loopback addresses are NOT in NO_PROXY (so they flow through the proxy for
 // network.host enforcement), while moat-proxy IS in NO_PROXY (preventing


### PR DESCRIPTION
## Summary

- MCP servers with `auth.grant` in `moat.yaml` had credentials validated but never loaded into the RunContext — the grant names were checked by `validateMCPGrants` but not added to the list that the credential processing loop iterates
- Adds `appendMCPGrants()` to merge MCP auth grants into the grant list before validation, using a defensive copy to avoid mutating the caller's slice
- Hardens `FileStore.Get()` against path traversal via crafted provider names containing slashes or `..` components
- Documents that MCP auth grants are automatically included (no need to duplicate in top-level `grants:`)

## Test plan

- [x] `TestAppendMCPGrants` — 9 cases covering nil config, empty grants, dedup, multiple servers, duplicate grants across servers, empty grant string
- [x] Existing `TestValidateMCPGrants` still passes
- [x] Existing credential store tests pass with path traversal guard
- [x] `make lint` clean
- [x] Full `make test-unit` passes (only pre-existing network-dependent test fails in sandbox)

Fixes #335