### PR TITLE
test(deps): skip transient failures in github URL reachability test

### DIFF
--- a/internal/deps/registry_test.go
+++ b/internal/deps/registry_test.go
@@ -228,7 +228,9 @@ func TestRegistryGithubBinaryPlaceholders(t *testing.T) {
 
 // TestRegistryGithubBinaryURLsExist validates that all github-binary download URLs
 // are reachable. This catches version/asset naming errors before e2e tests.
-// Skipped by default; run with: go test -run TestRegistryGithubBinaryURLsExist -urls
+// Skipped in short mode. Transient network errors and 5xx responses skip the
+// individual subtest rather than failing — only 404/410 (which indicate a
+// genuinely wrong asset URL) are reported as failures.
 func TestRegistryGithubBinaryURLsExist(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping URL validation in short mode")
@@ -270,13 +272,16 @@ func TestRegistryGithubBinaryURLsExist(t *testing.T) {
 
 					resp, err := client.Do(req)
 					if err != nil {
-						t.Fatalf("failed to reach %s: %v", url, err)
+						t.Skipf("transient network error reaching %s: %v", url, err)
 					}
 					defer resp.Body.Close()
 
-					if resp.StatusCode == http.StatusNotFound {
-						t.Errorf("URL returns 404: %s", url)
-					} else if resp.StatusCode >= 400 {
+					switch {
+					case resp.StatusCode == http.StatusNotFound, resp.StatusCode == http.StatusGone:
+						t.Errorf("URL returns %d (asset missing): %s", resp.StatusCode, url)
+					case resp.StatusCode >= 500:
+						t.Skipf("transient %d from %s", resp.StatusCode, url)
+					case resp.StatusCode >= 400:
 						t.Errorf("URL returns %d: %s", resp.StatusCode, url)
 					}
 				})


### PR DESCRIPTION
## Summary

`TestRegistryGithubBinaryURLsExist` HEADs every github-binary release URL in the registry to catch wrong asset names. Until now any non-2xx response was a hard failure — including transient 5xx blips from GitHub's CDN. That broke `main` in [run 25020206997](https://github.com/majorcontext/moat/actions/runs/25020206997) when ripgrep's arm64 asset returned a 502, and it'll keep doing so on every GitHub hiccup.

This change keeps the validation but classifies the response:

- **404 / 410** → fail (asset genuinely missing — what the test exists to catch)
- **other 4xx** → fail (e.g. 401/403 would mean a real config problem)
- **5xx** → skip the subtest (transient server-side)
- **transport error / timeout** → skip the subtest (transient network)

Also fixes the comment on the test, which claimed it was opt-in via a `-urls` flag — it only ever honored `testing.Short`.

## Test plan

- [x] `go vet ./internal/deps/...` clean
- [x] `golangci-lint run ./internal/deps/...` clean
- [x] `go test -short ./internal/deps/...` passes (skips the URL test)
- [ ] CI green on this branch