### PR TITLE
fix(run): bound network create and reap orphan moat networks

### DIFF
--- a/cmd/moat/cli/clean.go
+++ b/cmd/moat/cli/clean.go
@@ -43,9 +43,13 @@ func init() {
 func cleanResources(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	// Get runs (no sandbox needed for listing/cleaning)
+	// Get runs (no sandbox needed for listing/cleaning).
+	// `moat clean` is the explicit cleanup command, so reap orphan networks too.
 	noSandbox := true
-	manager, err := run.NewManagerWithOptions(run.ManagerOptions{NoSandbox: &noSandbox})
+	manager, err := run.NewManagerWithOptions(run.ManagerOptions{
+		NoSandbox:          &noSandbox,
+		ReapOrphanNetworks: true,
+	})
 	if err != nil {
 		return fmt.Errorf("creating run manager: %w", err)
 	}

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -195,8 +195,9 @@ func ExecuteRun(ctx context.Context, opts intcli.ExecOptions) (*run.Run, error) 
 	}
 	// If neither is set, detect.go checks MOAT_RUNTIME env var, then auto-detects
 
-	// Create manager
-	var managerOpts run.ManagerOptions
+	// Create manager. ReapOrphanNetworks=true because this path creates a
+	// new network — best moment to clean up leaks from prior crashed runs.
+	managerOpts := run.ManagerOptions{ReapOrphanNetworks: true}
 	if opts.Flags.NoSandbox {
 		noSandbox := true
 		managerOpts.NoSandbox = &noSandbox

--- a/internal/container/apple_network.go
+++ b/internal/container/apple_network.go
@@ -3,6 +3,7 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -18,9 +19,19 @@ type appleNetworkManager struct {
 // CreateNetwork creates an Apple container network.
 // Returns the network name as the identifier.
 func (m *appleNetworkManager) CreateNetwork(ctx context.Context, name string) (string, error) {
-	cmd := exec.CommandContext(ctx, m.containerBin, "network", "create", name)
+	callCtx, cancel := context.WithTimeout(ctx, networkCreateTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(callCtx, m.containerBin, "network", "create", name)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// If the bounded timeout fired (and the caller's ctx is still alive),
+		// surface a hint about the most likely cause: leaked networks from
+		// prior runs exhausting the IP pool.
+		if errors.Is(callCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return "", fmt.Errorf("creating network %s: timed out after %s — Apple's container IP pool may be exhausted by orphaned moat networks. List with `container network list` and remove unused entries with `container network delete <name>`",
+				name, networkCreateTimeout)
+		}
 		return "", fmt.Errorf("creating network %s: %s: %w", name, strings.TrimSpace(string(output)), err)
 	}
 	log.Debug("created apple container network", "name", name)
@@ -57,10 +68,26 @@ func (m *appleNetworkManager) ListNetworks(ctx context.Context) ([]NetworkInfo, 
 	if err != nil {
 		return nil, fmt.Errorf("listing networks: %s: %w", strings.TrimSpace(string(output)), err)
 	}
+	return parseAppleNetworkList(string(output)), nil
+}
 
+// parseAppleNetworkList extracts moat-managed network names from the output of
+// `container network list`. The output is multi-column with a header row:
+//
+//	NETWORK                STATE    SUBNET
+//	moat-run_abc123def456  running  192.168.65.0/24
+//	default                running  192.168.64.0/24
+//
+// Only the first whitespace-separated token on each line is the network name;
+// rows that don't begin with "moat-" are ignored (including the header).
+func parseAppleNetworkList(output string) []NetworkInfo {
 	var result []NetworkInfo
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		name := strings.TrimSpace(line)
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
 		if strings.HasPrefix(name, "moat-") {
 			result = append(result, NetworkInfo{
 				ID:   name,
@@ -68,7 +95,7 @@ func (m *appleNetworkManager) ListNetworks(ctx context.Context) ([]NetworkInfo, 
 			})
 		}
 	}
-	return result, nil
+	return result
 }
 
 // NetworkGateway returns the IPv4 gateway for the named Apple container network.

--- a/internal/container/apple_network_test.go
+++ b/internal/container/apple_network_test.go
@@ -1,9 +1,58 @@
 package container
 
 import (
+	"reflect"
 	"testing"
 )
 
 func TestAppleNetworkManagerImplementsInterface(t *testing.T) {
 	var _ NetworkManager = (*appleNetworkManager)(nil)
+}
+
+func TestParseAppleNetworkList(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   []NetworkInfo
+	}{
+		{
+			name: "header plus moat networks plus default",
+			output: "NETWORK                STATE    SUBNET\n" +
+				"moat-run_abc123def456  running  192.168.65.0/24\n" +
+				"moat-run_fed987cba321  running  192.168.66.0/24\n" +
+				"default                running  192.168.64.0/24\n",
+			want: []NetworkInfo{
+				{ID: "moat-run_abc123def456", Name: "moat-run_abc123def456"},
+				{ID: "moat-run_fed987cba321", Name: "moat-run_fed987cba321"},
+			},
+		},
+		{
+			name:   "only header",
+			output: "NETWORK  STATE    SUBNET\n",
+			want:   nil,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   nil,
+		},
+		{
+			name: "blank lines are tolerated",
+			output: "NETWORK                STATE    SUBNET\n" +
+				"\n" +
+				"moat-run_abc123def456  running  192.168.65.0/24\n",
+			want: []NetworkInfo{
+				{ID: "moat-run_abc123def456", Name: "moat-run_abc123def456"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseAppleNetworkList(tt.output)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseAppleNetworkList() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -875,13 +875,21 @@ func (r *DockerRuntime) StartAttached(ctx context.Context, containerID string, o
 // dockerNetworkManager methods
 
 // CreateNetwork creates a Docker network for inter-container communication.
-// Returns the network ID.
+// Returns the network ID. Bounded by networkCreateTimeout so a wedged Docker
+// daemon surfaces as a clear error instead of an indefinite hang.
 func (m *dockerNetworkManager) CreateNetwork(ctx context.Context, name string) (string, error) {
-	resp, err := m.cli.NetworkCreate(ctx, name, network.CreateOptions{
+	callCtx, cancel := context.WithTimeout(ctx, networkCreateTimeout)
+	defer cancel()
+
+	resp, err := m.cli.NetworkCreate(callCtx, name, network.CreateOptions{
 		Driver: "bridge", // Bridge network for inter-container communication
 		Labels: map[string]string{"moat.managed": "true"},
 	})
 	if err != nil {
+		if errors.Is(callCtx.Err(), context.DeadlineExceeded) && ctx.Err() == nil {
+			return "", fmt.Errorf("creating network %s: timed out after %s — Docker daemon may be unresponsive. List moat networks with `docker network ls --filter label=moat.managed=true` and remove unused entries with `docker network rm <id>`",
+				name, networkCreateTimeout)
+		}
 		return "", fmt.Errorf("creating network: %w", err)
 	}
 	return resp.ID, nil

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -38,6 +38,12 @@ func AllRuntimeTypes() []RuntimeType {
 // does not set container.memory. Docker containers remain unlimited.
 const DefaultAgentMemoryMB = 8192
 
+// networkCreateTimeout bounds CreateNetwork so an unresponsive runtime fails
+// fast instead of hanging indefinitely. On Apple this manifests when the IP
+// allocation pool is exhausted by leaked networks; on Docker, when the daemon
+// is wedged. See https://github.com/majorcontext/moat/issues/315.
+const networkCreateTimeout = 30 * time.Second
+
 // Runtime is the interface for container runtime operations.
 type Runtime interface {
 	// Type returns the runtime type (Docker or Apple).

--- a/internal/e2e/services_test.go
+++ b/internal/e2e/services_test.go
@@ -29,6 +29,24 @@ func skipIfNoServiceRuntime(t *testing.T) {
 	t.Skip("No container runtime with service support available")
 }
 
+// cleanupRun stops then destroys a run, ignoring errors. Registered via
+// t.Cleanup so it runs even when assertions fail. Destroy refuses to remove
+// a Running run, so the explicit Stop is required to avoid leaking the
+// container's network and run dir on test failure (see #315).
+func cleanupRun(t *testing.T, mgr *run.Manager, runID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := mgr.Stop(ctx, runID); err != nil {
+			t.Logf("cleanup: stop run %s: %v", runID, err)
+		}
+		if err := mgr.Destroy(ctx, runID); err != nil {
+			t.Logf("cleanup: destroy run %s: %v", runID, err)
+		}
+	})
+}
+
 // TestServicePostgres verifies that a postgres service dependency starts,
 // injects MOAT_POSTGRES_URL, and the database is reachable from the main container.
 func TestServicePostgres(t *testing.T) {
@@ -42,7 +60,7 @@ func TestServicePostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	defer mgr.Close()
+	t.Cleanup(func() { _ = mgr.Close() })
 
 	workspace := createTestWorkspaceWithDeps(t, []string{"postgres@17"})
 
@@ -70,7 +88,7 @@ func TestServicePostgres(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	defer mgr.Destroy(context.Background(), r.ID)
+	cleanupRun(t, mgr, r.ID)
 
 	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -124,7 +142,7 @@ func TestServiceRedis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	defer mgr.Close()
+	t.Cleanup(func() { _ = mgr.Close() })
 
 	workspace := createTestWorkspaceWithDeps(t, []string{"redis@7"})
 
@@ -143,7 +161,7 @@ func TestServiceRedis(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	defer mgr.Destroy(context.Background(), r.ID)
+	cleanupRun(t, mgr, r.ID)
 
 	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -191,7 +209,7 @@ func TestServiceMultiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	defer mgr.Close()
+	t.Cleanup(func() { _ = mgr.Close() })
 
 	workspace := createTestWorkspaceWithDeps(t, []string{"postgres@17", "redis@7"})
 
@@ -209,7 +227,7 @@ func TestServiceMultiple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	defer mgr.Destroy(context.Background(), r.ID)
+	cleanupRun(t, mgr, r.ID)
 
 	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -264,7 +282,7 @@ func TestServiceCustomConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	defer mgr.Close()
+	t.Cleanup(func() { _ = mgr.Close() })
 
 	workspace := createTestWorkspaceWithDeps(t, []string{"postgres@17"})
 
@@ -287,7 +305,7 @@ func TestServiceCustomConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	defer mgr.Destroy(context.Background(), r.ID)
+	cleanupRun(t, mgr, r.ID)
 
 	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -342,7 +360,7 @@ func TestServiceCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewManager: %v", err)
 	}
-	defer mgr.Close()
+	t.Cleanup(func() { _ = mgr.Close() })
 
 	workspace := createTestWorkspaceWithDeps(t, []string{"postgres@17"})
 
@@ -357,6 +375,10 @@ func TestServiceCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	// Safety net: even though this test deliberately destroys the run mid-test,
+	// register cleanup in case an assertion fails before the explicit Destroy.
+	// Stop+Destroy on an already-destroyed run is a harmless no-op.
+	cleanupRun(t, mgr, r.ID)
 
 	runID := r.ID
 

--- a/internal/e2e/services_test.go
+++ b/internal/e2e/services_test.go
@@ -32,7 +32,6 @@ func skipIfNoServiceRuntime(t *testing.T) {
 // TestServicePostgres verifies that a postgres service dependency starts,
 // injects MOAT_POSTGRES_URL, and the database is reachable from the main container.
 func TestServicePostgres(t *testing.T) {
-	t.Skip("skipped: hangs intermittently — see https://github.com/majorcontext/moat/issues/315")
 	skipIfNoServiceRuntime(t)
 	skipIfNestedDind(t)
 
@@ -115,7 +114,6 @@ func TestServicePostgres(t *testing.T) {
 // TestServiceRedis verifies that a redis service dependency starts,
 // injects MOAT_REDIS_URL, and the cache is reachable.
 func TestServiceRedis(t *testing.T) {
-	t.Skip("skipped: hangs intermittently — see https://github.com/majorcontext/moat/issues/315")
 	skipIfNoServiceRuntime(t)
 	skipIfNestedDind(t)
 
@@ -183,7 +181,6 @@ func TestServiceRedis(t *testing.T) {
 // TestServiceMultiple verifies that multiple services (postgres and redis)
 // can run together and both sets of env vars are injected.
 func TestServiceMultiple(t *testing.T) {
-	t.Skip("skipped: hangs intermittently — see https://github.com/majorcontext/moat/issues/315")
 	skipIfNoServiceRuntime(t)
 	skipIfNestedDind(t)
 
@@ -257,7 +254,6 @@ func TestServiceMultiple(t *testing.T) {
 // TestServiceCustomConfig verifies that service configuration can be overridden
 // via the services: block in moat.yaml (e.g., custom database name).
 func TestServiceCustomConfig(t *testing.T) {
-	t.Skip("skipped: hangs intermittently — see https://github.com/majorcontext/moat/issues/315")
 	skipIfNoServiceRuntime(t)
 	skipIfNestedDind(t)
 
@@ -336,7 +332,6 @@ func TestServiceCustomConfig(t *testing.T) {
 // TestServiceCleanup verifies that service containers are removed when
 // the run is destroyed.
 func TestServiceCleanup(t *testing.T) {
-	t.Skip("skipped: hangs intermittently — see https://github.com/majorcontext/moat/issues/315")
 	skipIfNoServiceRuntime(t)
 	skipIfNestedDind(t)
 

--- a/internal/run/edge_cases_test.go
+++ b/internal/run/edge_cases_test.go
@@ -139,10 +139,14 @@ func newEdgeCaseManager(t *testing.T, rt container.Runtime) *Manager {
 	if err != nil {
 		t.Fatal(err)
 	}
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { monitorCancel() })
 	return &Manager{
-		runtimePool: container.NewRuntimePoolWithDefault(rt),
-		runs:        make(map[string]*Run),
-		routes:      routes,
+		runtimePool:   container.NewRuntimePoolWithDefault(rt),
+		runs:          make(map[string]*Run),
+		routes:        routes,
+		monitorCtx:    monitorCtx,
+		monitorCancel: monitorCancel,
 	}
 }
 
@@ -921,7 +925,7 @@ func TestMonitorContainerExitSetsStateFailed(t *testing.T) {
 	// Run monitor in goroutine and wait for it to complete
 	done := make(chan struct{})
 	go func() {
-		m.monitorContainerExit(r)
+		m.monitorContainerExit(context.Background(), r)
 		close(done)
 	}()
 
@@ -980,7 +984,7 @@ func TestMonitorContainerExitSetsStateStopped(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		m.monitorContainerExit(r)
+		m.monitorContainerExit(context.Background(), r)
 		close(done)
 	}()
 
@@ -1060,7 +1064,7 @@ func TestMonitorContainerExitWaitError(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		m.monitorContainerExit(r)
+		m.monitorContainerExit(context.Background(), r)
 		close(done)
 	}()
 
@@ -1227,7 +1231,7 @@ func TestMonitorContainerExitAlreadyStopped(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		m.monitorContainerExit(r)
+		m.monitorContainerExit(context.Background(), r)
 		close(done)
 	}()
 
@@ -1240,5 +1244,180 @@ func TestMonitorContainerExitAlreadyStopped(t *testing.T) {
 	// State should remain Stopped (not changed to Failed or re-Stopped)
 	if r.GetState() != StateStopped {
 		t.Errorf("expected state to remain StateStopped, got %s", r.GetState())
+	}
+}
+
+// TestCloseUnblocksStuckMonitor verifies the fix for #315: Close() cancels
+// the monitor context so monitorContainerExit's WaitContainer unblocks, and
+// Close() returns within its bounded timeout instead of deadlocking.
+func TestCloseUnblocksStuckMonitor(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "TestCloseUnblocksStuckMonitor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := storage.NewRunStore(tmpDir, "run_slow")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a container where WaitContainer blocks until context cancellation.
+	// This models the E2E scenario where Docker's ContainerWait hangs
+	// on containers using custom networks with services.
+	rt := &flexibleRuntime{
+		done: make(chan struct{}),
+		waitFn: func(ctx context.Context, _ string) (int64, error) {
+			<-ctx.Done()
+			return 0, ctx.Err()
+		},
+	}
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
+	m := newEdgeCaseManager(t, rt)
+	m.monitorCtx = monitorCtx
+	m.monitorCancel = monitorCancel
+
+	r := &Run{
+		ID:          "run_slow",
+		Name:        "slow-container",
+		ContainerID: "ctr-slow",
+		State:       StateRunning,
+		Store:       store,
+		exitCh:      make(chan struct{}),
+	}
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.mu.Unlock()
+
+	// Simulate what Start() does: register the monitor on monitorWg
+	// using monitorCtx (as the real code now does).
+	m.monitorWg.Add(1)
+	go func() {
+		defer m.monitorWg.Done()
+		m.monitorContainerExit(m.monitorCtx, r)
+	}()
+
+	// Simulate what the E2E test does: Wait() with a short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	waitErr := m.Wait(ctx, r.ID)
+	if !errors.Is(waitErr, context.DeadlineExceeded) {
+		t.Fatalf("expected DeadlineExceeded from Wait, got: %v", waitErr)
+	}
+
+	// Close() should cancel the monitor context, unblocking WaitContainer,
+	// and return within a few seconds — NOT deadlock.
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- m.Close()
+	}()
+
+	select {
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("Close() returned error: %v", err)
+		}
+		// Close() returned — the fix works.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close() deadlocked — monitorContainerExit was not unblocked by context cancellation")
+	}
+}
+
+// TestCleanupRemovesContainerWhileMonitorBlocked reproduces Scenario B from #315:
+// the container exits and transitions to a non-running state, but
+// monitorContainerExit hasn't processed the exit yet. cleanupResources then
+// force-removes the container. If WaitContainer doesn't handle a removed
+// container gracefully, monitorContainerExit hangs, and Close() deadlocks.
+//
+// In the E2E tests, defers run in LIFO order:
+//  1. Destroy() — calls cleanupResources → RemoveContainer
+//  2. Close() — blocks on monitorWg.Wait()
+func TestCleanupRemovesContainerWhileMonitorBlocked(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "TestCleanupWhileMonitorBlocked")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	store, err := storage.NewRunStore(tmpDir, "run_cleanup_race")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Track whether RemoveContainer was called while WaitContainer is blocked.
+	var (
+		waitStarted      = make(chan struct{}) // closed when WaitContainer starts blocking
+		containerRemoved = make(chan struct{}) // closed when RemoveContainer is called
+	)
+
+	rt := &flexibleRuntime{
+		done: make(chan struct{}),
+		waitFn: func(ctx context.Context, _ string) (int64, error) {
+			close(waitStarted)
+			// Block until container is removed, then return error
+			// (simulating Docker behavior when container is removed during wait)
+			select {
+			case <-containerRemoved:
+				// In real Docker: either returns immediately with error,
+				// or hangs forever. This test checks the optimistic case.
+				return 0, fmt.Errorf("container removed")
+			case <-ctx.Done():
+				return 0, ctx.Err()
+			}
+		},
+		removeFn: func(_ context.Context, _ string) error {
+			select {
+			case <-containerRemoved:
+				// already closed
+			default:
+				close(containerRemoved)
+			}
+			return nil
+		},
+	}
+	m := newEdgeCaseManager(t, rt)
+
+	r := &Run{
+		ID:          "run_cleanup_race",
+		Name:        "cleanup-race",
+		ContainerID: "ctr-race",
+		State:       StateStopped,
+		Store:       store,
+		exitCh:      make(chan struct{}),
+	}
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.mu.Unlock()
+
+	// Start monitor (tracked by monitorWg, like Start() does)
+	m.monitorWg.Add(1)
+	go func() {
+		defer m.monitorWg.Done()
+		m.monitorContainerExit(context.Background(), r)
+	}()
+
+	// Wait for the monitor to start blocking
+	<-waitStarted
+
+	// Simulate what Destroy does: call cleanupResources directly.
+	// This calls RemoveContainer (force) while monitorContainerExit is
+	// blocked on WaitContainer.
+	m.cleanupResources(context.Background(), r)
+
+	// Now Close() — does it deadlock?
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- m.Close()
+	}()
+
+	select {
+	case <-closeDone:
+		t.Log("Close() returned after cleanup removed the container — no deadlock in this scenario")
+	case <-time.After(2 * time.Second):
+		t.Log("Close() still blocked after cleanup — confirms the deadlock even when container is removed")
+		// Unblock to clean up
+		close(rt.done)
+		<-closeDone
 	}
 }

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/majorcontext/moat/internal/daemon"
 	"github.com/majorcontext/moat/internal/deps"
 	"github.com/majorcontext/moat/internal/hostnames"
+	"github.com/majorcontext/moat/internal/id"
 	"github.com/majorcontext/moat/internal/image"
 
 	internalkeep "github.com/majorcontext/moat/internal/keep"
@@ -140,6 +141,12 @@ type ManagerOptions struct {
 	// NoSandbox disables gVisor sandbox for Docker containers.
 	// If nil, uses platform-aware defaults (gVisor on Linux, standard on macOS/Windows).
 	NoSandbox *bool
+
+	// ReapOrphanNetworks enables a one-shot sweep of moat-managed networks whose
+	// run directories no longer exist. Set by commands that create networks
+	// (`moat run`) or explicitly clean up (`moat clean`). Read-only commands
+	// leave it false to avoid the per-invocation cost of listing networks.
+	ReapOrphanNetworks bool
 }
 
 // NewManagerWithOptions creates a new run manager with the given options.
@@ -193,7 +200,85 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 		// Non-fatal - continue with empty runs map
 	}
 
+	// Reap orphan moat networks left behind by killed/crashed runs. Each leaked
+	// network on Apple's container runtime keeps a vmnet daemon alive and
+	// consumes a /24 from the IP pool; eventually `container network create`
+	// hangs. See https://github.com/majorcontext/moat/issues/315.
+	//
+	// Only sweep when explicitly requested (commands that create networks or
+	// clean up). Read-only commands skip it to avoid the per-invocation cost.
+	// Long-term this belongs in the daemon — see
+	// https://github.com/majorcontext/moat/issues/341.
+	if opts.ReapOrphanNetworks {
+		reapCtx, reapCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		m.cleanOrphanNetworks(reapCtx)
+		reapCancel()
+	}
+
 	return m, nil
+}
+
+// cleanOrphanNetworks removes moat-managed networks whose run directory has
+// been deleted from disk. Best-effort: errors are logged but do not fail
+// manager initialization. Only sweeps the default runtime to avoid eagerly
+// initializing other runtimes.
+//
+// Networks are listed BEFORE run dirs to close the race with concurrent
+// Create() calls in another process: Create() makes the run dir before any
+// network op, so if a network exists at list time but its dir wasn't seen at
+// the later snapshot, the dir genuinely doesn't exist.
+//
+// Networks whose suffix isn't a valid run ID are skipped — protects users
+// who happen to have a network named e.g. "moat-shared".
+func (m *Manager) cleanOrphanNetworks(ctx context.Context) {
+	rt, err := m.runtimePool.Default()
+	if err != nil {
+		return
+	}
+	netMgr := rt.NetworkManager()
+	if netMgr == nil {
+		return
+	}
+
+	networks, err := netMgr.ListNetworks(ctx)
+	if err != nil {
+		log.Debug("orphan sweep: listing networks failed", "error", err)
+		return
+	}
+
+	known, err := storage.ListRunDirNames(storage.DefaultBaseDir())
+	if err != nil {
+		log.Debug("orphan sweep: scanning run dirs failed", "error", err)
+		return
+	}
+
+	var reaped int
+	for _, n := range networks {
+		runID, ok := strings.CutPrefix(n.Name, "moat-")
+		if !ok {
+			continue
+		}
+		if !id.IsValid(runID, "run") {
+			continue
+		}
+		if _, alive := known[runID]; alive {
+			continue
+		}
+		// Bound each removal individually so one wedged network doesn't burn
+		// the whole sweep budget.
+		rmCtx, rmCancel := context.WithTimeout(ctx, 5*time.Second)
+		log.Debug("removing orphan network", "name", n.Name, "id", n.ID)
+		if rmErr := netMgr.ForceRemoveNetwork(rmCtx, n.ID); rmErr != nil {
+			log.Debug("orphan sweep: failed to remove network", "name", n.Name, "error", rmErr)
+			rmCancel()
+			continue
+		}
+		rmCancel()
+		reaped++
+	}
+	if reaped > 0 {
+		log.Info("reaped orphan moat networks", "count", reaped)
+	}
 }
 
 // NewManager creates a new run manager with default options.
@@ -522,6 +607,13 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 		Interactive:   opts.Interactive,
 		CreatedAt:     time.Now(),
 		exitCh:        make(chan struct{}),
+	}
+
+	// Create the run directory before any network/container operations so that
+	// concurrent orphan sweeps (in another process's NewManager) treat this
+	// run's network as alive even before metadata.json is written.
+	if err := os.MkdirAll(filepath.Join(storage.DefaultBaseDir(), r.ID), 0o700); err != nil {
+		return nil, fmt.Errorf("creating run directory: %w", err)
 	}
 
 	// Default command

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -103,9 +103,16 @@ type Manager struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 
+	// monitorCtx/monitorCancel control monitorContainerExit goroutines.
+	// Separate from the main ctx so monitors can outlive general operations
+	// but still be canceled by Close(). Close() cancels monitorCtx first,
+	// then waits on monitorWg with a bounded timeout to prevent deadlocks
+	// when WaitContainer blocks (e.g., Docker daemon slow on custom networks).
+	monitorCtx    context.Context
+	monitorCancel context.CancelFunc
+
 	// monitorWg tracks active monitorContainerExit goroutines.
-	// Close() waits on this before closing the runtime so that
-	// monitors can finish capturing logs and updating state.
+	// Close() waits on this (with a timeout) after canceling monitorCtx.
 	monitorWg sync.WaitGroup
 }
 
@@ -163,6 +170,7 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	monitorCtx, monitorCancel := context.WithCancel(context.Background())
 	defaultRT, _ := pool.Default()
 	m := &Manager{
 		runtimePool:    pool,
@@ -172,6 +180,8 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 		proxyLifecycle: lifecycle,
 		ctx:            ctx,
 		cancel:         cancel,
+		monitorCtx:     monitorCtx,
+		monitorCancel:  monitorCancel,
 	}
 
 	// Load existing runs from disk and reconcile with container state.
@@ -439,7 +449,10 @@ func (m *Manager) registerPersistedRun(runState State, stateConfirmed bool, skip
 	// skipMonitor is set for cross-runtime runs where the runtime is unavailable —
 	// spawning a monitor would immediately fail and corrupt the persisted state.
 	if runState == StateRunning && !skipMonitor {
-		go m.monitorContainerExit(r)
+		// Inherited monitors from persisted runs are NOT tracked by monitorWg
+		// and use context.Background() — they may block indefinitely on
+		// long-running containers from previous CLI invocations.
+		go m.monitorContainerExit(context.Background(), r)
 	}
 }
 
@@ -2915,11 +2928,12 @@ func (m *Manager) Start(ctx context.Context, runID string, opts StartOptions) er
 	}
 
 	// Start background monitor to capture logs when container exits.
-	// Tracked by monitorWg so Close() waits for completion.
+	// Tracked by monitorWg so Close() waits for completion. Uses monitorCtx
+	// so Close() can cancel stuck monitors (prevents deadlock on custom networks).
 	m.monitorWg.Add(1)
 	go func() {
 		defer m.monitorWg.Done()
-		m.monitorContainerExit(r)
+		m.monitorContainerExit(m.monitorCtx, r)
 	}()
 
 	// Start proxy health monitor to re-register the run if the daemon restarts.
@@ -3432,7 +3446,12 @@ func (m *Manager) cleanupResources(ctx context.Context, r *Run) {
 // exitCh is closed, and resources are cleaned up regardless of which path
 // (interactive, non-interactive, Stop) caused the container to exit.
 // It's safe to call multiple times - captureLogs is idempotent.
-func (m *Manager) monitorContainerExit(r *Run) {
+//
+// The ctx parameter controls the WaitContainer call. Close() cancels this
+// context to unblock the monitor when the manager is shutting down, preventing
+// deadlocks when WaitContainer blocks indefinitely (e.g., Docker daemon slow
+// to report exit on custom networks — see #315).
+func (m *Manager) monitorContainerExit(ctx context.Context, r *Run) {
 	// Resolve the correct runtime for this run.
 	rt, rtErr := m.runtimeForRun(r)
 	if rtErr != nil {
@@ -3443,11 +3462,10 @@ func (m *Manager) monitorContainerExit(r *Run) {
 		return
 	}
 
-	// Wait for container to exit (no timeout - let it run as long as needed).
-	// This is the ONLY place that calls WaitContainer to avoid race conditions.
-	// Uses context.Background() so this goroutine is not canceled by Close().
-	// Close() waits on monitorWg before closing the runtime.
-	exitCode, err := rt.WaitContainer(context.Background(), r.ContainerID)
+	// Wait for container to exit. This is the ONLY place that calls
+	// WaitContainer to avoid race conditions. The context is typically
+	// monitorCtx, which Close() cancels to unblock stuck monitors.
+	exitCode, err := rt.WaitContainer(ctx, r.ContainerID)
 
 	// CRITICAL: Capture logs IMMEDIATELY after container exits, BEFORE signaling.
 	// Docker may start removing/cleaning the container at any moment after exit.
@@ -3795,19 +3813,37 @@ func (m *Manager) RuntimePool() *container.RuntimePool {
 }
 
 // Close releases manager resources.
-// It waits for active monitorContainerExit goroutines to finish so that
-// logs are captured and state is updated before the runtime is closed.
+// It cancels monitor goroutines and waits (with a bounded timeout) for them
+// to finish capturing logs and updating state before closing the runtime.
 func (m *Manager) Close() error {
 	// Cancel the manager context.
 	if m.cancel != nil {
 		m.cancel()
 	}
 
-	// Wait for all monitor goroutines to finish. This ensures log capture
-	// and state updates complete before we close the runtime connection.
-	// monitorContainerExit uses context.Background() so it is not
-	// affected by the cancel above.
-	m.monitorWg.Wait()
+	// Cancel monitor goroutines so WaitContainer unblocks. This prevents
+	// Close() from deadlocking when the Docker daemon is slow to report
+	// container exit (e.g., on custom networks with service dependencies).
+	// See https://github.com/majorcontext/moat/issues/315
+	if m.monitorCancel != nil {
+		m.monitorCancel()
+	}
+
+	// Wait for monitor goroutines to finish with a bounded timeout.
+	// Normally monitors complete quickly after context cancellation.
+	// The timeout is a safety net for cases where even a canceled
+	// WaitContainer doesn't return (e.g., Docker daemon unresponsive).
+	monitorDone := make(chan struct{})
+	go func() {
+		m.monitorWg.Wait()
+		close(monitorDone)
+	}()
+	select {
+	case <-monitorDone:
+		// All monitors finished cleanly.
+	case <-time.After(10 * time.Second):
+		log.Warn("timed out waiting for container monitors to finish; proceeding with shutdown")
+	}
 
 	// Stop all proxy/SSH servers and unregister runs from daemon,
 	// with a 10-second overall timeout.

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -211,8 +211,8 @@ func NewManagerWithOptions(opts ManagerOptions) (*Manager, error) {
 	// https://github.com/majorcontext/moat/issues/341.
 	if opts.ReapOrphanNetworks {
 		reapCtx, reapCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer reapCancel()
 		m.cleanOrphanNetworks(reapCtx)
-		reapCancel()
 	}
 
 	return m, nil
@@ -612,9 +612,20 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 	// Create the run directory before any network/container operations so that
 	// concurrent orphan sweeps (in another process's NewManager) treat this
 	// run's network as alive even before metadata.json is written.
-	if err := os.MkdirAll(filepath.Join(storage.DefaultBaseDir(), r.ID), 0o700); err != nil {
+	runDir := filepath.Join(storage.DefaultBaseDir(), r.ID)
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating run directory: %w", err)
 	}
+	// Remove the empty run dir if Create fails before successfully returning —
+	// otherwise we'd leak `~/.moat/runs/<id>/` directories with no metadata.json
+	// that don't surface in `moat list` or `moat clean`. Set to false on
+	// the success path before returning.
+	cleanupRunDir := true
+	defer func() {
+		if cleanupRunDir {
+			_ = os.RemoveAll(runDir)
+		}
+	}()
 
 	// Default command
 	cmd := opts.Cmd
@@ -2884,6 +2895,7 @@ region = %s
 	m.runs[r.ID] = r
 	m.mu.Unlock()
 
+	cleanupRunDir = false
 	return r, nil
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -143,6 +143,28 @@ func ListRunDirs(baseDir string) ([]string, error) {
 	return runIDs, nil
 }
 
+// ListRunDirNames returns the set of subdirectory names under baseDir.
+// Unlike ListRunDirs, it does NOT require metadata.json — Create() makes the
+// directory before writing metadata, so this catches in-flight runs that
+// ListRunDirs would miss. Used by orphan resource sweeps where it's important
+// to treat newly-created (but not yet persisted) runs as alive.
+func ListRunDirNames(baseDir string) (map[string]struct{}, error) {
+	entries, err := os.ReadDir(baseDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]struct{}{}, nil
+		}
+		return nil, err
+	}
+	names := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			names[e.Name()] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
 // LogEntry represents a single log line with timestamp.
 type LogEntry struct {
 	Timestamp time.Time `json:"ts"`


### PR DESCRIPTION
## Summary

Three commits addressing #315 (E2E service tests intermittently hang):

1. **`fix(run): prevent Close() deadlock when WaitContainer blocks`** — earlier work; bounds `Close()` so a stuck monitor goroutine can't deadlock teardown.
2. **`docs: add investigation brief for #315`** — captures what was tried and what's left.
3. **`fix(run): bound network create and reap orphan moat networks`** (new) — finds and fixes the actual hang.

The actual root cause for the test hangs: orphaned `moat-*` container networks accumulate from crashed/timed-out test processes whose `defer mgr.Destroy()` didn't run. Each leaked network on Apple's container runtime keeps a `vmnet` daemon alive and consumes a `/24` from the IP allocation pool. Once the pool is exhausted, `container network create` blocks indefinitely waiting for free space.

### What changed in the new commit

- **Bounded `CreateNetwork`** on both Apple (`apple_network.go`) and Docker (`docker.go`) with a shared 30s timeout (`networkCreateTimeout` in `runtime.go`). Each runtime returns a clear error naming the runtime-specific diagnostic command.
- **Orphan network sweep** at `NewManagerWithOptions` time, gated behind `ManagerOptions.ReapOrphanNetworks`. Wired into `moat run` (via `cmd/moat/cli/exec.go`) and `moat clean` only — read-only commands skip the cost.
- **Sweep heuristic**: list networks → snapshot run dirs (LIFO order closes the residual TOCTOU window) → reap any `moat-<runID>` whose dir is missing AND whose suffix is a valid moat run ID. The validation protects users with manually-created networks like `moat-shared`.
- **Race-window closure**: `Create()` now creates the run dir at the very top before any container/network operation, so concurrent sweeps in another process always see in-flight runs.
- **Per-removal 5s sub-context** prevents one wedged network from burning the entire sweep budget.
- **`appleNetworkManager.ListNetworks` parsing bug fix** — was returning the entire multi-column line as the network name. Extracted parsing into `parseAppleNetworkList` for unit testing.
- **`forceCleanupRun` test helper** (renamed `cleanupRun`) does Stop+Destroy via `t.Cleanup` so a failing assertion no longer leaks the run's network. Removed `t.Skip` from all 5 service tests.

### Long-term follow-up

Daemon-side reaper tracked as #341 — moving the sweep into the long-lived proxy daemon would eliminate the per-CLI-invocation cost and give us periodic background cleanup that catches hard-process-kill leaks.

## Test plan

- [x] `make test-unit` — passes with race detector (38 packages)
- [x] `make lint` — 0 issues
- [x] `MOAT_RUNTIME=docker go test -tags=e2e -run '^TestService' ./internal/e2e/` — all 5 service tests pass in ~10s
- [x] `MOAT_RUNTIME=apple go test -tags=e2e -run '^TestService' ./internal/e2e/` — all 5 service tests pass on a clean Apple system
- [x] `MOAT_RUNTIME=apple` with exhausted IP pool — fails fast at 30s with the precise diagnostic, instead of hanging until the outer test timeout
- [x] New `TestParseAppleNetworkList` covers the multi-column parsing fix that was silently broken since the function was written
- [ ] Verify CI runs cleanly (was previously fresh state, so fix should not regress)