### PR TITLE
feat(tui): add ctrl+/ d (dump) and r (reset) shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ### Added
 
-- **TUI debug shortcuts** — `Ctrl-/ d` dumps a snapshot of recent terminal I/O to `~/.moat/runs/<id>/tui-debug-<unix-ts>.json` for offline analysis or feeding into a Claude session; `Ctrl-/ r` issues a soft terminal reset and nudges the child to redraw, recovering wedged sessions. The dump uses the same JSON format as `--tty-trace` and works with `moat tty-trace analyze`. Ring buffer size is 8 MB by default, tunable via `MOAT_TTY_RING_BYTES`. ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
+- **TUI debug shortcuts** — `Ctrl-/ d` dumps a snapshot of recent terminal I/O to `~/.moat/runs/<id>/tui-debug-<unix-ts>.json` for offline analysis or feeding into a Claude session; `Ctrl-/ r` issues a soft terminal reset and nudges the child to redraw, recovering wedged sessions. The dump uses the same JSON format as `--tty-trace` and works with `moat tty-trace analyze`. Ring buffer size is 8 MB by default, tunable via `MOAT_TTY_RING_BYTES`. ([#343](https://github.com/majorcontext/moat/pull/343))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ## Unreleased
 
+### Added
+
+- **TUI debug shortcuts** — `Ctrl-/ d` dumps a snapshot of recent terminal I/O to `~/.moat/runs/<id>/tui-debug-<unix-ts>.json` for offline analysis or feeding into a Claude session; `Ctrl-/ r` issues a soft terminal reset and nudges the child to redraw, recovering wedged sessions. The dump uses the same JSON format as `--tty-trace` and works with `moat tty-trace analyze`. Ring buffer size is 8 MB by default, tunable via `MOAT_TTY_RING_BYTES`. ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
+
 ### Changed
 
 - **Gatekeeper extracted to standalone module** — `internal/proxy/` and `cmd/gatekeeper/` have moved to [github.com/majorcontext/gatekeeper](https://github.com/majorcontext/gatekeeper). The `ghcr.io/majorcontext/moat-gatekeeper` image is no longer published from this repository. ([#333](https://github.com/majorcontext/moat/pull/333))

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -633,7 +633,7 @@ func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWrite
 	}
 
 	if statusWriter == nil {
-		flash("tui reset: no status writer")
+		log.Warn("ctrl+/ r pressed but no status writer; skipping reset")
 		return
 	}
 	if err := statusWriter.Reset(); err != nil {

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/run"
 	"github.com/majorcontext/moat/internal/snapshot"
+	"github.com/majorcontext/moat/internal/storage"
 	"github.com/majorcontext/moat/internal/term"
 	"github.com/majorcontext/moat/internal/trace"
 	"github.com/majorcontext/moat/internal/tui"
@@ -28,6 +31,11 @@ const (
 	// ttyStartupDelay is how long to wait before resizing TTY after container starts.
 	// This allows the container process to initialize before we resize.
 	ttyStartupDelay = 200 * time.Millisecond
+
+	// defaultRingBytes is the default byte budget for the always-on TUI debug ring
+	// buffer. ~5–15 minutes of typical terminal output. Override with
+	// MOAT_TTY_RING_BYTES.
+	defaultRingBytes = 8 * 1024 * 1024
 )
 
 // Re-export types from internal/cli for backward compatibility
@@ -358,6 +366,23 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	tracer := setupTTYTracer(tracePath, r, command)
 	defer tracer.save()
 
+	// Always-on bounded ring buffer for on-demand TUI debug dumps.
+	ringBytes := defaultRingBytes
+	if env := os.Getenv("MOAT_TTY_RING_BYTES"); env != "" {
+		if n, err := strconv.Atoi(env); err == nil && n > 0 {
+			ringBytes = n
+		} else {
+			log.Warn("invalid MOAT_TTY_RING_BYTES, using default", "value", env, "default", defaultRingBytes)
+		}
+	}
+	ringWidth, ringHeight := 80, 24
+	if term.IsTerminal(os.Stdout) {
+		if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
+			ringWidth, ringHeight = w, h
+		}
+	}
+	ringRecorder := trace.NewRingRecorder(r.ID, command, trace.GetTraceEnv(), trace.Size{Width: ringWidth, Height: ringHeight}, ringBytes)
+
 	// Put terminal in raw mode to capture escape sequences without echo
 	var rawState *term.RawModeState
 	if term.IsTerminal(os.Stdin) {
@@ -386,6 +411,7 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	if tracer != nil {
 		stdout = trace.NewRecordingWriter(stdout, tracer.recorder, trace.EventStdout)
 	}
+	stdout = trace.NewRecordingWriter(stdout, ringRecorder, trace.EventStdout)
 
 	// Wrap stdin with escape proxy to detect stop sequences
 	escapeProxy := term.NewEscapeProxy(os.Stdin)
@@ -395,12 +421,17 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 		statusWriter.SetupEscapeHints(escapeProxy)
 	}
 
-	// Set up callback for non-disruptive escape actions (snapshot)
+	// Set up callback for non-disruptive escape actions (snapshot, dump, reset)
 	var flashMu sync.Mutex
 	var flashTimer *time.Timer
 	escapeProxy.OnAction(func(action term.EscapeAction) {
-		if action == term.EscapeSnapshot {
+		switch action {
+		case term.EscapeSnapshot:
 			go takeSnapshot(r, statusWriter, &flashMu, &flashTimer)
+		case term.EscapeDumpTUI:
+			go dumpTUI(r, ringRecorder, statusWriter, &flashMu, &flashTimer)
+		case term.EscapeResetTUI:
+			go resetTUI(ctx, manager, r, statusWriter, &flashMu, &flashTimer)
 		}
 	})
 
@@ -429,6 +460,7 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	if tracer != nil {
 		stdin = trace.NewRecordingReader(stdin, tracer.recorder, trace.EventStdin)
 	}
+	stdin = trace.NewRecordingReader(stdin, ringRecorder, trace.EventStdin)
 
 	// Set up signal handling
 	sigCh := make(chan os.Signal, 1)
@@ -475,6 +507,7 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 						if tracer != nil {
 							tracer.recorder.AddResize(width, height)
 						}
+						ringRecorder.AddResize(width, height)
 						_ = statusWriter.Resize(width, height)
 						// Also resize container TTY
 						// #nosec G115 -- width/height are validated positive above
@@ -548,4 +581,75 @@ func takeSnapshot(r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, fla
 	}
 
 	flash("Snapshot saved: " + snap.ID)
+}
+
+// dumpTUI saves the in-memory TTY ring buffer to disk and flashes the path.
+func dumpTUI(r *run.Run, ringRecorder *trace.RingRecorder, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
+	flash := func(msg string) {
+		if statusWriter == nil {
+			return
+		}
+		flashMu.Lock()
+		defer flashMu.Unlock()
+		if *flashTimer != nil {
+			(*flashTimer).Stop()
+		}
+		statusWriter.SetMessage(msg)
+		_ = statusWriter.UpdateStatus()
+		*flashTimer = time.AfterFunc(2*time.Second, func() {
+			statusWriter.ClearMessage()
+			_ = statusWriter.UpdateStatus()
+		})
+	}
+
+	runDir := filepath.Join(storage.DefaultBaseDir(), r.ID)
+	path := filepath.Join(runDir, fmt.Sprintf("tui-debug-%d.json", time.Now().Unix()))
+	if err := ringRecorder.Dump(path); err != nil {
+		log.Error("tui dump failed", "path", path, "error", err)
+		flash("tui dump failed: " + err.Error())
+		return
+	}
+	log.Info("tui dump saved", "path", path)
+	flash("tui dump saved: " + path)
+}
+
+// resetTUI emits a soft terminal reset and nudges the container to redraw.
+func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
+	flash := func(msg string) {
+		if statusWriter == nil {
+			return
+		}
+		flashMu.Lock()
+		defer flashMu.Unlock()
+		if *flashTimer != nil {
+			(*flashTimer).Stop()
+		}
+		statusWriter.SetMessage(msg)
+		_ = statusWriter.UpdateStatus()
+		*flashTimer = time.AfterFunc(2*time.Second, func() {
+			statusWriter.ClearMessage()
+			_ = statusWriter.UpdateStatus()
+		})
+	}
+
+	if statusWriter == nil {
+		flash("tui reset: no status writer")
+		return
+	}
+	if err := statusWriter.Reset(); err != nil {
+		log.Error("tui reset failed", "error", err)
+		flash("tui reset failed: " + err.Error())
+		return
+	}
+
+	if term.IsTerminal(os.Stdout) {
+		if width, height := term.GetSize(os.Stdout); width > 0 && height > 0 {
+			// #nosec G115 -- width/height validated positive
+			if err := manager.ResizeTTY(ctx, r.ID, uint(height), uint(width)); err != nil {
+				log.Debug("post-reset resize nudge failed", "error", err)
+			}
+		}
+	}
+
+	flash("tui reset")
 }

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -421,22 +421,15 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 		statusWriter.SetupEscapeHints(escapeProxy)
 	}
 
-	// Set up callback for non-disruptive escape actions (snapshot, dump, reset)
-	var flashMu sync.Mutex
-	var flashTimer *time.Timer
-	escapeProxy.OnAction(func(action term.EscapeAction) {
-		switch action {
-		case term.EscapeSnapshot:
-			go takeSnapshot(r, statusWriter, &flashMu, &flashTimer)
-		case term.EscapeDumpTUI:
-			go dumpTUI(r, ringRecorder, statusWriter, &flashMu, &flashTimer)
-		case term.EscapeResetTUI:
-			go resetTUI(ctx, manager, r, statusWriter, &flashMu, &flashTimer)
-		}
-	})
-
-	// Build stdin reader chain: escape proxy -> clipboard proxy (optional) -> tracer (optional)
+	// Build stdin reader chain. Layering, from upstream to downstream:
+	//   os.Stdin -> escapeProxy -> injectable -> clipboard? -> tracer? -> ring
+	// The injectable reader sits just below the escape proxy so synthetic
+	// keystrokes (e.g. Ctrl+L from resetTUI) flow through the recorders and
+	// appear in trace dumps.
 	var stdin io.Reader = escapeProxy
+	injectable := term.NewInjectableReader(stdin)
+	defer injectable.Close()
+	stdin = injectable
 	if r.Clipboard {
 		stdin = term.NewClipboardProxy(stdin, func() {
 			done := make(chan struct{})
@@ -461,6 +454,20 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 		stdin = trace.NewRecordingReader(stdin, tracer.recorder, trace.EventStdin)
 	}
 	stdin = trace.NewRecordingReader(stdin, ringRecorder, trace.EventStdin)
+
+	// Set up callback for non-disruptive escape actions (snapshot, dump, reset).
+	var flashMu sync.Mutex
+	var flashTimer *time.Timer
+	escapeProxy.OnAction(func(action term.EscapeAction) {
+		switch action {
+		case term.EscapeSnapshot:
+			go takeSnapshot(r, statusWriter, &flashMu, &flashTimer)
+		case term.EscapeDumpTUI:
+			go dumpTUI(r, ringRecorder, statusWriter, &flashMu, &flashTimer)
+		case term.EscapeResetTUI:
+			go resetTUI(ctx, manager, r, statusWriter, injectable, &flashMu, &flashTimer)
+		}
+	})
 
 	// Set up signal handling
 	sigCh := make(chan os.Signal, 1)
@@ -614,7 +621,10 @@ func dumpTUI(r *run.Run, ringRecorder *trace.RingRecorder, statusWriter *tui.Wri
 }
 
 // resetTUI emits a soft terminal reset and nudges the container to redraw.
-func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
+// injectable, if non-nil, is used to splice Ctrl+L into the child's stdin —
+// many TUIs treat that as a redraw command. A SIGWINCH is also fired as a
+// belt-and-suspenders nudge for TUIs that ignore Ctrl+L.
+func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWriter *tui.Writer, injectable *term.InjectableReader, flashMu *sync.Mutex, flashTimer **time.Timer) {
 	flash := func(msg string) {
 		if statusWriter == nil {
 			return
@@ -640,6 +650,18 @@ func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWrite
 		log.Error("tui reset failed", "error", err)
 		flash("tui reset failed: " + err.Error())
 		return
+	}
+
+	// Send Ctrl+L (form feed) — the de facto redraw convention for terminal
+	// UIs. Inject blocks until the byte is consumed by the child, so run
+	// it in a goroutine to avoid stalling the reset path if the child is
+	// slow to read.
+	if injectable != nil {
+		go func() {
+			if err := injectable.Inject([]byte{0x0C}); err != nil {
+				log.Debug("post-reset Ctrl+L inject failed", "error", err)
+			}
+		}()
 	}
 
 	if term.IsTerminal(os.Stdout) {

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -367,12 +367,14 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	defer tracer.save()
 
 	// Always-on bounded ring buffer for on-demand TUI debug dumps.
+	// MOAT_TTY_RING_BYTES overrides the default; 0 disables eviction (unbounded);
+	// non-numeric or negative values fall back to the default with a user-visible warning.
 	ringBytes := defaultRingBytes
 	if env := os.Getenv("MOAT_TTY_RING_BYTES"); env != "" {
-		if n, err := strconv.Atoi(env); err == nil && n > 0 {
+		if n, err := strconv.Atoi(env); err == nil && n >= 0 {
 			ringBytes = n
 		} else {
-			log.Warn("invalid MOAT_TTY_RING_BYTES, using default", "value", env, "default", defaultRingBytes)
+			ui.Warnf("MOAT_TTY_RING_BYTES=%q is not a non-negative integer; using default %d", env, defaultRingBytes)
 		}
 	}
 	ringWidth, ringHeight := 80, 24
@@ -554,26 +556,41 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	}
 }
 
-// takeSnapshot creates a manual snapshot and shows the result in the status bar.
-// The flashMu/flashTimer pair are shared across calls to prevent rapid snapshots
-// from clearing each other's flash message.
-func takeSnapshot(r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
-	flash := func(msg string) {
-		if statusWriter == nil {
-			return
-		}
+// flashMessage briefly shows a message in the status bar, replacing any prior
+// flash. The flashMu/flashTimer pair are shared across all flash callers so
+// rapid calls don't clear each other's messages.
+//
+// The auto-clear callback re-acquires flashMu and verifies it is still the
+// current owner before clearing, so a new flash that arrives while the old
+// timer is firing isn't immediately wiped.
+func flashMessage(statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer, msg string) {
+	if statusWriter == nil {
+		return
+	}
+	flashMu.Lock()
+	defer flashMu.Unlock()
+	if *flashTimer != nil {
+		(*flashTimer).Stop()
+	}
+	statusWriter.SetMessage(msg)
+	_ = statusWriter.UpdateStatus()
+
+	var thisTimer *time.Timer
+	thisTimer = time.AfterFunc(2*time.Second, func() {
 		flashMu.Lock()
 		defer flashMu.Unlock()
-		if *flashTimer != nil {
-			(*flashTimer).Stop()
+		if *flashTimer != thisTimer {
+			return // a newer flash has taken over
 		}
-		statusWriter.SetMessage(msg)
+		statusWriter.ClearMessage()
 		_ = statusWriter.UpdateStatus()
-		*flashTimer = time.AfterFunc(2*time.Second, func() {
-			statusWriter.ClearMessage()
-			_ = statusWriter.UpdateStatus()
-		})
-	}
+	})
+	*flashTimer = thisTimer
+}
+
+// takeSnapshot creates a manual snapshot and shows the result in the status bar.
+func takeSnapshot(r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
+	flash := func(msg string) { flashMessage(statusWriter, flashMu, flashTimer, msg) }
 
 	if r.SnapEngine == nil {
 		flash("Snapshots not configured")
@@ -592,24 +609,14 @@ func takeSnapshot(r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, fla
 
 // dumpTUI saves the in-memory TTY ring buffer to disk and flashes the path.
 func dumpTUI(r *run.Run, ringRecorder *trace.RingRecorder, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
-	flash := func(msg string) {
-		if statusWriter == nil {
-			return
-		}
-		flashMu.Lock()
-		defer flashMu.Unlock()
-		if *flashTimer != nil {
-			(*flashTimer).Stop()
-		}
-		statusWriter.SetMessage(msg)
-		_ = statusWriter.UpdateStatus()
-		*flashTimer = time.AfterFunc(2*time.Second, func() {
-			statusWriter.ClearMessage()
-			_ = statusWriter.UpdateStatus()
-		})
-	}
+	flash := func(msg string) { flashMessage(statusWriter, flashMu, flashTimer, msg) }
 
 	runDir := filepath.Join(storage.DefaultBaseDir(), r.ID)
+	if err := os.MkdirAll(runDir, 0700); err != nil {
+		log.Error("tui dump mkdir failed", "dir", runDir, "error", err)
+		flash("tui dump failed: " + err.Error())
+		return
+	}
 	path := filepath.Join(runDir, fmt.Sprintf("tui-debug-%d.json", time.Now().Unix()))
 	if err := ringRecorder.Dump(path); err != nil {
 		log.Error("tui dump failed", "path", path, "error", err)
@@ -625,22 +632,7 @@ func dumpTUI(r *run.Run, ringRecorder *trace.RingRecorder, statusWriter *tui.Wri
 // many TUIs treat that as a redraw command. A SIGWINCH is also fired as a
 // belt-and-suspenders nudge for TUIs that ignore Ctrl+L.
 func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWriter *tui.Writer, injectable *term.InjectableReader, flashMu *sync.Mutex, flashTimer **time.Timer) {
-	flash := func(msg string) {
-		if statusWriter == nil {
-			return
-		}
-		flashMu.Lock()
-		defer flashMu.Unlock()
-		if *flashTimer != nil {
-			(*flashTimer).Stop()
-		}
-		statusWriter.SetMessage(msg)
-		_ = statusWriter.UpdateStatus()
-		*flashTimer = time.AfterFunc(2*time.Second, func() {
-			statusWriter.ClearMessage()
-			_ = statusWriter.UpdateStatus()
-		})
-	}
+	flash := func(msg string) { flashMessage(statusWriter, flashMu, flashTimer, msg) }
 
 	if statusWriter == nil {
 		log.Warn("ctrl+/ r pressed but no status writer; skipping reset")

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -138,7 +138,17 @@ moat run [flags] [path] [-- command]
 moat run ./my-project
 ```
 
-**Interactive (`-i`):** The run owns the terminal with stdin/stdout/stderr connected and a TTY allocated. Press `Ctrl-/ k` to stop the run. `Ctrl+C` is forwarded to the container process.
+**Interactive (`-i`):** The run owns the terminal with stdin/stdout/stderr connected and a TTY allocated. `Ctrl+C` is forwarded to the container process. The Ctrl-/ menu offers the following actions:
+
+| Key | Action |
+| --- | --- |
+| `Ctrl-/ s` | Take a manual workspace snapshot |
+| `Ctrl-/ k` | Stop the run |
+| `Ctrl-/ d` | Dump the in-memory TTY history to `~/.moat/runs/<id>/tui-debug-<unix-ts>.json` for offline analysis with `moat tty-trace analyze` |
+| `Ctrl-/ r` | Soft-reset the terminal (recover from rendering corruption) |
+| `Ctrl-/ Ctrl-/` | Cancel the menu |
+
+The TTY history is captured into a bounded ring buffer (default 8 MB, override with `MOAT_TTY_RING_BYTES`) for every interactive session, so `Ctrl-/ d` can be used retroactively after a rendering bug appears.
 
 ```bash
 moat run -i -- bash

--- a/docs/plans/2026-04-25-tui-debug-dump-reset-design.md
+++ b/docs/plans/2026-04-25-tui-debug-dump-reset-design.md
@@ -1,0 +1,201 @@
+# TUI Debug — On-Demand History Dump and Terminal Reset
+
+## Problem
+
+Interactive Moat sessions occasionally hit terminal-rendering bugs that are hard to reproduce: e.g. multiple Moat footers interlaced with the child's UI, after which the session is wedged. The existing `--tty-trace=FILE` flag captures everything from session start, but only when set up front — by the time the bug manifests, it's too late to start recording. There's also no way to recover the terminal short of killing the run.
+
+This design adds two on-demand actions to the existing Ctrl+/ menu:
+
+- **`d` (dump TUI history)** — writes the in-memory trace ring buffer to a file for offline analysis or feeding into a Claude session.
+- **`r` (reset terminal)** — issues a hard terminal reset and nudges the child to redraw, attempting to unstick a wedged session.
+
+## Goals
+
+- Capture useful debug artifacts retroactively, with no flag required.
+- Reuse the existing `Trace` JSON format and `moat tty-trace analyze` tool.
+- Keep memory cost bounded and predictable.
+- Recover from common stuck-footer cases without restarting the session.
+
+## Non-goals
+
+- Auto-detection of corruption or auto-reset. The user pulls the trigger.
+- New analyzer features. Existing `moat tty-trace analyze` is sufficient.
+- Persisted ring buffer across runs. Process-local memory only.
+- Reproducing the underlying bug in tests. By definition we can't.
+
+## Architecture
+
+Three components, each in its existing package:
+
+### 1. `internal/trace` — `RingRecorder`
+
+New file `internal/trace/ring.go`. A `RingRecorder` records `Event`s into a bounded byte budget, evicting oldest events FIFO when the budget would be exceeded.
+
+```go
+type RingRecorder struct {
+    mu        sync.Mutex
+    trace     *Trace
+    startTime time.Time
+    maxBytes  int
+    curBytes  int
+}
+
+func NewRingRecorder(runID string, command []string, env map[string]string, initialSize Size, maxBytes int) *RingRecorder
+func (r *RingRecorder) AddEvent(eventType EventType, data []byte)
+func (r *RingRecorder) AddResize(width, height int)
+func (r *RingRecorder) AddSignal(sig string)
+func (r *RingRecorder) Dump(path string) error
+```
+
+`maxBytes` defaults to 8 MB, overridable via `MOAT_TTY_RING_BYTES`. At typical terminal write volume this covers ~5–15 minutes of backlog.
+
+`Dump` snapshots the current event list and writes a standard `Trace` JSON file via the existing `Trace.Save` path. Timestamps are monotonic from session start regardless of eviction (the analyzer treats them as relative).
+
+To let `RecordingWriter`/`RecordingReader` write to either recorder type, extract an interface in `recorder.go`:
+
+```go
+type EventRecorder interface {
+    AddEvent(eventType EventType, data []byte)
+    AddResize(width, height int)
+    AddSignal(sig string)
+}
+```
+
+`*Recorder` and `*RingRecorder` both satisfy it. `RecordingWriter`/`RecordingReader` take `EventRecorder` instead of `*Recorder`. Callers pass either.
+
+### 2. `internal/tui` — `Writer.Reset`
+
+New method on `*Writer`:
+
+```go
+func (w *Writer) Reset() error
+```
+
+Behavior, under `w.mu`:
+
+1. Stop `footerTimer` if running.
+2. If `altScreen`: stop the render loop, exit alt screen (`ESC[?1049l`), drop the emulator, set `altScreen = false`.
+3. Emit a soft reset sequence (`ESC[!p` — DECSTR), clear screen (`ESC[2J`), home cursor (`ESC[H`).
+4. Reset the `escBuf` partial-escape buffer to empty.
+5. Re-run `setupScrollRegionLocked()`, which re-establishes DECSTBM and redraws the footer.
+
+We use soft reset (`ESC[!p`) rather than full RIS (`ESC c`) to avoid clearing the user's scrollback. Soft reset clears the scroll region, character attributes, cursor mode, and saved cursor — enough to recover the cases we expect, without nuking the terminal session itself.
+
+The caller is responsible for nudging the child to redraw — see exec.go wiring.
+
+### 3. `internal/term` — escape proxy keys
+
+Add to `escape.go`:
+
+```go
+const (
+    EscapeNone EscapeAction = iota
+    EscapeStop
+    EscapeSnapshot
+    EscapeDumpTUI    // new
+    EscapeResetTUI   // new
+)
+
+const (
+    escapeKeyStop     byte = 'k'
+    escapeKeySnapshot byte = 's'
+    escapeKeyDumpTUI  byte = 'd' // new
+    escapeKeyResetTUI byte = 'r' // new
+)
+```
+
+Both new actions are routed through the existing `onAction` callback path (non-disruptive — they don't unwind `Read()`).
+
+Update `EscapeHelpText()` and the in-session footer hint:
+
+```
+ctrl+/ s (snapshot) · k (stop) · d (dump tui) · r (reset tui)
+```
+
+## Wire-up in `cmd/moat/cli/exec.go`
+
+`RunInteractiveAttached` changes:
+
+- Always construct a `RingRecorder` for interactive sessions (independent of `--tty-trace`).
+- If `--tty-trace` is also set, chain both recorders. `RecordingWriter` and `RecordingReader` are wrappable, so we layer them — each recorder gets its own copy of events.
+- The explicit trace recorder remains unbounded (existing behavior). The ring recorder is always bounded.
+
+Add two `OnAction` branches alongside the existing snapshot handler:
+
+```go
+case term.EscapeDumpTUI:
+    go dumpTUI(r, ringRecorder, statusWriter, &flashMu, &flashTimer)
+case term.EscapeResetTUI:
+    go resetTUI(ctx, manager, r, statusWriter, &flashMu, &flashTimer)
+```
+
+`dumpTUI`:
+- Writes to `<run-dir>/tui-debug-<unix-ts>.json` where `<run-dir>` is `r.Dir()` (or equivalent — match the path used by `takeSnapshot`).
+- On success, flash the path in the footer using the existing flash mechanism.
+- On error, log via `log.Error` and flash `tui dump failed: <err>`.
+
+`resetTUI`:
+- Calls `statusWriter.Reset()`.
+- Then calls `manager.ResizeTTY(ctx, r.ID, height, width)` with current terminal dimensions to provoke the child to redraw.
+- On success, flash `tui reset`.
+- On error, log + flash `tui reset failed: <err>`. The session was already broken; don't make it worse.
+
+## Data flow
+
+Reading direction (terminal → container):
+
+```
+os.Stdin → escapeProxy → [clipboardProxy?] → ringRecorderReader → [traceRecorderReader?] → container
+```
+
+Writing direction (container → terminal):
+
+```
+container → ringRecorderWriter → [traceRecorderWriter?] → tuiWriter → os.Stdout
+```
+
+The recorders sit between the escape/clipboard layers and the I/O endpoint, so they observe exactly what the child sees on stdin and exactly what bytes the child emits — equivalent to `--tty-trace` semantics today.
+
+## Error handling
+
+- `Dump` failure: log + flash. Session continues.
+- `Reset` write failure to terminal: log + flash. Session continues; user can retry or kill.
+- `RingRecorder` is best-effort: if eviction has a bug, recordings are wrong but the session is unaffected. No `RingRecorder` error returns from `AddEvent`.
+- `MOAT_TTY_RING_BYTES` parse failure: log warning, fall back to default. Don't fail session startup over a bad env var.
+
+## Testing
+
+Unit tests:
+
+- `RingRecorder`:
+  - Eviction at byte budget — adding events past `maxBytes` evicts oldest.
+  - `Dump` produces a valid `Trace` JSON readable by `trace.Load`.
+  - Timestamps monotonic across eviction (the analyzer's resize-issue detector relies on this).
+  - Concurrent `AddEvent` from multiple goroutines (race detector).
+- `EscapeProxy`:
+  - `Ctrl-/ d` fires `OnAction(EscapeDumpTUI)`, no bytes pass through.
+  - `Ctrl-/ r` fires `OnAction(EscapeResetTUI)`, no bytes pass through.
+  - Match the existing `EscapeSnapshot` test pattern in `escape_test.go`.
+- `Writer.Reset`:
+  - From scroll mode — emitted bytes contain soft reset, DECSTBM, footer redraw.
+  - From alt screen mode — emitted bytes include alt-screen exit before reset, render loop is stopped.
+  - Footer timer stopped after `Reset` returns.
+
+Manual verification (no E2E):
+
+- `d` produces a file at the expected path with non-zero events.
+- `moat tty-trace analyze <dump>` runs successfully on a dump.
+- `r` redraws the footer and triggers Claude Code to redraw.
+
+## Backwards compatibility
+
+- `Trace` JSON format unchanged. Existing `moat tty-trace analyze` consumes dumps without modification.
+- `--tty-trace` flag behavior unchanged. The ring recorder runs alongside it.
+- `EscapeAction` enum values are append-only (`EscapeDumpTUI`, `EscapeResetTUI` added at the end). No existing key bindings change.
+- Footer hint text changes to include `d` and `r`. User-visible string only.
+
+## Out of scope (future work)
+
+- Pulling the dump trigger from a slash command inside Claude Code rather than the Moat menu.
+- Including a screenshot of the rendered emulator state alongside the raw event stream in dumps.
+- Auto-dump on detected corruption (would need a corruption signal we don't currently have).

--- a/docs/plans/2026-04-25-tui-debug-dump-reset-plan.md
+++ b/docs/plans/2026-04-25-tui-debug-dump-reset-plan.md
@@ -1,0 +1,1034 @@
+# TUI Debug — Dump and Reset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Ctrl+/ shortcuts `d` (dump TUI history) and `r` (reset terminal) to interactive Moat sessions, backed by an always-on bounded ring buffer of TTY events.
+
+**Architecture:** A new `RingRecorder` in `internal/trace` mirrors the existing `Recorder` API but enforces a byte budget with FIFO eviction. `RecordingWriter` and `RecordingReader` are generalized via a new `EventRecorder` interface so either recorder type works. `internal/tui.Writer` gains a `Reset()` method that emits a soft terminal reset and re-establishes the scroll region/footer. Two new escape actions in `internal/term` route through the existing `OnAction` callback pattern. `cmd/moat/cli/exec.go` wires the ring recorder into every interactive session and handles the two new escape callbacks.
+
+**Tech Stack:** Go, existing `internal/trace`/`internal/tui`/`internal/term` packages. No new dependencies.
+
+**Spec:** `docs/plans/2026-04-25-tui-debug-dump-reset-design.md`
+
+---
+
+## File Map
+
+**Create:**
+- `internal/trace/ring.go` — `RingRecorder` type with byte-bounded FIFO eviction.
+- `internal/trace/ring_test.go` — unit tests for ring recorder.
+
+**Modify:**
+- `internal/trace/recorder.go` — extract `EventRecorder` interface; change `RecordingWriter`/`RecordingReader` to take it.
+- `internal/term/escape.go` — add `EscapeDumpTUI`/`EscapeResetTUI` actions and `d`/`r` keys; update `EscapeHelpText`.
+- `internal/term/escape_test.go` — adjust the test case using `d` as an unrecognized key; add tests for new actions.
+- `internal/tui/writer.go` — add `Reset()` method; update `SetupEscapeHints` menu text.
+- `internal/tui/writer_test.go` — add `Reset()` tests.
+- `cmd/moat/cli/exec.go` — always-on ring recorder; `dumpTUI`/`resetTUI` handlers; wire new `OnAction` cases.
+
+---
+
+## Task 1: Extract `EventRecorder` interface
+
+**Why:** `RecordingWriter` and `RecordingReader` currently embed `*Recorder`. We need them to also accept the upcoming `*RingRecorder`.
+
+**Files:**
+- Modify: `internal/trace/recorder.go`
+
+- [ ] **Step 1: Add the interface and switch the wrappers to use it**
+
+Edit `internal/trace/recorder.go`. Add the interface near the top (right after the imports / `Recorder` declarations) and update the wrapper structs:
+
+```go
+// EventRecorder is the minimal surface used by RecordingWriter/RecordingReader.
+// Both *Recorder (unbounded) and *RingRecorder (bounded) satisfy it.
+type EventRecorder interface {
+    AddEvent(eventType EventType, data []byte)
+    AddResize(width, height int)
+    AddSignal(sig string)
+}
+```
+
+Change the `RecordingWriter` and `RecordingReader` structs from `recorder *Recorder` to `recorder EventRecorder`, and update the constructors:
+
+```go
+type RecordingWriter struct {
+    w         io.Writer
+    recorder  EventRecorder
+    eventType EventType
+}
+
+func NewRecordingWriter(w io.Writer, recorder EventRecorder, eventType EventType) io.Writer {
+    return &RecordingWriter{w: w, recorder: recorder, eventType: eventType}
+}
+
+type RecordingReader struct {
+    r         io.Reader
+    recorder  EventRecorder
+    eventType EventType
+}
+
+func NewRecordingReader(r io.Reader, recorder EventRecorder, eventType EventType) io.Reader {
+    return &RecordingReader{r: r, recorder: recorder, eventType: eventType}
+}
+```
+
+The `Write`/`Read` methods don't change — they call `rw.recorder.AddEvent(...)` which the interface satisfies.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./internal/trace/...`
+Expected: success.
+
+- [ ] **Step 3: Run trace tests**
+
+Run: `go test ./internal/trace/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/trace/recorder.go
+git commit -m "refactor(trace): extract EventRecorder interface"
+```
+
+---
+
+## Task 2: `RingRecorder` — failing test
+
+**Files:**
+- Create: `internal/trace/ring_test.go`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `internal/trace/ring_test.go` with the full content below. It covers eviction, dump format, monotonic timestamps across eviction, and concurrent writes.
+
+```go
+package trace
+
+import (
+    "bytes"
+    "path/filepath"
+    "sync"
+    "testing"
+)
+
+func TestRingRecorder_AddAndDump(t *testing.T) {
+    r := NewRingRecorder("run_test", []string{"echo", "hi"}, map[string]string{"TERM": "xterm"}, Size{Width: 80, Height: 24}, 1024)
+    r.AddEvent(EventStdout, []byte("hello"))
+    r.AddEvent(EventStdin, []byte("a"))
+    r.AddResize(120, 40)
+    r.AddSignal("SIGWINCH")
+
+    path := filepath.Join(t.TempDir(), "dump.json")
+    if err := r.Dump(path); err != nil {
+        t.Fatalf("Dump: %v", err)
+    }
+
+    loaded, err := Load(path)
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+    if loaded.Metadata.RunID != "run_test" {
+        t.Errorf("RunID = %q, want %q", loaded.Metadata.RunID, "run_test")
+    }
+    if len(loaded.Events) != 4 {
+        t.Fatalf("got %d events, want 4", len(loaded.Events))
+    }
+    if loaded.Events[0].Type != EventStdout || !bytes.Equal(loaded.Events[0].Data, []byte("hello")) {
+        t.Errorf("event 0 mismatch: %+v", loaded.Events[0])
+    }
+    if loaded.Events[2].Type != EventResize || loaded.Events[2].Size == nil || loaded.Events[2].Size.Width != 120 {
+        t.Errorf("resize event mismatch: %+v", loaded.Events[2])
+    }
+    if loaded.Events[3].Signal != "SIGWINCH" {
+        t.Errorf("signal event mismatch: %+v", loaded.Events[3])
+    }
+}
+
+func TestRingRecorder_Eviction(t *testing.T) {
+    // Budget 100 bytes — write 10 events of ~30 bytes each => most must be evicted.
+    r := NewRingRecorder("run_test", nil, nil, Size{}, 100)
+    payload := bytes.Repeat([]byte("x"), 30)
+    for i := 0; i < 10; i++ {
+        r.AddEvent(EventStdout, payload)
+    }
+
+    path := filepath.Join(t.TempDir(), "dump.json")
+    if err := r.Dump(path); err != nil {
+        t.Fatalf("Dump: %v", err)
+    }
+    loaded, err := Load(path)
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+
+    // Total bytes retained must not exceed budget.
+    var total int
+    for _, e := range loaded.Events {
+        total += len(e.Data)
+    }
+    if total > 100 {
+        t.Errorf("retained %d bytes, want <= 100", total)
+    }
+    if len(loaded.Events) == 10 {
+        t.Errorf("no eviction occurred: still have all 10 events")
+    }
+    if len(loaded.Events) == 0 {
+        t.Errorf("evicted everything: ring is empty")
+    }
+}
+
+func TestRingRecorder_MonotonicTimestamps(t *testing.T) {
+    r := NewRingRecorder("run_test", nil, nil, Size{}, 50)
+    for i := 0; i < 5; i++ {
+        r.AddEvent(EventStdout, bytes.Repeat([]byte("x"), 20))
+    }
+
+    path := filepath.Join(t.TempDir(), "dump.json")
+    if err := r.Dump(path); err != nil {
+        t.Fatalf("Dump: %v", err)
+    }
+    loaded, err := Load(path)
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+
+    // After eviction, remaining events must still have non-decreasing timestamps.
+    var prev int64 = -1
+    for i, e := range loaded.Events {
+        if e.TimestampNano < prev {
+            t.Errorf("event %d timestamp %d < previous %d (not monotonic)", i, e.TimestampNano, prev)
+        }
+        prev = e.TimestampNano
+    }
+}
+
+func TestRingRecorder_ConcurrentAdd(t *testing.T) {
+    r := NewRingRecorder("run_test", nil, nil, Size{}, 1<<20)
+    var wg sync.WaitGroup
+    for i := 0; i < 8; i++ {
+        wg.Add(1)
+        go func() {
+            defer wg.Done()
+            for j := 0; j < 100; j++ {
+                r.AddEvent(EventStdout, []byte("xx"))
+            }
+        }()
+    }
+    wg.Wait()
+
+    path := filepath.Join(t.TempDir(), "dump.json")
+    if err := r.Dump(path); err != nil {
+        t.Fatalf("Dump: %v", err)
+    }
+    loaded, err := Load(path)
+    if err != nil {
+        t.Fatalf("Load: %v", err)
+    }
+    if len(loaded.Events) != 800 {
+        t.Errorf("got %d events, want 800", len(loaded.Events))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run: `go test ./internal/trace/ -run RingRecorder`
+Expected: build/compile error (NewRingRecorder undefined). This is the failing-test step.
+
+---
+
+## Task 3: `RingRecorder` — implementation
+
+**Files:**
+- Create: `internal/trace/ring.go`
+
+- [ ] **Step 1: Implement RingRecorder**
+
+Create `internal/trace/ring.go`:
+
+```go
+package trace
+
+import (
+    "sync"
+    "time"
+)
+
+// RingRecorder records events into a bounded byte budget, evicting oldest
+// events FIFO when the budget would be exceeded. Used for always-on capture
+// of recent TTY activity in interactive sessions, so users can dump on demand
+// after a rendering bug manifests.
+//
+// Only Event.Data bytes count against the budget. Per-event overhead (struct
+// size, JSON encoding) is small relative to data and ignored.
+type RingRecorder struct {
+    mu        sync.Mutex
+    trace     *Trace
+    startTime time.Time
+    maxBytes  int
+    curBytes  int
+}
+
+// NewRingRecorder creates a ring recorder with the given byte budget.
+// maxBytes <= 0 disables eviction (unbounded).
+func NewRingRecorder(runID string, command []string, env map[string]string, initialSize Size, maxBytes int) *RingRecorder {
+    return &RingRecorder{
+        trace: &Trace{
+            Metadata: Metadata{
+                Timestamp:   time.Now(),
+                RunID:       runID,
+                Command:     command,
+                Environment: env,
+                InitialSize: initialSize,
+            },
+            Events: make([]Event, 0),
+        },
+        startTime: time.Now(),
+        maxBytes:  maxBytes,
+    }
+}
+
+// AddEvent records an I/O event, evicting oldest events if the byte budget is exceeded.
+func (r *RingRecorder) AddEvent(eventType EventType, data []byte) {
+    if len(data) == 0 {
+        return
+    }
+    r.mu.Lock()
+    defer r.mu.Unlock()
+
+    dataCopy := make([]byte, len(data))
+    copy(dataCopy, data)
+
+    r.trace.Events = append(r.trace.Events, Event{
+        TimestampNano: time.Since(r.startTime).Nanoseconds(),
+        Type:          eventType,
+        Data:          dataCopy,
+    })
+    r.curBytes += len(dataCopy)
+    r.evictLocked()
+}
+
+// AddResize records a terminal resize event.
+func (r *RingRecorder) AddResize(width, height int) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.trace.Events = append(r.trace.Events, Event{
+        TimestampNano: time.Since(r.startTime).Nanoseconds(),
+        Type:          EventResize,
+        Size:          &Size{Width: width, Height: height},
+    })
+}
+
+// AddSignal records a signal event.
+func (r *RingRecorder) AddSignal(sig string) {
+    r.mu.Lock()
+    defer r.mu.Unlock()
+    r.trace.Events = append(r.trace.Events, Event{
+        TimestampNano: time.Since(r.startTime).Nanoseconds(),
+        Type:          EventSignal,
+        Signal:        sig,
+    })
+}
+
+// Dump writes the current ring contents to a file as a Trace JSON.
+func (r *RingRecorder) Dump(path string) error {
+    r.mu.Lock()
+    snapshot := Trace{
+        Metadata: r.trace.Metadata,
+        Events:   make([]Event, len(r.trace.Events)),
+    }
+    copy(snapshot.Events, r.trace.Events)
+    r.mu.Unlock()
+    return snapshot.Save(path)
+}
+
+// evictLocked drops oldest events until curBytes <= maxBytes. Caller holds the mutex.
+func (r *RingRecorder) evictLocked() {
+    if r.maxBytes <= 0 || r.curBytes <= r.maxBytes {
+        return
+    }
+    drop := 0
+    for drop < len(r.trace.Events) && r.curBytes > r.maxBytes {
+        r.curBytes -= len(r.trace.Events[drop].Data)
+        drop++
+    }
+    if drop > 0 {
+        r.trace.Events = r.trace.Events[drop:]
+    }
+}
+```
+
+- [ ] **Step 2: Run tests and verify they pass**
+
+Run: `go test -race ./internal/trace/ -run RingRecorder`
+Expected: PASS, no data races.
+
+- [ ] **Step 3: Run all trace tests**
+
+Run: `go test ./internal/trace/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/trace/ring.go internal/trace/ring_test.go
+git commit -m "feat(trace): add bounded RingRecorder for on-demand dumps"
+```
+
+---
+
+## Task 4: Escape proxy — new actions and keys
+
+**Files:**
+- Modify: `internal/term/escape.go`
+- Modify: `internal/term/escape_test.go`
+
+- [ ] **Step 1: Update existing test that uses `d` as unrecognized**
+
+In `internal/term/escape_test.go` around line 258, the test case `"prefix detected then canceled with unrecognized d"` uses `d` as an unrecognized key. Since `d` is now a recognized key, replace `'d'` with `'q'` and update the test name:
+
+```go
+{
+    name:           "prefix detected then canceled with unrecognized q",
+    input:          []byte{EscapePrefix, 'q'},
+    wantCallbacks:  []bool{true, false},
+    wantFinalState: false,
+},
+```
+
+- [ ] **Step 2: Add failing tests for the two new actions**
+
+Append to `internal/term/escape_test.go`:
+
+```go
+func TestEscapeProxy_DumpTUI(t *testing.T) {
+    input := []byte{EscapePrefix, 'd'}
+    r := NewEscapeProxy(bytes.NewReader(input))
+
+    var gotAction EscapeAction
+    r.OnAction(func(action EscapeAction) {
+        gotAction = action
+    })
+
+    buf := make([]byte, 10)
+    _, err := r.Read(buf)
+    if IsEscapeError(err) {
+        t.Fatalf("dump should not return EscapeError, got: %v", err)
+    }
+    if gotAction != EscapeDumpTUI {
+        t.Errorf("expected EscapeDumpTUI callback, got: %v", gotAction)
+    }
+}
+
+func TestEscapeProxy_ResetTUI(t *testing.T) {
+    input := []byte{EscapePrefix, 'r'}
+    r := NewEscapeProxy(bytes.NewReader(input))
+
+    var gotAction EscapeAction
+    r.OnAction(func(action EscapeAction) {
+        gotAction = action
+    })
+
+    buf := make([]byte, 10)
+    _, err := r.Read(buf)
+    if IsEscapeError(err) {
+        t.Fatalf("reset should not return EscapeError, got: %v", err)
+    }
+    if gotAction != EscapeResetTUI {
+        t.Errorf("expected EscapeResetTUI callback, got: %v", gotAction)
+    }
+}
+
+func TestEscapeProxy_DumpAndResetContinueReading(t *testing.T) {
+    // After Ctrl-/ d and Ctrl-/ r, surrounding data flows through.
+    input := []byte{'a', EscapePrefix, 'd', 'b', EscapePrefix, 'r', 'c'}
+    r := NewEscapeProxy(bytes.NewReader(input))
+
+    var actions []EscapeAction
+    r.OnAction(func(action EscapeAction) {
+        actions = append(actions, action)
+    })
+
+    out, err := io.ReadAll(r)
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    expected := []byte{'a', 'b', 'c'}
+    if !bytes.Equal(out, expected) {
+        t.Errorf("got %q, want %q", out, expected)
+    }
+    if len(actions) != 2 || actions[0] != EscapeDumpTUI || actions[1] != EscapeResetTUI {
+        t.Errorf("expected [EscapeDumpTUI, EscapeResetTUI], got %v", actions)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/term/ -run "EscapeProxy_DumpTUI|EscapeProxy_ResetTUI|EscapeProxy_DumpAndResetContinueReading"`
+Expected: build error (`EscapeDumpTUI`/`EscapeResetTUI` undefined).
+
+- [ ] **Step 4: Add the new actions and key bindings**
+
+Edit `internal/term/escape.go`:
+
+```go
+const (
+    EscapeNone EscapeAction = iota
+    EscapeStop
+    EscapeSnapshot
+    EscapeDumpTUI
+    EscapeResetTUI
+)
+```
+
+Update `(e EscapeError) Error()`:
+
+```go
+func (e EscapeError) Error() string {
+    switch e.Action {
+    case EscapeStop:
+        return "escape: stop"
+    case EscapeSnapshot:
+        return "escape: snapshot"
+    case EscapeDumpTUI:
+        return "escape: dump-tui"
+    case EscapeResetTUI:
+        return "escape: reset-tui"
+    default:
+        return "escape: unknown"
+    }
+}
+```
+
+Add the key constants near `escapeKeyStop`/`escapeKeySnapshot`:
+
+```go
+const (
+    EscapePrefix byte = 0x1f
+
+    escapeKeyStop     byte = 'k'
+    escapeKeySnapshot byte = 's'
+    escapeKeyDumpTUI  byte = 'd'
+    escapeKeyResetTUI byte = 'r'
+)
+```
+
+In the two `Read()` switch statements (the one inside the for loop and the one in the "consumed all input ended on prefix" branch), add cases alongside `escapeKeySnapshot`. Both new actions are non-disruptive (call `onAction`, continue reading) — same shape as snapshot:
+
+In the in-loop switch (around line 168):
+
+```go
+case escapeKeySnapshot:
+    if e.onAction != nil {
+        e.onAction(EscapeSnapshot)
+    }
+
+case escapeKeyDumpTUI:
+    if e.onAction != nil {
+        e.onAction(EscapeDumpTUI)
+    }
+
+case escapeKeyResetTUI:
+    if e.onAction != nil {
+        e.onAction(EscapeResetTUI)
+    }
+```
+
+In the "one more byte" branch (around line 247):
+
+```go
+case escapeKeySnapshot:
+    if e.onAction != nil {
+        e.onAction(EscapeSnapshot)
+    }
+    return 0, nil
+case escapeKeyDumpTUI:
+    if e.onAction != nil {
+        e.onAction(EscapeDumpTUI)
+    }
+    return 0, nil
+case escapeKeyResetTUI:
+    if e.onAction != nil {
+        e.onAction(EscapeResetTUI)
+    }
+    return 0, nil
+```
+
+Update `EscapeHelpText()`:
+
+```go
+func EscapeHelpText() string {
+    return "ctrl+/ s (snapshot) · k (stop) · d (dump tui) · r (reset tui)"
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/term/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/term/escape.go internal/term/escape_test.go
+git commit -m "feat(term): add ctrl+/ d and r escape actions for TUI debug"
+```
+
+---
+
+## Task 5: `Writer.Reset` — failing test
+
+**Files:**
+- Modify: `internal/tui/writer_test.go`
+
+- [ ] **Step 1: Read the existing test file to match style**
+
+Run: `head -60 internal/tui/writer_test.go`
+Note the helpers (e.g., how a `Writer` is constructed, how output is captured via a `bytes.Buffer`, and the existing `StatusBar` constructor).
+
+- [ ] **Step 2: Add failing tests for Reset**
+
+Append to `internal/tui/writer_test.go`. Use the same construction pattern as the surrounding tests. The exact `NewStatusBar`/`NewWriter` signatures are visible at the top of the file — match them.
+
+```go
+func TestWriter_Reset_ScrollMode(t *testing.T) {
+    var out bytes.Buffer
+    bar := NewStatusBar(80, 24)
+    w := NewWriter(&out, bar, "docker")
+
+    if err := w.Setup(); err != nil {
+        t.Fatalf("Setup: %v", err)
+    }
+    out.Reset()
+
+    if err := w.Reset(); err != nil {
+        t.Fatalf("Reset: %v", err)
+    }
+
+    written := out.String()
+    // Soft reset
+    if !strings.Contains(written, "\x1b[!p") {
+        t.Errorf("expected soft reset (ESC[!p), got %q", written)
+    }
+    // DECSTBM scroll region (re-established by setupScrollRegionLocked)
+    if !strings.Contains(written, "\x1b[1;23r") {
+        t.Errorf("expected DECSTBM 1;23r, got %q", written)
+    }
+}
+
+func TestWriter_Reset_StopsFooterTimer(t *testing.T) {
+    var out bytes.Buffer
+    bar := NewStatusBar(80, 24)
+    w := NewWriter(&out, bar, "docker")
+    if err := w.Setup(); err != nil {
+        t.Fatalf("Setup: %v", err)
+    }
+
+    // Trigger a footer redraw schedule by writing some output.
+    _, _ = w.Write([]byte("hello"))
+
+    if err := w.Reset(); err != nil {
+        t.Fatalf("Reset: %v", err)
+    }
+
+    w.mu.Lock()
+    timerActive := w.footerTimer != nil
+    w.mu.Unlock()
+    if timerActive {
+        t.Errorf("footerTimer should be cleared after Reset")
+    }
+}
+
+func TestWriter_Reset_ExitsAltScreen(t *testing.T) {
+    var out bytes.Buffer
+    bar := NewStatusBar(80, 24)
+    w := NewWriter(&out, bar, "docker")
+    if err := w.Setup(); err != nil {
+        t.Fatalf("Setup: %v", err)
+    }
+    // Enter alt screen by writing the enter sequence.
+    if _, err := w.Write([]byte("\x1b[?1049h")); err != nil {
+        t.Fatalf("Write alt-screen enter: %v", err)
+    }
+    out.Reset()
+
+    if err := w.Reset(); err != nil {
+        t.Fatalf("Reset: %v", err)
+    }
+
+    written := out.String()
+    if !strings.Contains(written, "\x1b[?1049l") {
+        t.Errorf("expected alt-screen exit (ESC[?1049l), got %q", written)
+    }
+
+    w.mu.Lock()
+    inAlt := w.altScreen
+    hasEmu := w.emulator != nil
+    w.mu.Unlock()
+    if inAlt {
+        t.Errorf("altScreen should be false after Reset")
+    }
+    if hasEmu {
+        t.Errorf("emulator should be nil after Reset")
+    }
+}
+```
+
+If `strings` isn't imported in this file, add it.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/tui/ -run "Writer_Reset"`
+Expected: build error (`w.Reset undefined`).
+
+---
+
+## Task 6: `Writer.Reset` — implementation
+
+**Files:**
+- Modify: `internal/tui/writer.go`
+
+- [ ] **Step 1: Add the Reset method**
+
+Insert this method in `internal/tui/writer.go` near `Cleanup`:
+
+```go
+// Reset attempts to recover the terminal from a corrupted state. It exits
+// alternate screen mode if active, drops the VT emulator, emits a soft
+// terminal reset (DECSTR), clears the screen, and re-establishes the scroll
+// region and footer.
+//
+// Soft reset (ESC[!p) is used rather than full RIS (ESC c) so the user's
+// scrollback is preserved. The caller is responsible for nudging the child
+// process to redraw (typically via a no-op TTY resize).
+func (w *Writer) Reset() error {
+    w.mu.Lock()
+    defer w.mu.Unlock()
+
+    // Stop footer timer
+    if w.footerTimer != nil {
+        w.footerTimer.Stop()
+        w.footerTimer = nil
+    }
+
+    var buf bytes.Buffer
+
+    // If in compositor mode, exit it cleanly.
+    if w.altScreen {
+        w.stopRenderLoop()
+        w.emulator = nil
+        w.altScreen = false
+        buf.WriteString("\x1b[?1049l") // exit alt screen
+    }
+
+    // Clear partial-escape buffer; any in-flight sequence is invalid after reset.
+    w.escBuf = nil
+
+    // Soft terminal reset: clears scroll region, attributes, modes, saved cursor.
+    buf.WriteString("\x1b[!p")
+    // Clear screen and home cursor.
+    buf.WriteString("\x1b[2J\x1b[H")
+    // Show cursor (in case the child had hidden it).
+    buf.WriteString("\x1b[?25h")
+
+    if _, err := w.out.Write(buf.Bytes()); err != nil {
+        return err
+    }
+
+    // Re-establish scroll region and redraw footer.
+    return w.setupScrollRegionLocked()
+}
+```
+
+- [ ] **Step 2: Run Reset tests**
+
+Run: `go test ./internal/tui/ -run "Writer_Reset"`
+Expected: PASS.
+
+- [ ] **Step 3: Run all TUI tests**
+
+Run: `go test -race ./internal/tui/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/tui/writer.go internal/tui/writer_test.go
+git commit -m "feat(tui): add Writer.Reset for terminal recovery"
+```
+
+---
+
+## Task 7: Wire ring recorder + dump/reset handlers in exec.go
+
+**Files:**
+- Modify: `cmd/moat/cli/exec.go`
+
+- [ ] **Step 1: Add the always-on ring recorder construction**
+
+In `RunInteractiveAttached` (currently around line 354), after `setupTTYTracer` returns and before the status-bar setup, build a `RingRecorder` keyed off the run:
+
+```go
+// Always-on bounded ring buffer for on-demand TUI debug dumps.
+ringBytes := defaultRingBytes
+if env := os.Getenv("MOAT_TTY_RING_BYTES"); env != "" {
+    if n, err := strconv.Atoi(env); err == nil && n > 0 {
+        ringBytes = n
+    } else {
+        log.Warn("invalid MOAT_TTY_RING_BYTES, using default", "value", env, "default", defaultRingBytes)
+    }
+}
+width, height := 80, 24
+if term.IsTerminal(os.Stdout) {
+    if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
+        width, height = w, h
+    }
+}
+ringRecorder := trace.NewRingRecorder(r.ID, command, trace.GetTraceEnv(), trace.Size{Width: width, Height: height}, ringBytes)
+```
+
+Add `defaultRingBytes` as a package-level const near the top of the file:
+
+```go
+// defaultRingBytes is the default byte budget for the always-on TUI debug ring
+// buffer. ~5–15 minutes of typical terminal output. Override with
+// MOAT_TTY_RING_BYTES.
+const defaultRingBytes = 8 * 1024 * 1024
+```
+
+Add `"strconv"` to the imports if not already present.
+
+- [ ] **Step 2: Wrap stdout/stdin with the ring recorder**
+
+After the existing `if tracer != nil { stdout = trace.NewRecordingWriter(...) }`, also wrap with the ring (always):
+
+```go
+stdout = trace.NewRecordingWriter(stdout, ringRecorder, trace.EventStdout)
+```
+
+After the existing `if tracer != nil { stdin = trace.NewRecordingReader(...) }`, also wrap with the ring (always):
+
+```go
+stdin = trace.NewRecordingReader(stdin, ringRecorder, trace.EventStdin)
+```
+
+Order: recorders should sit *after* the escape/clipboard wrappers (so they see the bytes the child actually receives), matching the existing `tracer` placement. Make sure `ringRecorder` wraps occur in the same position the `tracer` wraps already do.
+
+- [ ] **Step 3: Add the SIGWINCH path's ring resize event**
+
+In the existing `case sig := <-sigCh:` block, where `tracer.recorder.AddResize(...)` is called on resize, add the ring as well:
+
+```go
+ringRecorder.AddResize(width, height)
+```
+
+(Place this immediately above or below the existing `tracer != nil` resize call.)
+
+- [ ] **Step 4: Add the dump and reset handlers**
+
+Append to `cmd/moat/cli/exec.go`:
+
+```go
+// dumpTUI saves the in-memory TTY ring buffer to disk and flashes the path.
+func dumpTUI(r *run.Run, ringRecorder *trace.RingRecorder, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
+    flash := func(msg string) {
+        if statusWriter == nil {
+            return
+        }
+        flashMu.Lock()
+        defer flashMu.Unlock()
+        if *flashTimer != nil {
+            (*flashTimer).Stop()
+        }
+        statusWriter.SetMessage(msg)
+        _ = statusWriter.UpdateStatus()
+        *flashTimer = time.AfterFunc(2*time.Second, func() {
+            statusWriter.ClearMessage()
+            _ = statusWriter.UpdateStatus()
+        })
+    }
+
+    runDir := filepath.Join(storage.DefaultBaseDir(), r.ID)
+    path := filepath.Join(runDir, fmt.Sprintf("tui-debug-%d.json", time.Now().Unix()))
+    if err := ringRecorder.Dump(path); err != nil {
+        log.Error("tui dump failed", "path", path, "error", err)
+        flash("tui dump failed: " + err.Error())
+        return
+    }
+    log.Info("tui dump saved", "path", path)
+    flash("tui dump saved: " + path)
+}
+
+// resetTUI emits a soft terminal reset and nudges the container to redraw.
+func resetTUI(ctx context.Context, manager *run.Manager, r *run.Run, statusWriter *tui.Writer, flashMu *sync.Mutex, flashTimer **time.Timer) {
+    flash := func(msg string) {
+        if statusWriter == nil {
+            return
+        }
+        flashMu.Lock()
+        defer flashMu.Unlock()
+        if *flashTimer != nil {
+            (*flashTimer).Stop()
+        }
+        statusWriter.SetMessage(msg)
+        _ = statusWriter.UpdateStatus()
+        *flashTimer = time.AfterFunc(2*time.Second, func() {
+            statusWriter.ClearMessage()
+            _ = statusWriter.UpdateStatus()
+        })
+    }
+
+    if statusWriter == nil {
+        flash("tui reset: no status writer")
+        return
+    }
+    if err := statusWriter.Reset(); err != nil {
+        log.Error("tui reset failed", "error", err)
+        flash("tui reset failed: " + err.Error())
+        return
+    }
+
+    // Nudge the container's TUI to redraw via a no-op resize.
+    if term.IsTerminal(os.Stdout) {
+        if width, height := term.GetSize(os.Stdout); width > 0 && height > 0 {
+            // #nosec G115 -- width/height validated positive
+            if err := manager.ResizeTTY(ctx, r.ID, uint(height), uint(width)); err != nil {
+                log.Debug("post-reset resize nudge failed", "error", err)
+            }
+        }
+    }
+
+    flash("tui reset")
+}
+```
+
+Imports to verify present at the top of the file: `"path/filepath"`, `"github.com/majorcontext/moat/internal/storage"`, `"github.com/majorcontext/moat/internal/trace"`, `"github.com/majorcontext/moat/internal/tui"`.
+
+- [ ] **Step 5: Wire the new actions into OnAction**
+
+Replace the existing `escapeProxy.OnAction(...)` block:
+
+```go
+escapeProxy.OnAction(func(action term.EscapeAction) {
+    switch action {
+    case term.EscapeSnapshot:
+        go takeSnapshot(r, statusWriter, &flashMu, &flashTimer)
+    case term.EscapeDumpTUI:
+        go dumpTUI(r, ringRecorder, statusWriter, &flashMu, &flashTimer)
+    case term.EscapeResetTUI:
+        go resetTUI(ctx, manager, r, statusWriter, &flashMu, &flashTimer)
+    }
+})
+```
+
+- [ ] **Step 6: Update the in-session menu hint**
+
+Find the `SetupEscapeHints` callsite and the `SetMessage` in `internal/tui/writer.go`'s `SetupEscapeHints`. Update the message to reflect the new keys:
+
+```go
+w.SetMessage("s (snapshot) · k (stop) · d (dump tui) · r (reset tui) · ctrl+/ (cancel)")
+```
+
+- [ ] **Step 7: Build the project**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 8: Run unit tests with race detector**
+
+Run: `make test-unit`
+Expected: PASS. (If `make test-unit` is unavailable in this env, run `go test -race ./...` instead.)
+
+- [ ] **Step 9: Run the linter**
+
+Run: `make lint`
+Expected: PASS. (If unavailable, fall back to `go vet ./...`.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add cmd/moat/cli/exec.go internal/tui/writer.go
+git commit -m "feat(tui): wire ctrl+/ d (dump) and r (reset) handlers"
+```
+
+---
+
+## Task 8: Documentation
+
+**Files:**
+- Modify: `docs/content/reference/01-cli.md` (if it documents the Ctrl+/ menu)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Check current docs for the Ctrl+/ menu**
+
+Run: `grep -n "ctrl+/\|snapshot\|escape" docs/content/reference/01-cli.md docs/content/guides/*.md 2>/dev/null | head -20`
+
+If a guide or reference page documents the existing `s` and `k` keys, update it to include `d` (dump tui) and `r` (reset tui), with one sentence each describing what they do and where the dump file is written.
+
+If no doc currently lists the Ctrl+/ menu keys, add a short subsection in the most appropriate guide (likely `docs/content/guides/`) — but do not invent a new top-level page. If unsure, skip and ask reviewer.
+
+- [ ] **Step 2: Add a CHANGELOG entry**
+
+Edit `CHANGELOG.md`. Under the next-release `### Added` section (create one if it doesn't exist):
+
+```markdown
+- TUI debug shortcuts — Ctrl+/ d dumps a snapshot of recent terminal I/O to `~/.moat/runs/<id>/tui-debug-<ts>.json` for offline analysis; Ctrl+/ r issues a soft terminal reset and nudges the child to redraw. The dump uses the existing `moat tty-trace analyze` format. Ring buffer size is 8 MB by default, tunable via `MOAT_TTY_RING_BYTES`. ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
+```
+
+(Replace `NNN` with the PR number when the PR is opened, or leave the placeholder for the PR-creation step.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md docs/content/
+git commit -m "docs: document ctrl+/ d and r tui debug shortcuts"
+```
+
+---
+
+## Task 9: Manual verification
+
+This isn't a unit test step — it's the human-in-the-loop check before merging. The bug we're targeting can't be reproduced on demand, so we verify the *mechanism* works.
+
+- [ ] **Step 1: Build a binary**
+
+Run: `go build -o /tmp/moat ./cmd/moat`
+Expected: success.
+
+- [ ] **Step 2: Start an interactive Claude session**
+
+Run: `/tmp/moat claude` in a workspace.
+Expected: status bar appears at the bottom; Ctrl+/ shows `s (snapshot) · k (stop) · d (dump tui) · r (reset tui) · ctrl+/ (cancel)`.
+
+- [ ] **Step 3: Verify dump**
+
+Press Ctrl+/ then `d`. Expected: footer flashes a path like `tui dump saved: /Users/.../.moat/runs/run_<id>/tui-debug-<ts>.json`. Open that file and confirm it's valid JSON with `metadata` and `events` fields. Run `/tmp/moat tty-trace analyze <path>` and confirm it produces output.
+
+- [ ] **Step 4: Verify reset**
+
+Send a deliberately corrupting sequence to the terminal (e.g., from inside the running child, `printf '\x1b[10;15r'` to set a bogus scroll region), then press Ctrl+/ then `r`. Expected: terminal redraws, footer reappears at the bottom, child UI re-renders. Footer flashes `tui reset`.
+
+- [ ] **Step 5: Verify ring eviction**
+
+Set `MOAT_TTY_RING_BYTES=65536`, start a session, generate >64 KB of output (e.g., `seq 1 10000`), press Ctrl+/ d. Expected: dumped file's data size sums to ≤ 64 KB, but contains the most recent events.
+
+---
+
+## Self-Review Notes
+
+Spec coverage check:
+- RingRecorder type + bounds + dump → Tasks 2–3.
+- `EventRecorder` interface for chaining → Task 1.
+- `Writer.Reset` with soft reset → Tasks 5–6.
+- New escape actions/keys → Task 4.
+- Always-on wiring + dump/reset handlers + nudge → Task 7.
+- Menu/help text → Task 4 (`EscapeHelpText`) + Task 7 step 6 (`SetupEscapeHints`).
+- Env var override + 8 MB default → Task 7 step 1.
+- Docs + CHANGELOG → Task 8.
+- Manual verification (no E2E for the bug) → Task 9.
+- Backwards-compat (Trace JSON, `--tty-trace` flag, append-only enum) → preserved by construction; no separate task needed.
+
+Ambiguity resolved: the snapshot path follows the existing `filepath.Join(storage.DefaultBaseDir(), r.ID)` convention used by `cmd/moat/cli/snapshot.go`.

--- a/internal/term/escape.go
+++ b/internal/term/escape.go
@@ -71,8 +71,10 @@ const (
 // EscapeProxy wraps a reader and watches for escape sequences.
 //
 // Escape sequences are: Ctrl-/ followed by:
-//   - k: stop the run (returns EscapeError to unwind Read)
 //   - s: take a snapshot (invokes onAction callback, continues reading)
+//   - k: stop the run (returns EscapeError to unwind Read)
+//   - d: dump TTY history (invokes onAction callback, continues reading)
+//   - r: reset terminal (invokes onAction callback, continues reading)
 //
 // If Ctrl-/ is followed by an unrecognized key, both bytes are passed through.
 // If Ctrl-/ is followed by another Ctrl-/, a single Ctrl-/ is passed through

--- a/internal/term/escape.go
+++ b/internal/term/escape.go
@@ -16,6 +16,10 @@ const (
 	EscapeStop
 	// EscapeSnapshot means the user wants to take a manual snapshot.
 	EscapeSnapshot
+	// EscapeDumpTUI means the user wants to dump the TUI state for debugging.
+	EscapeDumpTUI
+	// EscapeResetTUI means the user wants to reset the TUI.
+	EscapeResetTUI
 )
 
 // EscapeError is returned when an escape sequence is detected.
@@ -29,6 +33,10 @@ func (e EscapeError) Error() string {
 		return "escape: stop"
 	case EscapeSnapshot:
 		return "escape: snapshot"
+	case EscapeDumpTUI:
+		return "escape: dump-tui"
+	case EscapeResetTUI:
+		return "escape: reset-tui"
 	default:
 		return "escape: unknown"
 	}
@@ -56,6 +64,8 @@ const (
 	// Command keys (after the prefix)
 	escapeKeyStop     byte = 'k'
 	escapeKeySnapshot byte = 's'
+	escapeKeyDumpTUI  byte = 'd'
+	escapeKeyResetTUI byte = 'r'
 )
 
 // EscapeProxy wraps a reader and watches for escape sequences.
@@ -181,6 +191,16 @@ func (e *EscapeProxy) Read(p []byte) (int, error) {
 					e.onAction(EscapeSnapshot)
 				}
 
+			case escapeKeyDumpTUI:
+				if e.onAction != nil {
+					e.onAction(EscapeDumpTUI)
+				}
+
+			case escapeKeyResetTUI:
+				if e.onAction != nil {
+					e.onAction(EscapeResetTUI)
+				}
+
 			case EscapePrefix:
 				// Ctrl-/ Ctrl-/ sends a single Ctrl-/
 				out = append(out, EscapePrefix)
@@ -253,6 +273,16 @@ func (e *EscapeProxy) Read(p []byte) (int, error) {
 				e.onAction(EscapeSnapshot)
 			}
 			return 0, nil
+		case escapeKeyDumpTUI:
+			if e.onAction != nil {
+				e.onAction(EscapeDumpTUI)
+			}
+			return 0, nil
+		case escapeKeyResetTUI:
+			if e.onAction != nil {
+				e.onAction(EscapeResetTUI)
+			}
+			return 0, nil
 		case EscapePrefix:
 			// Send single prefix
 			p[0] = EscapePrefix
@@ -291,5 +321,5 @@ func (e *EscapeProxy) Read(p []byte) (int, error) {
 
 // EscapeHelpText returns help text explaining the escape sequences.
 func EscapeHelpText() string {
-	return "ctrl+/ s (snapshot) · k (stop)"
+	return "ctrl+/ s (snapshot) · k (stop) · d (dump tui) · r (reset tui)"
 }

--- a/internal/term/escape_test.go
+++ b/internal/term/escape_test.go
@@ -20,7 +20,7 @@ func TestEscapeProxy_PassThrough(t *testing.T) {
 	}
 }
 
-func TestEscapeProxy_DPassesThrough(t *testing.T) {
+func TestEscapeProxy_UnrecognizedKeyPassesThrough(t *testing.T) {
 	// Ctrl-/ q is not an escape sequence; both bytes should pass through
 	input := []byte{EscapePrefix, 'q', 'x', 'y', 'z'}
 	r := NewEscapeProxy(bytes.NewReader(input))

--- a/internal/term/escape_test.go
+++ b/internal/term/escape_test.go
@@ -21,8 +21,8 @@ func TestEscapeProxy_PassThrough(t *testing.T) {
 }
 
 func TestEscapeProxy_DPassesThrough(t *testing.T) {
-	// Ctrl-/ d is not an escape sequence; both bytes should pass through
-	input := []byte{EscapePrefix, 'd', 'x', 'y', 'z'}
+	// Ctrl-/ q is not an escape sequence; both bytes should pass through
+	input := []byte{EscapePrefix, 'q', 'x', 'y', 'z'}
 	r := NewEscapeProxy(bytes.NewReader(input))
 
 	out, err := io.ReadAll(r)
@@ -30,7 +30,7 @@ func TestEscapeProxy_DPassesThrough(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := []byte{EscapePrefix, 'd', 'x', 'y', 'z'}
+	expected := []byte{EscapePrefix, 'q', 'x', 'y', 'z'}
 	if !bytes.Equal(out, expected) {
 		t.Errorf("got %v, want %v", out, expected)
 	}
@@ -86,7 +86,7 @@ func TestEscapeProxy_UnrecognizedEscape(t *testing.T) {
 
 func TestEscapeProxy_MixedContent(t *testing.T) {
 	// Normal content with unrecognized escape in the middle - both bytes pass through
-	input := []byte{'a', 'b', EscapePrefix, 'd', 'c'}
+	input := []byte{'a', 'b', EscapePrefix, 'q', 'c'}
 	r := NewEscapeProxy(bytes.NewReader(input))
 
 	out, err := io.ReadAll(r)
@@ -94,7 +94,7 @@ func TestEscapeProxy_MixedContent(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected := []byte{'a', 'b', EscapePrefix, 'd', 'c'}
+	expected := []byte{'a', 'b', EscapePrefix, 'q', 'c'}
 	if !bytes.Equal(out, expected) {
 		t.Errorf("got %v, want %v", out, expected)
 	}
@@ -159,6 +159,8 @@ func TestEscapeError_Error(t *testing.T) {
 	}{
 		{EscapeStop, "escape: stop"},
 		{EscapeSnapshot, "escape: snapshot"},
+		{EscapeDumpTUI, "escape: dump-tui"},
+		{EscapeResetTUI, "escape: reset-tui"},
 		{EscapeNone, "escape: unknown"},
 	}
 
@@ -256,8 +258,8 @@ func TestEscapeProxy_OnPrefixChange(t *testing.T) {
 		wantFinalState bool
 	}{
 		{
-			name:           "prefix detected then canceled with unrecognized d",
-			input:          []byte{EscapePrefix, 'd'},
+			name:           "prefix detected then canceled with unrecognized q",
+			input:          []byte{EscapePrefix, 'q'},
 			wantCallbacks:  []bool{true, false},
 			wantFinalState: false,
 		},
@@ -341,5 +343,65 @@ func TestEscapeProxy_OnPrefixChange_SplitReads(t *testing.T) {
 		t.Errorf("after prefix read: got %d callbacks %v, want 2 callbacks [true, false]", len(callbacks), callbacks)
 	} else if callbacks[0] != true || callbacks[1] != false {
 		t.Errorf("after prefix read: got callbacks %v, want [true, false]", callbacks)
+	}
+}
+
+func TestEscapeProxy_DumpTUI(t *testing.T) {
+	input := []byte{EscapePrefix, 'd'}
+	r := NewEscapeProxy(bytes.NewReader(input))
+
+	var gotAction EscapeAction
+	r.OnAction(func(action EscapeAction) {
+		gotAction = action
+	})
+
+	buf := make([]byte, 10)
+	_, err := r.Read(buf)
+	if IsEscapeError(err) {
+		t.Fatalf("dump should not return EscapeError, got: %v", err)
+	}
+	if gotAction != EscapeDumpTUI {
+		t.Errorf("expected EscapeDumpTUI callback, got: %v", gotAction)
+	}
+}
+
+func TestEscapeProxy_ResetTUI(t *testing.T) {
+	input := []byte{EscapePrefix, 'r'}
+	r := NewEscapeProxy(bytes.NewReader(input))
+
+	var gotAction EscapeAction
+	r.OnAction(func(action EscapeAction) {
+		gotAction = action
+	})
+
+	buf := make([]byte, 10)
+	_, err := r.Read(buf)
+	if IsEscapeError(err) {
+		t.Fatalf("reset should not return EscapeError, got: %v", err)
+	}
+	if gotAction != EscapeResetTUI {
+		t.Errorf("expected EscapeResetTUI callback, got: %v", gotAction)
+	}
+}
+
+func TestEscapeProxy_DumpAndResetContinueReading(t *testing.T) {
+	input := []byte{'a', EscapePrefix, 'd', 'b', EscapePrefix, 'r', 'c'}
+	r := NewEscapeProxy(bytes.NewReader(input))
+
+	var actions []EscapeAction
+	r.OnAction(func(action EscapeAction) {
+		actions = append(actions, action)
+	})
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []byte{'a', 'b', 'c'}
+	if !bytes.Equal(out, expected) {
+		t.Errorf("got %q, want %q", out, expected)
+	}
+	if len(actions) != 2 || actions[0] != EscapeDumpTUI || actions[1] != EscapeResetTUI {
+		t.Errorf("expected [EscapeDumpTUI, EscapeResetTUI], got %v", actions)
 	}
 }

--- a/internal/term/inject.go
+++ b/internal/term/inject.go
@@ -1,0 +1,61 @@
+package term
+
+import "io"
+
+// InjectableReader wraps an io.Reader so another goroutine can splice bytes
+// into the stream via Inject. Useful for sending synthetic keystrokes (e.g.
+// Ctrl+L for redraw) to a child process without going through the user's
+// stdin.
+//
+// Internally it runs an io.Copy goroutine that drains the underlying reader
+// into an io.Pipe; Read returns whichever data — user input or injected
+// bytes — arrives first. Injected bytes are interleaved at byte boundaries.
+//
+// Errors returned by the underlying reader propagate to Read via
+// pw.CloseWithError, so wrapped readers can still signal sentinel errors
+// (e.g. EscapeError) to consumers downstream.
+//
+// Inject blocks until the bytes have been consumed by Read or Close has been
+// called.
+type InjectableReader struct {
+	pr *io.PipeReader
+	pw *io.PipeWriter
+}
+
+// NewInjectableReader wraps r and starts a goroutine that copies from r into
+// the pipe. The goroutine exits when r returns an error (including EOF) or
+// when Close is called *and* r returns. Callers should call Close to release
+// the pipe; the underlying reader is not closed.
+func NewInjectableReader(r io.Reader) *InjectableReader {
+	pr, pw := io.Pipe()
+	ir := &InjectableReader{pr: pr, pw: pw}
+	go func() {
+		_, err := io.Copy(pw, r)
+		_ = pw.CloseWithError(err)
+	}()
+	return ir
+}
+
+// Read implements io.Reader.
+func (i *InjectableReader) Read(p []byte) (int, error) {
+	return i.pr.Read(p)
+}
+
+// Inject splices b into the stream. The bytes appear in the next Read call
+// (or are interleaved with concurrent user input at byte boundaries). Blocks
+// until the bytes are consumed by Read or until Close, whichever comes first;
+// returns io.ErrClosedPipe in the latter case.
+func (i *InjectableReader) Inject(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	_, err := i.pw.Write(b)
+	return err
+}
+
+// Close closes the pipe, causing pending and future Read calls to return EOF
+// and pending Inject calls to return io.ErrClosedPipe. The underlying reader
+// is not closed; the background copy goroutine exits when that reader returns.
+func (i *InjectableReader) Close() error {
+	return i.pw.Close()
+}

--- a/internal/term/inject_test.go
+++ b/internal/term/inject_test.go
@@ -1,0 +1,203 @@
+package term
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+	"time"
+)
+
+func TestInjectableReader_PassThrough(t *testing.T) {
+	input := []byte("hello world")
+	r := NewInjectableReader(bytes.NewReader(input))
+	defer r.Close()
+
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(out, input) {
+		t.Errorf("got %q, want %q", out, input)
+	}
+}
+
+func TestInjectableReader_Inject(t *testing.T) {
+	// Underlying reader blocks forever; we only ever see injected bytes.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	r := NewInjectableReader(pr)
+	defer r.Close()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Inject([]byte{0x0C})
+	}()
+
+	buf := make([]byte, 4)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 || buf[0] != 0x0C {
+		t.Errorf("got %v (n=%d), want [0x0C]", buf[:n], n)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Inject returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Inject did not return after Read consumed bytes")
+	}
+}
+
+func TestInjectableReader_InjectInterleaved(t *testing.T) {
+	// Drain the first chunk, then inject 0x0C and push more user input,
+	// verifying both arrive in order. Inject runs in a goroutine because
+	// it blocks until the bytes are consumed by Read.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	r := NewInjectableReader(pr)
+	defer r.Close()
+
+	go func() {
+		_, _ = pw.Write([]byte("ab"))
+	}()
+
+	buf := make([]byte, 8)
+	got := make([]byte, 0, 8)
+
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("first read error: %v", err)
+	}
+	got = append(got, buf[:n]...)
+
+	injectErr := make(chan error, 1)
+	go func() {
+		injectErr <- r.Inject([]byte{0x0C})
+	}()
+
+	go func() {
+		_, _ = pw.Write([]byte("c"))
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for len(got) < 4 {
+		select {
+		case <-deadline:
+			t.Fatalf("timed out, got %v", got)
+		default:
+		}
+		n, err = r.Read(buf)
+		got = append(got, buf[:n]...)
+		if err != nil && err != io.EOF {
+			t.Fatalf("drain read error: %v", err)
+		}
+	}
+
+	if err := <-injectErr; err != nil {
+		t.Errorf("inject error: %v", err)
+	}
+
+	// Inject and "c" race; both must appear after "ab" but their relative
+	// order is non-deterministic.
+	if string(got[:2]) != "ab" {
+		t.Errorf("prefix: got %q, want \"ab\"", string(got[:2]))
+	}
+	if !bytes.Contains(got, []byte{0x0C}) {
+		t.Errorf("missing injected byte; got %v", got)
+	}
+	if !bytes.Contains(got, []byte{'c'}) {
+		t.Errorf("missing 'c'; got %v", got)
+	}
+}
+
+func TestInjectableReader_InjectEmpty(t *testing.T) {
+	r := NewInjectableReader(bytes.NewReader(nil))
+	defer r.Close()
+	if err := r.Inject(nil); err != nil {
+		t.Errorf("Inject(nil) error: %v", err)
+	}
+	if err := r.Inject([]byte{}); err != nil {
+		t.Errorf("Inject(empty) error: %v", err)
+	}
+}
+
+func TestInjectableReader_CloseAfterEOF(t *testing.T) {
+	r := NewInjectableReader(bytes.NewReader([]byte("x")))
+	if _, err := io.ReadAll(r); err != nil {
+		t.Fatalf("ReadAll error: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Errorf("Close error: %v", err)
+	}
+}
+
+// errReader returns the given bytes once, then a sentinel error. Used to
+// verify that errors from the underlying reader propagate through the pipe
+// rather than being silently converted to EOF.
+type errReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+	r.done = true
+	n := copy(p, r.data)
+	return n, nil
+}
+
+func TestInjectableReader_PropagatesError(t *testing.T) {
+	// Regression: io.Copy must propagate the underlying reader's error via
+	// pw.CloseWithError, not swallow it. The escape proxy uses this path to
+	// signal Ctrl+/ k via EscapeError; a previous version of this code
+	// dropped the error and made stop a silent no-op.
+	sentinel := errors.New("sentinel")
+	r := NewInjectableReader(&errReader{data: []byte("hi"), err: sentinel})
+	defer r.Close()
+
+	got, err := io.ReadAll(r)
+	if !errors.Is(err, sentinel) {
+		t.Errorf("got err %v, want %v", err, sentinel)
+	}
+	if !bytes.Equal(got, []byte("hi")) {
+		t.Errorf("got bytes %q, want \"hi\"", got)
+	}
+}
+
+func TestInjectableReader_CloseUnblocksInject(t *testing.T) {
+	// Inject blocks until Read consumes the bytes — or until Close. Verify
+	// that Close releases a parked Inject with io.ErrClosedPipe rather than
+	// hanging.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	r := NewInjectableReader(pr)
+
+	injectErr := make(chan error, 1)
+	go func() {
+		injectErr <- r.Inject([]byte{0x0C})
+	}()
+
+	// Give Inject a moment to park in pw.Write.
+	time.Sleep(10 * time.Millisecond)
+
+	if err := r.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+
+	select {
+	case err := <-injectErr:
+		if !errors.Is(err, io.ErrClosedPipe) {
+			t.Errorf("Inject returned %v, want io.ErrClosedPipe", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Inject did not return after Close")
+	}
+}

--- a/internal/term/inject_test.go
+++ b/internal/term/inject_test.go
@@ -174,20 +174,20 @@ func TestInjectableReader_PropagatesError(t *testing.T) {
 
 func TestInjectableReader_CloseUnblocksInject(t *testing.T) {
 	// Inject blocks until Read consumes the bytes — or until Close. Verify
-	// that Close releases a parked Inject with io.ErrClosedPipe rather than
-	// hanging.
+	// that Close releases Inject with io.ErrClosedPipe rather than hanging,
+	// regardless of the race between the two calls.
 	pr, pw := io.Pipe()
 	defer pw.Close()
 	r := NewInjectableReader(pr)
 
+	started := make(chan struct{})
 	injectErr := make(chan error, 1)
 	go func() {
+		close(started)
 		injectErr <- r.Inject([]byte{0x0C})
 	}()
 
-	// Give Inject a moment to park in pw.Write.
-	time.Sleep(10 * time.Millisecond)
-
+	<-started
 	if err := r.Close(); err != nil {
 		t.Fatalf("Close error: %v", err)
 	}

--- a/internal/trace/recorder.go
+++ b/internal/trace/recorder.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+// EventRecorder is the minimal surface used by RecordingWriter/RecordingReader.
+// Both *Recorder (unbounded) and *RingRecorder (bounded) satisfy it.
+type EventRecorder interface {
+	AddEvent(eventType EventType, data []byte)
+	AddResize(width, height int)
+	AddSignal(sig string)
+}
+
 // Recorder captures I/O events to a trace.
 type Recorder struct {
 	trace     *Trace
@@ -85,12 +93,12 @@ func (r *Recorder) Save(path string) error {
 // RecordingWriter wraps an io.Writer and records all writes to the trace.
 type RecordingWriter struct {
 	w         io.Writer
-	recorder  *Recorder
+	recorder  EventRecorder
 	eventType EventType
 }
 
 // NewRecordingWriter creates a writer that records to the trace.
-func NewRecordingWriter(w io.Writer, recorder *Recorder, eventType EventType) io.Writer {
+func NewRecordingWriter(w io.Writer, recorder EventRecorder, eventType EventType) io.Writer {
 	return &RecordingWriter{
 		w:         w,
 		recorder:  recorder,
@@ -109,12 +117,12 @@ func (rw *RecordingWriter) Write(p []byte) (n int, err error) {
 // RecordingReader wraps an io.Reader and records all reads to the trace.
 type RecordingReader struct {
 	r         io.Reader
-	recorder  *Recorder
+	recorder  EventRecorder
 	eventType EventType
 }
 
 // NewRecordingReader creates a reader that records to the trace.
-func NewRecordingReader(r io.Reader, recorder *Recorder, eventType EventType) io.Reader {
+func NewRecordingReader(r io.Reader, recorder EventRecorder, eventType EventType) io.Reader {
 	return &RecordingReader{
 		r:         r,
 		recorder:  recorder,

--- a/internal/trace/ring.go
+++ b/internal/trace/ring.go
@@ -39,7 +39,11 @@ func NewRingRecorder(runID string, command []string, env map[string]string, init
 	}
 }
 
-// AddEvent records an I/O event, evicting oldest events if the byte budget is exceeded.
+// AddEvent records an I/O event, evicting oldest events if the byte budget is
+// exceeded. A single event larger than maxBytes is appended and then evicted
+// in the same call — the budget is a hard ceiling, not a per-event cap, so
+// oversized payloads are intentionally dropped rather than silently retained.
+// Callers should size maxBytes with the largest expected event in mind.
 func (r *RingRecorder) AddEvent(eventType EventType, data []byte) {
 	if len(data) == 0 {
 		return
@@ -103,7 +107,19 @@ func (r *RingRecorder) evictLocked() {
 		r.curBytes -= len(r.trace.Events[drop].Data)
 		drop++
 	}
-	if drop > 0 {
-		r.trace.Events = r.trace.Events[drop:]
+	if drop == 0 {
+		return
 	}
+	remaining := r.trace.Events[drop:]
+	// Re-slicing keeps the original backing array alive, so dropped events
+	// stay reachable until the slice is reallocated. Once we've dropped more
+	// than we kept, copy survivors into a fresh slice to release the old
+	// array back to the GC.
+	if drop > len(remaining) {
+		fresh := make([]Event, len(remaining))
+		copy(fresh, remaining)
+		r.trace.Events = fresh
+		return
+	}
+	r.trace.Events = remaining
 }

--- a/internal/trace/ring.go
+++ b/internal/trace/ring.go
@@ -1,0 +1,109 @@
+package trace
+
+import (
+	"sync"
+	"time"
+)
+
+// RingRecorder records events into a bounded byte budget, evicting oldest
+// events FIFO when the budget would be exceeded. Used for always-on capture
+// of recent TTY activity in interactive sessions, so users can dump on demand
+// after a rendering bug manifests.
+//
+// Only Event.Data bytes count against the budget. Per-event overhead (struct
+// size, JSON encoding) is small relative to data and ignored.
+type RingRecorder struct {
+	mu        sync.Mutex
+	trace     *Trace
+	startTime time.Time
+	maxBytes  int
+	curBytes  int
+}
+
+// NewRingRecorder creates a ring recorder with the given byte budget.
+// maxBytes <= 0 disables eviction (unbounded).
+func NewRingRecorder(runID string, command []string, env map[string]string, initialSize Size, maxBytes int) *RingRecorder {
+	return &RingRecorder{
+		trace: &Trace{
+			Metadata: Metadata{
+				Timestamp:   time.Now(),
+				RunID:       runID,
+				Command:     command,
+				Environment: env,
+				InitialSize: initialSize,
+			},
+			Events: make([]Event, 0),
+		},
+		startTime: time.Now(),
+		maxBytes:  maxBytes,
+	}
+}
+
+// AddEvent records an I/O event, evicting oldest events if the byte budget is exceeded.
+func (r *RingRecorder) AddEvent(eventType EventType, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+
+	r.trace.Events = append(r.trace.Events, Event{
+		TimestampNano: time.Since(r.startTime).Nanoseconds(),
+		Type:          eventType,
+		Data:          dataCopy,
+	})
+	r.curBytes += len(dataCopy)
+	r.evictLocked()
+}
+
+// AddResize records a terminal resize event.
+func (r *RingRecorder) AddResize(width, height int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.trace.Events = append(r.trace.Events, Event{
+		TimestampNano: time.Since(r.startTime).Nanoseconds(),
+		Type:          EventResize,
+		Size:          &Size{Width: width, Height: height},
+	})
+}
+
+// AddSignal records a signal event.
+func (r *RingRecorder) AddSignal(sig string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.trace.Events = append(r.trace.Events, Event{
+		TimestampNano: time.Since(r.startTime).Nanoseconds(),
+		Type:          EventSignal,
+		Signal:        sig,
+	})
+}
+
+// Dump writes the current ring contents to a file as a Trace JSON.
+func (r *RingRecorder) Dump(path string) error {
+	r.mu.Lock()
+	snapshot := Trace{
+		Metadata: r.trace.Metadata,
+		Events:   make([]Event, len(r.trace.Events)),
+	}
+	copy(snapshot.Events, r.trace.Events)
+	r.mu.Unlock()
+	return snapshot.Save(path)
+}
+
+// evictLocked drops oldest events until curBytes <= maxBytes. Caller holds the mutex.
+func (r *RingRecorder) evictLocked() {
+	if r.maxBytes <= 0 || r.curBytes <= r.maxBytes {
+		return
+	}
+	drop := 0
+	for drop < len(r.trace.Events) && r.curBytes > r.maxBytes {
+		r.curBytes -= len(r.trace.Events[drop].Data)
+		drop++
+	}
+	if drop > 0 {
+		r.trace.Events = r.trace.Events[drop:]
+	}
+}

--- a/internal/trace/ring_test.go
+++ b/internal/trace/ring_test.go
@@ -41,10 +41,11 @@ func TestRingRecorder_AddAndDump(t *testing.T) {
 }
 
 func TestRingRecorder_Eviction(t *testing.T) {
-	r := NewRingRecorder("run_test", nil, nil, Size{}, 100)
-	payload := bytes.Repeat([]byte("x"), 30)
+	// Each event is 1 byte; budget 4 bytes; write 10 events with payload byte = i.
+	// Survivors must be the last N events (FIFO eviction).
+	r := NewRingRecorder("run_test", nil, nil, Size{}, 4)
 	for i := 0; i < 10; i++ {
-		r.AddEvent(EventStdout, payload)
+		r.AddEvent(EventStdout, []byte{byte(i)})
 	}
 
 	path := filepath.Join(t.TempDir(), "dump.json")
@@ -60,14 +61,27 @@ func TestRingRecorder_Eviction(t *testing.T) {
 	for _, e := range loaded.Events {
 		total += len(e.Data)
 	}
-	if total > 100 {
-		t.Errorf("retained %d bytes, want <= 100", total)
+	if total > 4 {
+		t.Errorf("retained %d bytes, want <= 4", total)
+	}
+	if len(loaded.Events) == 0 {
+		t.Fatalf("evicted everything: ring is empty")
 	}
 	if len(loaded.Events) == 10 {
 		t.Errorf("no eviction occurred: still have all 10 events")
 	}
-	if len(loaded.Events) == 0 {
-		t.Errorf("evicted everything: ring is empty")
+
+	// Survivors must be the most recent — last byte must be 9, and the sequence
+	// must be a contiguous tail of [0..9].
+	want := byte(10 - len(loaded.Events))
+	for i, e := range loaded.Events {
+		if len(e.Data) != 1 {
+			t.Fatalf("event %d data len = %d, want 1", i, len(e.Data))
+		}
+		if e.Data[0] != want {
+			t.Errorf("event %d byte = %d, want %d (LIFO instead of FIFO?)", i, e.Data[0], want)
+		}
+		want++
 	}
 }
 

--- a/internal/trace/ring_test.go
+++ b/internal/trace/ring_test.go
@@ -85,6 +85,39 @@ func TestRingRecorder_Eviction(t *testing.T) {
 	}
 }
 
+func TestRingRecorder_OversizedEventEvictsItself(t *testing.T) {
+	// A single payload larger than maxBytes is appended and then immediately
+	// evicted — the budget is a hard ceiling, not a per-event cap. Document
+	// the behavior so a future tweak doesn't silently change it.
+	r := NewRingRecorder("run_test", nil, nil, Size{}, 4)
+	r.AddEvent(EventStdout, bytes.Repeat([]byte("X"), 100))
+
+	path := filepath.Join(t.TempDir(), "dump.json")
+	if err := r.Dump(path); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Events) != 0 {
+		t.Errorf("oversized event retained: %+v", loaded.Events)
+	}
+
+	// Recorder must remain usable after the oversized drop.
+	r.AddEvent(EventStdout, []byte{'a'})
+	if err := r.Dump(path); err != nil {
+		t.Fatalf("Dump after recovery: %v", err)
+	}
+	loaded, err = Load(path)
+	if err != nil {
+		t.Fatalf("Load after recovery: %v", err)
+	}
+	if len(loaded.Events) != 1 || !bytes.Equal(loaded.Events[0].Data, []byte{'a'}) {
+		t.Errorf("recovery state wrong: %+v", loaded.Events)
+	}
+}
+
 func TestRingRecorder_MonotonicTimestamps(t *testing.T) {
 	r := NewRingRecorder("run_test", nil, nil, Size{}, 50)
 	for i := 0; i < 5; i++ {

--- a/internal/trace/ring_test.go
+++ b/internal/trace/ring_test.go
@@ -1,0 +1,123 @@
+package trace
+
+import (
+	"bytes"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+func TestRingRecorder_AddAndDump(t *testing.T) {
+	r := NewRingRecorder("run_test", []string{"echo", "hi"}, map[string]string{"TERM": "xterm"}, Size{Width: 80, Height: 24}, 1024)
+	r.AddEvent(EventStdout, []byte("hello"))
+	r.AddEvent(EventStdin, []byte("a"))
+	r.AddResize(120, 40)
+	r.AddSignal("SIGWINCH")
+
+	path := filepath.Join(t.TempDir(), "dump.json")
+	if err := r.Dump(path); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded.Metadata.RunID != "run_test" {
+		t.Errorf("RunID = %q, want %q", loaded.Metadata.RunID, "run_test")
+	}
+	if len(loaded.Events) != 4 {
+		t.Fatalf("got %d events, want 4", len(loaded.Events))
+	}
+	if loaded.Events[0].Type != EventStdout || !bytes.Equal(loaded.Events[0].Data, []byte("hello")) {
+		t.Errorf("event 0 mismatch: %+v", loaded.Events[0])
+	}
+	if loaded.Events[2].Type != EventResize || loaded.Events[2].Size == nil || loaded.Events[2].Size.Width != 120 {
+		t.Errorf("resize event mismatch: %+v", loaded.Events[2])
+	}
+	if loaded.Events[3].Signal != "SIGWINCH" {
+		t.Errorf("signal event mismatch: %+v", loaded.Events[3])
+	}
+}
+
+func TestRingRecorder_Eviction(t *testing.T) {
+	r := NewRingRecorder("run_test", nil, nil, Size{}, 100)
+	payload := bytes.Repeat([]byte("x"), 30)
+	for i := 0; i < 10; i++ {
+		r.AddEvent(EventStdout, payload)
+	}
+
+	path := filepath.Join(t.TempDir(), "dump.json")
+	if err := r.Dump(path); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	var total int
+	for _, e := range loaded.Events {
+		total += len(e.Data)
+	}
+	if total > 100 {
+		t.Errorf("retained %d bytes, want <= 100", total)
+	}
+	if len(loaded.Events) == 10 {
+		t.Errorf("no eviction occurred: still have all 10 events")
+	}
+	if len(loaded.Events) == 0 {
+		t.Errorf("evicted everything: ring is empty")
+	}
+}
+
+func TestRingRecorder_MonotonicTimestamps(t *testing.T) {
+	r := NewRingRecorder("run_test", nil, nil, Size{}, 50)
+	for i := 0; i < 5; i++ {
+		r.AddEvent(EventStdout, bytes.Repeat([]byte("x"), 20))
+	}
+
+	path := filepath.Join(t.TempDir(), "dump.json")
+	if err := r.Dump(path); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	var prev int64 = -1
+	for i, e := range loaded.Events {
+		if e.TimestampNano < prev {
+			t.Errorf("event %d timestamp %d < previous %d (not monotonic)", i, e.TimestampNano, prev)
+		}
+		prev = e.TimestampNano
+	}
+}
+
+func TestRingRecorder_ConcurrentAdd(t *testing.T) {
+	r := NewRingRecorder("run_test", nil, nil, Size{}, 1<<20)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				r.AddEvent(EventStdout, []byte("xx"))
+			}
+		}()
+	}
+	wg.Wait()
+
+	path := filepath.Join(t.TempDir(), "dump.json")
+	if err := r.Dump(path); err != nil {
+		t.Fatalf("Dump: %v", err)
+	}
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded.Events) != 800 {
+		t.Errorf("got %d events, want 800", len(loaded.Events))
+	}
+}

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -484,6 +484,45 @@ func (w *Writer) renderCompositorLocked() {
 	w.out.Write(buf.Bytes()) //nolint:errcheck
 }
 
+// Reset attempts to recover the terminal from a corrupted state. It exits
+// alternate screen mode if active, drops the VT emulator, emits a soft
+// terminal reset (DECSTR), clears the screen, and re-establishes the scroll
+// region and footer.
+//
+// Soft reset (ESC[!p) is used rather than full RIS (ESC c) so the user's
+// scrollback is preserved. The caller is responsible for nudging the child
+// process to redraw (typically via a no-op TTY resize).
+func (w *Writer) Reset() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.footerTimer != nil {
+		w.footerTimer.Stop()
+		w.footerTimer = nil
+	}
+
+	var buf bytes.Buffer
+
+	if w.altScreen {
+		w.stopRenderLoop()
+		w.emulator = nil
+		w.altScreen = false
+		buf.WriteString("\x1b[?1049l")
+	}
+
+	w.escBuf = nil
+
+	buf.WriteString("\x1b[!p")       // DECSTR soft reset
+	buf.WriteString("\x1b[2J\x1b[H") // clear and home
+	buf.WriteString("\x1b[?25h")     // show cursor
+
+	if _, err := w.out.Write(buf.Bytes()); err != nil {
+		return err
+	}
+
+	return w.setupScrollRegionLocked()
+}
+
 // Cleanup resets the terminal state.
 func (w *Writer) Cleanup() error {
 	w.mu.Lock()

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -492,6 +492,11 @@ func (w *Writer) renderCompositorLocked() {
 // Soft reset (ESC[!p) is used rather than full RIS (ESC c) so the user's
 // scrollback is preserved. The caller is responsible for nudging the child
 // process to redraw (typically via a no-op TTY resize).
+//
+// Reset is best-effort. If the terminal write fails partway through, internal
+// state (altScreen, emulator, footerTimer, escBuf) has already been cleared,
+// so the Writer is left in a valid scroll-mode initial state from which the
+// caller may retry. The scroll region/footer redraw may not have completed.
 func (w *Writer) Reset() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -510,6 +515,8 @@ func (w *Writer) Reset() error {
 		buf.WriteString("\x1b[?1049l")
 	}
 
+	// Discard any partial alt-screen escape sequence buffered from a previous
+	// Write — carrying it forward could re-trigger a phantom mode transition.
 	w.escBuf = nil
 
 	buf.WriteString("\x1b[!p")       // DECSTR soft reset

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -638,7 +638,7 @@ func (w *Writer) ClearMessage() {
 func (w *Writer) SetupEscapeHints(proxy *term.EscapeProxy) {
 	proxy.OnPrefixChange(func(active bool) {
 		if active {
-			w.SetMessage("s (snapshot) · k (stop) · ctrl+/ (cancel)")
+			w.SetMessage("s (snapshot) · k (stop) · d (dump tui) · r (reset tui) · ctrl+/ (cancel)")
 		} else {
 			w.ClearMessage()
 		}

--- a/internal/tui/writer_test.go
+++ b/internal/tui/writer_test.go
@@ -844,6 +844,11 @@ func TestWriter_Reset_ScrollMode(t *testing.T) {
 	if !strings.Contains(written, "\x1b[1;23r") {
 		t.Errorf("expected DECSTBM 1;23r, got %q", written)
 	}
+	softIdx := strings.Index(written, "\x1b[!p")
+	stbmIdx := strings.Index(written, "\x1b[1;23r")
+	if softIdx < 0 || stbmIdx < 0 || softIdx >= stbmIdx {
+		t.Errorf("soft reset must precede DECSTBM, got positions %d and %d in %q", softIdx, stbmIdx, written)
+	}
 }
 
 func TestWriter_Reset_StopsFooterTimer(t *testing.T) {
@@ -896,6 +901,11 @@ func TestWriter_Reset_ExitsAltScreen(t *testing.T) {
 	written := out.String()
 	if !strings.Contains(written, "\x1b[?1049l") {
 		t.Errorf("expected alt-screen exit (ESC[?1049l), got %q", written)
+	}
+	exitIdx := strings.Index(written, "\x1b[?1049l")
+	softIdx := strings.Index(written, "\x1b[!p")
+	if exitIdx < 0 || softIdx < 0 || exitIdx >= softIdx {
+		t.Errorf("alt-screen exit must precede soft reset, got positions %d and %d in %q", exitIdx, softIdx, written)
 	}
 
 	w.mu.Lock()

--- a/internal/tui/writer_test.go
+++ b/internal/tui/writer_test.go
@@ -821,3 +821,91 @@ func TestWriter_PassthroughANSI(t *testing.T) {
 
 	w.Cleanup()
 }
+
+func TestWriter_Reset_ScrollMode(t *testing.T) {
+	var out bytes.Buffer
+	bar := NewStatusBar("run_test", "test-agent", "docker")
+	bar.SetDimensions(80, 24)
+	w := NewWriter(&out, bar, "docker")
+
+	if err := w.Setup(); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+	out.Reset()
+
+	if err := w.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	written := out.String()
+	if !strings.Contains(written, "\x1b[!p") {
+		t.Errorf("expected soft reset (ESC[!p), got %q", written)
+	}
+	if !strings.Contains(written, "\x1b[1;23r") {
+		t.Errorf("expected DECSTBM 1;23r, got %q", written)
+	}
+}
+
+func TestWriter_Reset_StopsFooterTimer(t *testing.T) {
+	var out bytes.Buffer
+	bar := NewStatusBar("run_test", "test-agent", "docker")
+	bar.SetDimensions(80, 24)
+	w := NewWriter(&out, bar, "docker")
+
+	if err := w.Setup(); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	// Trigger footer redraw schedule by writing some output.
+	if _, err := w.Write([]byte("hello")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := w.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	w.mu.Lock()
+	timerActive := w.footerTimer != nil
+	w.mu.Unlock()
+	if timerActive {
+		t.Errorf("footerTimer should be cleared after Reset")
+	}
+}
+
+func TestWriter_Reset_ExitsAltScreen(t *testing.T) {
+	var out bytes.Buffer
+	bar := NewStatusBar("run_test", "test-agent", "docker")
+	bar.SetDimensions(80, 24)
+	w := NewWriter(&out, bar, "docker")
+
+	if err := w.Setup(); err != nil {
+		t.Fatalf("Setup: %v", err)
+	}
+
+	// Enter alt screen by writing the enter sequence.
+	if _, err := w.Write([]byte("\x1b[?1049h")); err != nil {
+		t.Fatalf("Write alt-screen enter: %v", err)
+	}
+	out.Reset()
+
+	if err := w.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	written := out.String()
+	if !strings.Contains(written, "\x1b[?1049l") {
+		t.Errorf("expected alt-screen exit (ESC[?1049l), got %q", written)
+	}
+
+	w.mu.Lock()
+	inAlt := w.altScreen
+	hasEmu := w.emulator != nil
+	w.mu.Unlock()
+	if inAlt {
+		t.Errorf("altScreen should be false after Reset")
+	}
+	if hasEmu {
+		t.Errorf("emulator should be nil after Reset")
+	}
+}


### PR DESCRIPTION
## Summary

Two new Ctrl+/ shortcuts for diagnosing and recovering from TUI corruption in interactive moat sessions:

- **Ctrl+/ d** — dump the last ~8 MiB of terminal I/O (always-on bounded ring buffer) to `~/.moat/runs/<id>/tui-debug-<unix>.json`. The dump is a `trace.Trace` and can be fed back through `tty-trace analyze` for inspection.
- **Ctrl+/ r** — soft-reset the terminal (DECSTR, clear screen, re-establish scroll region). Sends Ctrl+L to the child's stdin and a SIGWINCH at the current size to nudge a redraw. Most TUIs honor Ctrl+L (vim, less, htop, Claude Code); SIGWINCH is the belt-and-suspenders fallback.

Ring buffer size is configurable via `MOAT_TTY_RING_BYTES`.

## Notable design points

- `internal/trace/ring.go` — new `RingRecorder` with FIFO byte-budget eviction, sharing the `EventRecorder` interface with the explicit `--tty-trace=FILE` recorder so both can chain in the I/O path without conflict.
- `internal/tui/writer.go` — new `Reset()` method that drops alt-screen state, clears `escBuf`, emits soft reset + clear, and re-establishes the scroll region in a load-bearing order (asserted in tests).
- `internal/term/inject.go` — new `InjectableReader` so a separate goroutine can splice synthetic keystrokes (Ctrl+L) into the child's stdin without going through the user. Wraps an `io.Reader` with `io.Pipe` + `io.Copy`; errors propagate via `CloseWithError` so existing escape signals (`Ctrl+/ k`) still reach the manager.

## Test plan

- [x] Unit: `internal/trace/ring_test.go` (FIFO eviction order, byte budget)
- [x] Unit: `internal/term/escape_test.go` (new `d`/`r` actions, prefix passthrough)
- [x] Unit: `internal/tui/writer_test.go` (reset operation ordering)
- [x] Unit: `internal/term/inject_test.go` (pass-through, inject blocking, error propagation, close-unblocks-inject)
- [x] `go test ./... -race` passes (pre-existing `internal/deps` network-test failures unrelated)
- [x] `make lint` clean
- [ ] Manual: confirm `Ctrl+/ d` produces a valid trace JSON inside a real session
- [ ] Manual: confirm `Ctrl+/ r` recovers a corrupted Claude Code TUI without dropping scrollback
- [ ] Manual: confirm `Ctrl+/ k` still stops the run after the InjectableReader change