### PR TITLE
fix(claude): use far-future expiry for setup-token credentials

### DIFF
--- a/internal/providers/claude/config.go
+++ b/internal/providers/claude/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/majorcontext/moat/internal/provider"
 )
@@ -157,10 +158,20 @@ func WriteCredentialsFile(cred *provider.Credential, stagingDir string) error {
 	// the proxy at the network layer. Claude Code needs this file to exist
 	// with valid structure to function, but the actual authentication is
 	// handled transparently by the TLS-intercepting proxy.
+	//
+	// ExpiresAt handling: Setup-token grants are long-lived and don't carry
+	// an expiry, so cred.ExpiresAt is the zero time.Time. UnixMilli() on the
+	// zero value returns -62135596800000 (year 0001), which Claude Code reads
+	// as an expired credential — the status line shows "not logged in" and
+	// "API Usage Billing". Substitute a far-future expiry in that case.
+	expiresAtMs := cred.ExpiresAt.UnixMilli()
+	if cred.ExpiresAt.IsZero() {
+		expiresAtMs = time.Now().Add(365 * 24 * time.Hour).UnixMilli()
+	}
 	creds := oauthCredentials{
 		ClaudeAiOauth: &oauthToken{
 			AccessToken: ProxyInjectedPlaceholder,
-			ExpiresAt:   cred.ExpiresAt.UnixMilli(),
+			ExpiresAt:   expiresAtMs,
 			Scopes:      cred.Scopes,
 		},
 	}

--- a/internal/providers/claude/provider_test.go
+++ b/internal/providers/claude/provider_test.go
@@ -656,6 +656,37 @@ func TestWriteCredentialsFile(t *testing.T) {
 		}
 	})
 
+	t.Run("zero ExpiresAt uses far-future expiry", func(t *testing.T) {
+		stagingDir := t.TempDir()
+		cred := &provider.Credential{
+			Provider: "claude",
+			Token:    "sk-ant-oat01-abc123",
+			// ExpiresAt intentionally zero — simulates setup-token grants
+		}
+
+		err := WriteCredentialsFile(cred, stagingDir)
+		if err != nil {
+			t.Fatalf("WriteCredentialsFile() error = %v", err)
+		}
+
+		data, err := os.ReadFile(filepath.Join(stagingDir, ".credentials.json"))
+		if err != nil {
+			t.Fatalf("failed to read credentials file: %v", err)
+		}
+
+		var creds oauthCredentials
+		if err := json.Unmarshal(data, &creds); err != nil {
+			t.Fatalf("failed to parse credentials file: %v", err)
+		}
+
+		if creds.ClaudeAiOauth == nil {
+			t.Fatal("ClaudeAiOauth should be present")
+		}
+		if creds.ClaudeAiOauth.ExpiresAt <= time.Now().UnixMilli() {
+			t.Errorf("ExpiresAt = %d, want future timestamp (got past/zero)", creds.ClaudeAiOauth.ExpiresAt)
+		}
+	})
+
 	t.Run("anthropic provider does not create file", func(t *testing.T) {
 		stagingDir := t.TempDir()
 		cred := &provider.Credential{


### PR DESCRIPTION
## Summary

Split out of #308 per @dpup's review.

Setup-token grants don't set `ExpiresAt` on the credential, leaving it as the zero `time.Time`. `WriteCredentialsFile` called `UnixMilli()` on this, producing `-62135596800000` (year 0001) in `.credentials.json`. Claude Code read that as an expired credential, showing "not logged in" and "API Usage Billing" in the status line instead of recognizing the session.

Substitute a 1-year-ahead timestamp when `ExpiresAt` is zero. Setup-tokens are long-lived and the placeholder credential just needs to look valid locally — the real token is injected by the proxy at the network layer.

## Test plan

- [x] `make test-unit` for `internal/providers/claude`
- [x] `make lint`
- [ ] `moat claude` with a setup-token grant no longer reports "not logged in"