### PR TITLE
fix(deps): handle multi-line YAML block scalars in build hooks

### DIFF
--- a/docs/content/guides/10-hooks.md
+++ b/docs/content/guides/10-hooks.md
@@ -153,6 +153,18 @@ hooks:
   pre_run: npm install && npm run build
 ```
 
+YAML block scalars also work. Lines are joined with `&&` automatically:
+
+```yaml
+hooks:
+  post_build_root: |
+    apt-get update -qq
+    apt-get install -y -qq figlet
+    apt-get clean
+```
+
+This produces a single `RUN` instruction equivalent to `apt-get update -qq && apt-get install -y -qq figlet && apt-get clean`. Each non-empty line becomes one command in the chain.
+
 > **Note:** Git identity (`user.name` and `user.email`) is imported automatically from the host when `git` is listed as a dependency. Use a `post_build` hook only if you need to override the host identity or set other git configuration.
 
 ### Claude Code agent with setup

--- a/internal/deps/dockerfile.go
+++ b/internal/deps/dockerfile.go
@@ -568,11 +568,18 @@ func formatHookCommand(cmd string) string {
 			continue
 		}
 		// Strip trailing shell operators so joining with && is idempotent.
-		line = strings.TrimRight(line, " ")
-		line = strings.TrimSuffix(line, "&&")
-		line = strings.TrimSuffix(line, ";")
-		line = strings.TrimSuffix(line, `\`)
-		line = strings.TrimRight(line, " ")
+		// Loop until stable to handle combinations like "&& \".
+		for {
+			trimmed := strings.TrimRight(line, " ")
+			trimmed = strings.TrimSuffix(trimmed, "&&")
+			trimmed = strings.TrimSuffix(trimmed, ";")
+			trimmed = strings.TrimSuffix(trimmed, `\`)
+			trimmed = strings.TrimRight(trimmed, " ")
+			if trimmed == line {
+				break
+			}
+			line = trimmed
+		}
 		if line != "" {
 			lines = append(lines, line)
 		}

--- a/internal/deps/dockerfile.go
+++ b/internal/deps/dockerfile.go
@@ -538,17 +538,17 @@ func writeBuildHooks(b *strings.Builder, hooks *HooksConfig) {
 		return
 	}
 
-	if hooks.PostBuildRoot != "" {
+	if cmd := formatHookCommand(hooks.PostBuildRoot); cmd != "" {
 		b.WriteString("# Build hook: post_build_root\n")
 		b.WriteString("WORKDIR /workspace\n")
-		b.WriteString("RUN " + formatHookCommand(hooks.PostBuildRoot) + "\n\n")
+		b.WriteString("RUN " + cmd + "\n\n")
 	}
 
-	if hooks.PostBuild != "" {
+	if cmd := formatHookCommand(hooks.PostBuild); cmd != "" {
 		b.WriteString("# Build hook: post_build\n")
 		b.WriteString(fmt.Sprintf("USER %s\n", containerUser))
 		b.WriteString("WORKDIR /workspace\n")
-		b.WriteString("RUN " + formatHookCommand(hooks.PostBuild) + "\n")
+		b.WriteString("RUN " + cmd + "\n")
 		b.WriteString("USER root\n\n")
 	}
 }

--- a/internal/deps/dockerfile.go
+++ b/internal/deps/dockerfile.go
@@ -541,16 +541,43 @@ func writeBuildHooks(b *strings.Builder, hooks *HooksConfig) {
 	if hooks.PostBuildRoot != "" {
 		b.WriteString("# Build hook: post_build_root\n")
 		b.WriteString("WORKDIR /workspace\n")
-		b.WriteString("RUN " + hooks.PostBuildRoot + "\n\n")
+		b.WriteString("RUN " + formatHookCommand(hooks.PostBuildRoot) + "\n\n")
 	}
 
 	if hooks.PostBuild != "" {
 		b.WriteString("# Build hook: post_build\n")
 		b.WriteString(fmt.Sprintf("USER %s\n", containerUser))
 		b.WriteString("WORKDIR /workspace\n")
-		b.WriteString("RUN " + hooks.PostBuild + "\n")
+		b.WriteString("RUN " + formatHookCommand(hooks.PostBuild) + "\n")
 		b.WriteString("USER root\n\n")
 	}
+}
+
+// formatHookCommand converts a user-provided hook string into a valid
+// Dockerfile RUN argument. Multi-line strings (e.g., from YAML block
+// scalars) are split into individual commands joined with " && ".
+func formatHookCommand(cmd string) string {
+	cmd = strings.TrimSpace(cmd)
+	if !strings.Contains(cmd, "\n") {
+		return cmd
+	}
+	var lines []string
+	for _, line := range strings.Split(cmd, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// Strip trailing shell operators so joining with && is idempotent.
+		line = strings.TrimRight(line, " ")
+		line = strings.TrimSuffix(line, "&&")
+		line = strings.TrimSuffix(line, ";")
+		line = strings.TrimSuffix(line, `\`)
+		line = strings.TrimRight(line, " ")
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, " && \\\n    ")
 }
 
 // writeEntrypoint writes the entrypoint configuration and working directory.

--- a/internal/deps/dockerfile_test.go
+++ b/internal/deps/dockerfile_test.go
@@ -1537,6 +1537,102 @@ func TestGenerateDockerfile_HooksPreRunTriggersInit(t *testing.T) {
 	}
 }
 
+func TestFormatHookCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want string
+	}{
+		{
+			name: "single line unchanged",
+			cmd:  "apt-get install -y figlet",
+			want: "apt-get install -y figlet",
+		},
+		{
+			name: "multi-line joined with &&",
+			cmd:  "touch ~/foo\ntouch ~/bar",
+			want: "touch ~/foo && \\\n    touch ~/bar",
+		},
+		{
+			name: "trailing newline stripped",
+			cmd:  "touch ~/foo\ntouch ~/bar\n",
+			want: "touch ~/foo && \\\n    touch ~/bar",
+		},
+		{
+			name: "blank lines filtered",
+			cmd:  "touch ~/foo\n\ntouch ~/bar\n",
+			want: "touch ~/foo && \\\n    touch ~/bar",
+		},
+		{
+			name: "leading/trailing whitespace trimmed",
+			cmd:  "  touch ~/foo  \n  touch ~/bar  \n",
+			want: "touch ~/foo && \\\n    touch ~/bar",
+		},
+		{
+			name: "three lines",
+			cmd:  "apt-get update\napt-get install -y curl\napt-get clean",
+			want: "apt-get update && \\\n    apt-get install -y curl && \\\n    apt-get clean",
+		},
+		{
+			name: "trailing && stripped to avoid double join",
+			cmd:  "apt-get update &&\napt-get install -y curl",
+			want: "apt-get update && \\\n    apt-get install -y curl",
+		},
+		{
+			name: "trailing semicolon stripped",
+			cmd:  "echo hello;\necho world",
+			want: "echo hello && \\\n    echo world",
+		},
+		{
+			name: "trailing backslash stripped",
+			cmd:  "echo hello \\\necho world",
+			want: "echo hello && \\\n    echo world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatHookCommand(tt.cmd)
+			if got != tt.want {
+				t.Errorf("formatHookCommand(%q)\ngot:  %q\nwant: %q", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateDockerfile_HooksMultiLine(t *testing.T) {
+	// Multi-line hooks (e.g., YAML block scalars) should produce valid Dockerfiles.
+	t.Run("PostBuild", func(t *testing.T) {
+		result, err := GenerateDockerfile(nil, &ImageSpec{
+			Hooks: &HooksConfig{
+				PostBuild: "touch ~/foo\ntouch ~/bar\n",
+			},
+		})
+		if err != nil {
+			t.Fatalf("GenerateDockerfile: %v", err)
+		}
+		// Verify a single RUN instruction with && joining.
+		want := "RUN touch ~/foo && \\\n    touch ~/bar\n"
+		if !strings.Contains(result.Dockerfile, want) {
+			t.Errorf("expected Dockerfile to contain:\n%s\ngot:\n%s", want, result.Dockerfile)
+		}
+	})
+
+	t.Run("PostBuildRoot", func(t *testing.T) {
+		result, err := GenerateDockerfile(nil, &ImageSpec{
+			Hooks: &HooksConfig{
+				PostBuildRoot: "apt-get update\napt-get install -y curl\n",
+			},
+		})
+		if err != nil {
+			t.Fatalf("GenerateDockerfile: %v", err)
+		}
+		want := "RUN apt-get update && \\\n    apt-get install -y curl\n"
+		if !strings.Contains(result.Dockerfile, want) {
+			t.Errorf("expected Dockerfile to contain:\n%s\ngot:\n%s", want, result.Dockerfile)
+		}
+	})
+}
+
 func TestGenerateDockerfileYarnPnpmCorepack(t *testing.T) {
 	deps := []Dependency{
 		{Name: "node", Version: "22"},

--- a/internal/deps/dockerfile_test.go
+++ b/internal/deps/dockerfile_test.go
@@ -1588,6 +1588,11 @@ func TestFormatHookCommand(t *testing.T) {
 			cmd:  "echo hello \\\necho world",
 			want: "echo hello && \\\n    echo world",
 		},
+		{
+			name: "trailing && backslash combination stripped",
+			cmd:  "apt-get update && \\\napt-get install -y curl",
+			want: "apt-get update && \\\n    apt-get install -y curl",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Multi-line strings from YAML block scalars (`|`) in `post_build` and `post_build_root` hooks produced invalid Dockerfiles — raw newlines were interpolated directly into `RUN` commands
- Adds `formatHookCommand()` to join non-empty lines with `&&` into a single valid `RUN` instruction
- Strips trailing shell operators (`&&`, `;`, `\`) before joining to avoid double-chaining when users include their own operators
- Documents YAML block scalar support in the hooks guide with examples

## Test plan

- [x] `TestFormatHookCommand` — 9 cases covering single line, multi-line, blank lines, whitespace trimming, trailing `&&`/`;`/`\` stripping
- [x] `TestGenerateDockerfile_HooksMultiLine` — integration test for both `PostBuild` and `PostBuildRoot` paths with exact RUN instruction assertions
- [x] Existing hook tests still pass
- [x] `make lint` clean
- [x] Full `make test-unit` passes (only pre-existing network-dependent test fails in sandbox)

Fixes #334