### PR TITLE
fix(claude): don't scrape claude setup-token output

### DIFF
--- a/internal/providers/claude/grant.go
+++ b/internal/providers/claude/grant.go
@@ -17,6 +17,7 @@ import (
 	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/provider"
 	"github.com/majorcontext/moat/internal/term"
+	"github.com/majorcontext/moat/internal/ui"
 )
 
 // Grant acquires a Claude Code OAuth token interactively.
@@ -74,10 +75,10 @@ func (p *OAuthProvider) Grant(ctx context.Context) (*provider.Credential, error)
 				fmt.Printf("Invalid choice: %s\n", response)
 				continue
 			}
-			return grantViaSetupToken(ctx)
+			return grantViaSetupToken(ctx, reader)
 
 		case fmt.Sprint(existingTokenOpt):
-			return grantViaExistingOAuthToken(ctx)
+			return grantViaExistingOAuthToken(ctx, reader)
 
 		case fmt.Sprint(importCredsOpt):
 			if importCredsOpt == 0 {
@@ -112,7 +113,7 @@ func isClaudeAvailable() bool {
 // scraping is brittle and fails silently on upgrades. Letting Claude render
 // to the real terminal and having the user paste the token is
 // version-independent and robust.
-func grantViaSetupToken(ctx context.Context) (*provider.Credential, error) {
+func grantViaSetupToken(ctx context.Context, reader *bufio.Reader) (*provider.Credential, error) {
 	fmt.Println()
 	fmt.Println("Running 'claude setup-token'. This may open a browser to sign in.")
 	fmt.Println("When it finishes, copy the token it displays (it starts with sk-ant-oat01-).")
@@ -129,15 +130,13 @@ func grantViaSetupToken(ctx context.Context) (*provider.Credential, error) {
 		fmt.Println("If it still displayed a token, paste it below.")
 	}
 
-	return promptAndValidateOAuthToken(ctx)
+	return promptAndValidateOAuthToken(ctx, reader)
 }
 
 // grantViaExistingOAuthToken prompts the user to paste an OAuth token they
 // already obtained via `claude setup-token`.
-func grantViaExistingOAuthToken(ctx context.Context) (*provider.Credential, error) {
-	fmt.Println()
-	fmt.Println("Paste the OAuth token from a 'claude setup-token' run.")
-	return promptAndValidateOAuthToken(ctx)
+func grantViaExistingOAuthToken(ctx context.Context, reader *bufio.Reader) (*provider.Credential, error) {
+	return promptAndValidateOAuthToken(ctx, reader)
 }
 
 // readPastedToken reads a pasted OAuth token, reassembling it if the source
@@ -309,22 +308,33 @@ func readCSI(br *bufio.Reader) (string, error) {
 
 // promptAndValidateOAuthToken reads an OAuth token pasted by the user, checks
 // its format, validates it against the API, and returns the credential.
-func promptAndValidateOAuthToken(ctx context.Context) (*provider.Credential, error) {
-	fmt.Println("\nPaste the OAuth token (it starts with sk-ant-oat01-).")
-
-	var (
-		token string
-		err   error
-	)
-	if term.IsTerminal(os.Stdin) {
+// readOAuthTokenInput reads a pasted OAuth token from stdin. On an interactive
+// terminal it uses bracketed paste; otherwise it reads from reader.
+//
+// reader MUST be the same bufio.Reader the menu prompt read the choice from.
+// Piped stdin is typically delivered in a single read, so reading the menu
+// choice can buffer the token line inside that reader; creating a fresh
+// bufio.Reader on os.Stdin here would read an already-drained stdin and lose
+// the token.
+func readOAuthTokenInput(reader *bufio.Reader, stdin *os.File) (string, error) {
+	if term.IsTerminal(stdin) {
 		// Bracketed paste captures the whole paste — including a token the
 		// source terminal soft-wrapped onto multiple lines — with no extra
 		// keystroke.
-		token, err = readTokenFromTerminal(os.Stdin)
-	} else {
-		// Piped/non-interactive input: read until a blank line or EOF.
-		token, err = readPastedToken(bufio.NewReader(os.Stdin))
+		return readTokenFromTerminal(stdin)
 	}
+	// Piped/non-interactive input: read until a blank line or EOF.
+	return readPastedToken(reader)
+}
+
+func promptAndValidateOAuthToken(ctx context.Context, reader *bufio.Reader) (*provider.Credential, error) {
+	// A blank line and a section header separate moat's prompt from whatever the
+	// `claude setup-token` TUI just rendered above it.
+	fmt.Println()
+	ui.Section("Paste your token into moat")
+	fmt.Println("It starts with sk-ant-oat01-.")
+
+	token, err := readOAuthTokenInput(reader, os.Stdin)
 	if err != nil {
 		return nil, fmt.Errorf("reading input: %w", err)
 	}

--- a/internal/providers/claude/grant.go
+++ b/internal/providers/claude/grant.go
@@ -12,10 +12,11 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unicode"
 
-	"github.com/creack/pty"
 	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/provider"
+	"github.com/majorcontext/moat/internal/term"
 )
 
 // Grant acquires a Claude Code OAuth token interactively.
@@ -103,145 +104,230 @@ func isClaudeAvailable() bool {
 	return cmd.Run() == nil
 }
 
-// grantViaSetupToken uses `claude setup-token` to get an OAuth token.
+// grantViaSetupToken runs `claude setup-token` attached to the user's
+// terminal, then asks them to paste the token it displays.
+//
+// moat deliberately does NOT capture or parse Claude's output. The CLI
+// renders setup-token as a TUI whose layout changes between versions, so any
+// scraping is brittle and fails silently on upgrades. Letting Claude render
+// to the real terminal and having the user paste the token is
+// version-independent and robust.
 func grantViaSetupToken(ctx context.Context) (*provider.Credential, error) {
 	fmt.Println()
-	fmt.Println("Running 'claude setup-token' to obtain authentication token...")
-	fmt.Println("This may open a browser for authentication.")
+	fmt.Println("Running 'claude setup-token'. This may open a browser to sign in.")
+	fmt.Println("When it finishes, copy the token it displays (it starts with sk-ant-oat01-).")
 	fmt.Println()
 
-	// Use a dedicated timeout for the setup-token command only.
-	// This context is NOT reused for validation — see below.
-	cmdCtx, cmdCancel := context.WithTimeout(ctx, 2*time.Minute)
-	defer cmdCancel()
-
-	cmd := exec.CommandContext(cmdCtx, "claude", "setup-token")
+	cmd := exec.CommandContext(ctx, "claude", "setup-token")
 	cmd.Stdin = os.Stdin
-
-	// Build a clean environment that forces dumb terminal mode.
-	// We filter out keys we override to avoid duplicates — on Linux (glibc),
-	// the first occurrence of a duplicate env var wins, so appending to
-	// os.Environ() without filtering means our overrides get ignored.
-	overrides := map[string]string{
-		"TERM":     "dumb",
-		"NO_COLOR": "1",
-		"CI":       "1",
-		"COLUMNS":  "10000",
-	}
-	var env []string
-	for _, e := range os.Environ() {
-		key, _, _ := strings.Cut(e, "=")
-		if _, override := overrides[key]; !override {
-			env = append(env, e)
-		}
-	}
-	for k, v := range overrides {
-		env = append(env, k+"="+v)
-	}
-	cmd.Env = env
-
-	// Spawn with a PTY so Node.js uses synchronous stdout writes.
-	// Without a PTY, stdout is a pipe and Node buffers writes asynchronously —
-	// if the process exits (or calls process.exit()) before the buffer is
-	// flushed, the token is lost. With a PTY, writes are synchronous on POSIX.
-	var output strings.Builder
-	ptmx, err := pty.StartWithAttrs(cmd, &pty.Winsize{Rows: 24, Cols: 10000}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("starting claude setup-token: %w", err)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Non-fatal: the CLI may have shown the token before failing during
+		// its own cleanup. Let the user paste it anyway.
+		fmt.Printf("\nNote: 'claude setup-token' exited with an error: %v\n", err)
+		fmt.Println("If it still displayed a token, paste it below.")
 	}
 
-	// Copy PTY output in a goroutine; it returns when the child exits and
-	// the PTY slave side closes.
-	ioDone := make(chan struct{})
-	go func() {
-		defer close(ioDone)
-		_, _ = io.Copy(&output, ptmx)
-	}()
-
-	cmdErr := cmd.Wait()
-	_ = ptmx.Close()
-	<-ioDone // wait for all output to be read
-
-	log.Debug("claude setup-token completed",
-		"subsystem", "grant",
-		"exit_error", cmdErr,
-		"output_len", output.Len(),
-	)
-	if log.Verbose() {
-		log.Debug("claude setup-token raw output",
-			"subsystem", "grant",
-			"raw_output", output.String(),
-		)
-	}
-
-	// Try to extract the token even if the command exited non-zero.
-	// The CLI may have printed the token but then failed during cleanup
-	// (e.g., writing to its own credential store).
-	token := extractOAuthToken(output.String())
-
-	if token == "" {
-		if cmdErr != nil {
-			return nil, fmt.Errorf("claude setup-token failed: %w", cmdErr)
-		}
-		return nil, fmt.Errorf("could not find OAuth token in claude setup-token output")
-	}
-
-	if cmdErr != nil {
-		log.Debug("claude setup-token exited non-zero but token was extracted",
-			"subsystem", "grant",
-			"exit_error", cmdErr,
-			"token_len", len(token),
-		)
-	}
-
-	log.Debug("extracted OAuth token",
-		"subsystem", "grant",
-		"token_len", len(token),
-	)
-
-	// Validate the token to catch corruption from ANSI parsing.
-	// Use a fresh context — the command timeout context may be nearly
-	// exhausted if the user took a while to authenticate in the browser.
-	fmt.Println("\nValidating OAuth token...")
-	auth := &anthropicAuth{}
-	validateCtx, validateCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer validateCancel()
-
-	if err := auth.ValidateOAuthToken(validateCtx, token); err != nil {
-		log.Error("OAuth token validation failed after extraction",
-			"subsystem", "grant",
-			"error", err,
-			"token_len", len(token),
-		)
-		return nil, fmt.Errorf("token validation failed: %w", err)
-	}
-	fmt.Println("OAuth token is valid.")
-
-	cred := &provider.Credential{
-		Provider:  "claude",
-		Token:     token,
-		CreatedAt: time.Now(),
-	}
-
-	fmt.Println("\nClaude credential acquired via setup-token.")
-	fmt.Println("You can now run 'moat claude' to start Claude Code.")
-	return cred, nil
+	return promptAndValidateOAuthToken(ctx)
 }
 
 // grantViaExistingOAuthToken prompts the user to paste an OAuth token they
 // already obtained via `claude setup-token`.
 func grantViaExistingOAuthToken(ctx context.Context) (*provider.Credential, error) {
 	fmt.Println()
-	fmt.Println("Paste the OAuth token from a previous 'claude setup-token' run.")
-	fmt.Println("The token starts with sk-ant-oat01-")
-	fmt.Print("\nOAuth Token: ")
+	fmt.Println("Paste the OAuth token from a 'claude setup-token' run.")
+	return promptAndValidateOAuthToken(ctx)
+}
 
-	reader := bufio.NewReader(os.Stdin)
-	token, err := reader.ReadString('\n')
+// readPastedToken reads a pasted OAuth token, reassembling it if the source
+// terminal soft-wrapped it across multiple lines (a narrow window makes the
+// clipboard selection capture real newlines).
+//
+// A terminal in canonical mode delivers a multi-line paste one line at a time,
+// so we cannot rely on the whole paste being buffered after the first line.
+// Instead we keep reading lines until a blank line or EOF terminates input,
+// then drop all whitespace since tokens contain none.
+func readPastedToken(r *bufio.Reader) (string, error) {
+	var b strings.Builder
+	for {
+		line, err := r.ReadString('\n')
+		if strings.TrimSpace(line) == "" {
+			// A blank line ends input once we have content (the user pressing
+			// Enter on an empty line); ignore leading blanks.
+			if b.Len() > 0 || err != nil {
+				if err != nil && err != io.EOF {
+					return "", err
+				}
+				break
+			}
+			continue
+		}
+		b.WriteString(line)
+		if err != nil {
+			if err != io.EOF {
+				return "", err
+			}
+			break
+		}
+	}
+
+	return stripWhitespace(b.String()), nil
+}
+
+// stripWhitespace removes all whitespace. OAuth tokens contain none, so this
+// losslessly reassembles a token that wrapping split with newlines or spaces.
+func stripWhitespace(s string) string {
+	return strings.Map(func(c rune) rune {
+		if unicode.IsSpace(c) {
+			return -1
+		}
+		return c
+	}, s)
+}
+
+// bracketedPasteStart and bracketedPasteEnd are the CSI markers a terminal
+// wraps pasted text in when bracketed paste mode (DECSET 2004) is enabled.
+const (
+	bracketedPasteOn  = "\x1b[?2004h"
+	bracketedPasteOff = "\x1b[?2004l"
+)
+
+// readTokenFromTerminal reads a pasted token from an interactive terminal
+// using bracketed paste, so a wrapped multi-line paste is captured whole with
+// no extra keystroke. Falls back to nothing special for typed input (ends on
+// Enter). The terminal is put in raw mode only for the duration of the read.
+func readTokenFromTerminal(in *os.File) (string, error) {
+	state, err := term.EnableRawMode(in)
+	if err != nil {
+		return "", fmt.Errorf("enabling raw mode: %w", err)
+	}
+	defer func() {
+		fmt.Print(bracketedPasteOff)
+		_ = term.RestoreTerminal(state)
+		fmt.Println()
+	}()
+	fmt.Print(bracketedPasteOn)
+
+	return scanBracketedPaste(in)
+}
+
+// scanBracketedPaste reads bytes until a bracketed paste (ESC[200~ … ESC[201~)
+// completes, or until Enter/EOF for manually typed input. It is pure over an
+// io.Reader so it can be tested without a real terminal. All whitespace is
+// stripped from the result.
+func scanBracketedPaste(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	var typed, pasted strings.Builder
+	inPaste := false
+
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return "", err
+		}
+
+		if b == 0x1b { // ESC: possible CSI sequence
+			seq, serr := readCSI(br)
+			if serr != nil {
+				if serr == io.EOF {
+					break
+				}
+				return "", serr
+			}
+			switch seq {
+			case "200~":
+				inPaste = true
+			case "201~":
+				return stripWhitespace(pasted.String()), nil
+			}
+			continue // ignore all other escape sequences
+		}
+
+		if inPaste {
+			pasted.WriteByte(b)
+			continue
+		}
+
+		// Manually typed input (no paste markers).
+		switch b {
+		case '\r', '\n':
+			if typed.Len() > 0 {
+				return stripWhitespace(typed.String()), nil
+			}
+		case 0x7f, 0x08: // backspace / delete
+			if s := typed.String(); s != "" {
+				typed.Reset()
+				typed.WriteString(s[:len(s)-1])
+			}
+		case 0x03: // Ctrl-C
+			return "", fmt.Errorf("input canceled")
+		case 0x04: // Ctrl-D
+			if typed.Len() > 0 {
+				return stripWhitespace(typed.String()), nil
+			}
+			return "", io.EOF
+		default:
+			if b >= 0x20 {
+				typed.WriteByte(b)
+			}
+		}
+	}
+
+	if inPaste {
+		return stripWhitespace(pasted.String()), nil
+	}
+	return stripWhitespace(typed.String()), nil
+}
+
+// readCSI consumes a CSI sequence after an ESC byte and returns its parameter
+// and final bytes (e.g. "200~"). If ESC is not followed by '[', the single
+// byte is returned so the caller can ignore it.
+func readCSI(br *bufio.Reader) (string, error) {
+	c, err := br.ReadByte()
+	if err != nil {
+		return "", err
+	}
+	if c != '[' {
+		return string(rune(c)), nil
+	}
+	var sb strings.Builder
+	for {
+		d, err := br.ReadByte()
+		if err != nil {
+			return "", err
+		}
+		sb.WriteByte(d)
+		if d >= 0x40 && d <= 0x7e { // CSI final byte
+			return sb.String(), nil
+		}
+	}
+}
+
+// promptAndValidateOAuthToken reads an OAuth token pasted by the user, checks
+// its format, validates it against the API, and returns the credential.
+func promptAndValidateOAuthToken(ctx context.Context) (*provider.Credential, error) {
+	fmt.Println("\nPaste the OAuth token (it starts with sk-ant-oat01-).")
+
+	var (
+		token string
+		err   error
+	)
+	if term.IsTerminal(os.Stdin) {
+		// Bracketed paste captures the whole paste — including a token the
+		// source terminal soft-wrapped onto multiple lines — with no extra
+		// keystroke.
+		token, err = readTokenFromTerminal(os.Stdin)
+	} else {
+		// Piped/non-interactive input: read until a blank line or EOF.
+		token, err = readPastedToken(bufio.NewReader(os.Stdin))
+	}
 	if err != nil {
 		return nil, fmt.Errorf("reading input: %w", err)
 	}
-	token = strings.TrimSpace(token)
 
 	if token == "" {
 		return nil, fmt.Errorf("OAuth token cannot be empty")
@@ -251,7 +337,6 @@ func grantViaExistingOAuthToken(ctx context.Context) (*provider.Credential, erro
 		return nil, fmt.Errorf("invalid token format: expected an OAuth token starting with \"sk-ant-oat\"")
 	}
 
-	// Validate the token against the API
 	fmt.Println("\nValidating OAuth token...")
 	auth := &anthropicAuth{}
 	validateCtx, validateCancel := context.WithTimeout(ctx, 30*time.Second)
@@ -271,175 +356,6 @@ func grantViaExistingOAuthToken(ctx context.Context) (*provider.Credential, erro
 	fmt.Println("\nClaude credential acquired.")
 	fmt.Println("You can now run 'moat claude' to start Claude Code.")
 	return cred, nil
-}
-
-// extractOAuthToken extracts the OAuth token from claude setup-token output.
-//
-// The token format is: sk-ant-oat01-<base64-data>
-// The token appears on its own line(s) between descriptive text.
-//
-// The Claude CLI output varies:
-// - Sometimes uses \n for newlines with blank lines as \n\n or \n<spaces>\n
-// - Sometimes uses \r with ANSI cursor codes: \x1b[1B (down 1), \x1b[2B (down 2 = blank line)
-//
-// Strategy:
-// 1. Find "sk-ant-oat01-" in the raw output
-// 2. Extract until we hit a "blank line" indicator:
-//   - \x1b[2B (ANSI cursor down 2+)
-//   - \n followed by whitespace-only line followed by \n
-//
-// 3. Clean the extracted block (strip ANSI codes and whitespace)
-func extractOAuthToken(output string) string {
-	// Find the start of the token in raw output
-	const prefix = "sk-ant-oat01-"
-	startIdx := strings.Index(output, prefix)
-	if startIdx == -1 {
-		log.Debug("no token prefix found in output",
-			"subsystem", "grant",
-			"action", "extract_token",
-			"output_len", len(output),
-		)
-		return ""
-	}
-
-	log.Debug("found token prefix",
-		"subsystem", "grant",
-		"action", "extract_token",
-		"start_idx", startIdx,
-		"output_len", len(output),
-	)
-
-	// Extract until we hit a "blank line" indicator
-	endIdx := len(output)
-	endReason := "end_of_output"
-	for i := startIdx; i < len(output); i++ {
-		// Check for ANSI cursor down 2+ lines: \x1b[NB where N >= 2
-		// This is used by Claude CLI to create visual blank lines
-		if output[i] == '\x1b' && i+3 < len(output) && output[i+1] == '[' {
-			// Parse the number before 'B'
-			j := i + 2
-			for j < len(output) && output[j] >= '0' && output[j] <= '9' {
-				j++
-			}
-			if j < len(output) && output[j] == 'B' && j > i+2 {
-				n := 0
-				for k := i + 2; k < j; k++ {
-					n = n*10 + int(output[k]-'0')
-				}
-				if n >= 2 {
-					// Find the \r or start of this escape sequence
-					endIdx = i
-					// Back up past any preceding \r
-					for endIdx > startIdx && output[endIdx-1] == '\r' {
-						endIdx--
-					}
-					endReason = fmt.Sprintf("ansi_cursor_down_%d", n)
-					goto done
-				}
-			}
-		}
-
-		// Check for blank line: \n followed by only whitespace until next \n
-		if output[i] == '\n' {
-			lineStart := i + 1
-			isBlank := true
-			for j := lineStart; j < len(output); j++ {
-				c := output[j]
-				if c == '\n' {
-					// Found end of line
-					if isBlank {
-						endIdx = i
-						endReason = "blank_line"
-						goto done
-					}
-					break
-				}
-				if c != ' ' && c != '\t' && c != '\r' {
-					break // Non-whitespace found, not a blank line
-				}
-			}
-		}
-	}
-done:
-
-	tokenBlock := output[startIdx:endIdx]
-	log.Debug("token block extracted",
-		"subsystem", "grant",
-		"action", "extract_token",
-		"end_reason", endReason,
-		"block_len", len(tokenBlock),
-	)
-	if log.Verbose() {
-		log.Debug("token block raw content",
-			"subsystem", "grant",
-			"action", "extract_token",
-			"raw_block", fmt.Sprintf("%q", tokenBlock),
-		)
-	}
-
-	// Now clean the token block: strip ANSI and extract only token characters
-	cleaned := stripANSI(tokenBlock)
-
-	// Extract only valid token characters, tracking what was removed
-	var token strings.Builder
-	var removed strings.Builder
-	for i := 0; i < len(cleaned); i++ {
-		c := cleaned[i]
-		if isTokenChar(c) {
-			token.WriteByte(c)
-		} else {
-			removed.WriteString(fmt.Sprintf("[%d]=%q ", i, string(c)))
-		}
-	}
-
-	result := token.String()
-	log.Debug("token extraction complete",
-		"subsystem", "grant",
-		"action", "extract_token",
-		"result_len", len(result),
-		"cleaned_len", len(cleaned),
-		"removed_chars", removed.String(),
-	)
-
-	// Validate the token looks reasonable
-	if len(result) < 60 {
-		log.Debug("token too short, rejecting",
-			"subsystem", "grant",
-			"action", "extract_token",
-			"result_len", len(result),
-			"min_len", 60,
-		)
-		return ""
-	}
-
-	return result
-}
-
-// isTokenChar returns true if c is a valid OAuth token character.
-func isTokenChar(c byte) bool {
-	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-		(c >= '0' && c <= '9') || c == '_' || c == '-'
-}
-
-// stripANSI removes ANSI escape sequences from a string.
-func stripANSI(s string) string {
-	var result strings.Builder
-	inEscape := false
-	for i := 0; i < len(s); i++ {
-		if s[i] == '\x1b' {
-			inEscape = true
-			continue
-		}
-		if inEscape {
-			// ANSI sequences end with a letter
-			if (s[i] >= 'A' && s[i] <= 'Z') || (s[i] >= 'a' && s[i] <= 'z') {
-				inEscape = false
-			}
-			continue
-		}
-		result.WriteByte(s[i])
-	}
-	return result.String()
 }
 
 // grantViaAPIKey prompts for an API key.

--- a/internal/providers/claude/grant_test.go
+++ b/internal/providers/claude/grant_test.go
@@ -1,0 +1,95 @@
+package claude
+
+import (
+	"bufio"
+	"io"
+	"strings"
+	"testing"
+)
+
+// TestScanBracketedPaste covers the interactive terminal path: a bracketed
+// paste (ESC[200~ … ESC[201~) is captured whole even when the source terminal
+// soft-wrapped the token across lines, with no terminator keystroke. Manually
+// typed input still ends on Enter.
+func TestScanBracketedPaste(t *testing.T) {
+	const tok = "sk-ant-oat01-6EGPt5Yxvrb5tYAeTxjvGeFG7kmCOnbT"
+	cases := []struct {
+		name, in, want string
+		wantErr        bool
+	}{
+		{name: "paste single line", in: "\x1b[200~" + tok + "\x1b[201~", want: tok},
+		{name: "paste wrapped with newlines", in: "\x1b[200~sk-ant-oat01-aaa\r\nbbb\nccc\x1b[201~", want: "sk-ant-oat01-aaabbbccc"},
+		{name: "paste then stray enter ignored", in: "\x1b[200~" + tok + "\x1b[201~", want: tok},
+		{name: "typed then enter", in: tok + "\r", want: tok},
+		{name: "typed with backspace", in: "sk-ant-oat01-zX\x7f\r", want: "sk-ant-oat01-z"},
+		{name: "ctrl-c cancels", in: "\x03", wantErr: true},
+		{name: "other CSI ignored around paste", in: "\x1b[0m\x1b[200~" + tok + "\x1b[201~", want: tok},
+		{name: "typed then EOF", in: tok, want: tok},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := scanBracketedPaste(strings.NewReader(c.in))
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got token %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("scanBracketedPaste(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+// lineReader yields exactly one element per Read call, simulating a terminal
+// in canonical mode where a multi-line paste is delivered to the process one
+// line at a time (each only after its newline). This is the condition under
+// which bufio.Buffered() is 0 between lines, which broke the first attempt.
+type lineReader struct {
+	lines []string
+	i     int
+}
+
+func (lr *lineReader) Read(p []byte) (int, error) {
+	if lr.i >= len(lr.lines) {
+		return 0, io.EOF
+	}
+	n := copy(p, lr.lines[lr.i])
+	lr.i++
+	return n, nil
+}
+
+// TestReadPastedToken covers a pasted OAuth token that the source terminal
+// soft-wrapped across lines, delivered line-by-line as a real terminal does.
+// The token has no internal whitespace, so reassembly must drop it all and
+// must not stop at the first newline.
+func TestReadPastedToken(t *testing.T) {
+	cases := []struct {
+		name  string
+		lines []string
+		want  string
+	}{
+		{"single line then blank", []string{"sk-ant-oat01-abc\n", "\n"}, "sk-ant-oat01-abc"},
+		{"wrapped, blank-line terminated", []string{"sk-ant-oat01-aaa\n", " bbb\n", "\n"}, "sk-ant-oat01-aaabbb"},
+		{"wrapped then EOF (ctrl-d)", []string{"sk-ant-oat01-1\n", "2"}, "sk-ant-oat01-12"},
+		{"no trailing newline, EOF", []string{"sk-ant-oat01-xyz"}, "sk-ant-oat01-xyz"},
+		{"crlf wraps", []string{"sk-ant-oat01-1\r\n", "2\r\n", "\r\n"}, "sk-ant-oat01-12"},
+		{"leading blank ignored", []string{"\n", "sk-ant-oat01-z\n", "\n"}, "sk-ant-oat01-z"},
+		{"empty", []string{}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := readPastedToken(bufio.NewReader(&lineReader{lines: c.lines}))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("readPastedToken(%q) = %q, want %q", c.lines, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/providers/claude/grant_test.go
+++ b/internal/providers/claude/grant_test.go
@@ -3,9 +3,41 @@ package claude
 import (
 	"bufio"
 	"io"
+	"os"
 	"strings"
 	"testing"
 )
+
+// TestReadOAuthTokenInput_pipedUsesSharedReader guards against re-introducing a
+// second bufio.Reader on os.Stdin for piped input. The menu prompt reads the
+// choice from a bufio.Reader, which can buffer the rest of a piped stdin (the
+// token line arrives in the same read as the choice). The token read MUST use
+// that same reader, or the buffered token is lost.
+func TestReadOAuthTokenInput_pipedUsesSharedReader(t *testing.T) {
+	// One reader over the whole piped stdin: menu choice + token, as a pipe
+	// delivers it in a single read.
+	reader := bufio.NewReader(strings.NewReader("2\nsk-ant-oat01-shared-token\n\n"))
+	if _, err := reader.ReadString('\n'); err != nil { // menu consumes the choice
+		t.Fatalf("consuming menu choice: %v", err)
+	}
+
+	// A pipe (not a TTY) selects the non-interactive branch; the token is read
+	// from reader, not from this file.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pw.Close()
+	defer pr.Close()
+
+	got, err := readOAuthTokenInput(reader, pr)
+	if err != nil {
+		t.Fatalf("readOAuthTokenInput: %v", err)
+	}
+	if got != "sk-ant-oat01-shared-token" {
+		t.Errorf("token = %q, want %q (token buffered by the menu reader was lost)", got, "sk-ant-oat01-shared-token")
+	}
+}
 
 // TestScanBracketedPaste covers the interactive terminal path: a bracketed
 // paste (ESC[200~ … ESC[201~) is captured whole even when the source terminal


### PR DESCRIPTION
moat grant claude spawned `claude setup-token` under a PTY, captured its output, and parsed the OAuth token out of it. Recent Claude CLI versions render setup-token as a TUI, so the token never appeared contiguously in the captured stream and extraction always failed with "could not find OAuth token in claude setup-token output", forcing a manual paste anyway.

Any output scraping here is inherently brittle: the CLI's rendering is not a stable interface and changes between versions. Instead, run `claude setup-token` attached directly to the user's terminal (no PTY, no capture) so Claude displays the token as normal, then have the user paste it and validate it against the API.

A token soft-wrapped by a narrow terminal puts real newlines in the clipboard. On an interactive terminal the paste is read via bracketed paste (DECSET 2004): the whole paste is captured between ESC[200~ and ESC[201~ with no terminator keystroke, then whitespace is stripped (tokens contain none). Non-interactive/piped input falls back to reading until a blank line or EOF. The scanner is a pure function over an io.Reader and is unit-tested without a terminal.

Consolidates the paste-and-validate logic shared with the existing-token option into one helper.