### PR TITLE
fix(container): set tmpfs mode to 1777 for non-root container users

### DIFF
--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -302,13 +302,9 @@ func (r *AppleRuntime) buildCreateArgs(cfg Config) ([]string, error) {
 		args = append(args, "--volume", mountStr)
 	}
 
-	// Tmpfs mounts (overlays for excluded directories).
-	// Use --mount instead of --tmpfs so we can set mode=1777 (sticky
-	// world-writable). Without an explicit mode the runtime may default to
-	// 755, causing EACCES for non-root container users — the same issue
-	// fixed for Docker in PR #355.
+	// --mount (not --tmpfs) so we can set the mode; --tmpfs accepts no options.
 	for _, tm := range cfg.TmpfsMounts {
-		args = append(args, "--mount", fmt.Sprintf("type=tmpfs,destination=%s,mode=1777", tm.Target))
+		args = append(args, "--mount", fmt.Sprintf("type=tmpfs,destination=%s,mode=%o", tm.Target, tmpfsMode))
 	}
 
 	// Image

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -302,9 +302,13 @@ func (r *AppleRuntime) buildCreateArgs(cfg Config) ([]string, error) {
 		args = append(args, "--volume", mountStr)
 	}
 
-	// Tmpfs mounts (overlays for excluded directories)
+	// Tmpfs mounts (overlays for excluded directories).
+	// Use --mount instead of --tmpfs so we can set mode=1777 (sticky
+	// world-writable). Without an explicit mode the runtime may default to
+	// 755, causing EACCES for non-root container users — the same issue
+	// fixed for Docker in PR #355.
 	for _, tm := range cfg.TmpfsMounts {
-		args = append(args, "--tmpfs", tm.Target)
+		args = append(args, "--mount", fmt.Sprintf("type=tmpfs,destination=%s,mode=1777", tm.Target))
 	}
 
 	// Image

--- a/internal/container/apple_test.go
+++ b/internal/container/apple_test.go
@@ -174,7 +174,7 @@ func TestBuildCreateArgs(t *testing.T) {
 					{Target: "/workspace/node_modules"},
 				},
 			},
-			want: []string{"create", "--memory", "4096MB", "--dns", "8.8.8.8", "--dns", "8.8.4.4", "--tmpfs", "/workspace/node_modules", "ubuntu:22.04"},
+			want: []string{"create", "--memory", "4096MB", "--dns", "8.8.8.8", "--dns", "8.8.4.4", "--mount", "type=tmpfs,destination=/workspace/node_modules,mode=1777", "ubuntu:22.04"},
 		},
 		{
 			name: "with volume and tmpfs mounts",
@@ -188,7 +188,7 @@ func TestBuildCreateArgs(t *testing.T) {
 					{Target: "/workspace/.venv"},
 				},
 			},
-			want: []string{"create", "--memory", "4096MB", "--dns", "8.8.8.8", "--dns", "8.8.4.4", "--volume", "/home/user/project:/workspace", "--tmpfs", "/workspace/node_modules", "--tmpfs", "/workspace/.venv", "ubuntu:22.04"},
+			want: []string{"create", "--memory", "4096MB", "--dns", "8.8.8.8", "--dns", "8.8.4.4", "--volume", "/home/user/project:/workspace", "--mount", "type=tmpfs,destination=/workspace/node_modules,mode=1777", "--mount", "type=tmpfs,destination=/workspace/.venv,mode=1777", "ubuntu:22.04"},
 		},
 		{
 			// Apple's container CLI has no --add-host equivalent. ExtraHosts must

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -162,11 +162,11 @@ func (r *DockerRuntime) Ping(ctx context.Context) error {
 }
 
 // buildContainerMounts converts moat's MountConfig and TmpfsMount entries into
-// Docker SDK mount.Mount structs. Tmpfs mounts overlay subdirectories of
-// bind-mounted paths and are appended after bind mounts so they apply on top.
-func buildContainerMounts(cfg Config) []mount.Mount {
-	mounts := make([]mount.Mount, 0, len(cfg.Mounts)+len(cfg.TmpfsMounts))
-	for _, m := range cfg.Mounts {
+// Docker SDK mount.Mount structs. Tmpfs mounts follow bind mounts so overlays
+// of paths inside a bind take effect.
+func buildContainerMounts(binds []MountConfig, tmpfs []TmpfsMount) []mount.Mount {
+	mounts := make([]mount.Mount, 0, len(binds)+len(tmpfs))
+	for _, m := range binds {
 		mounts = append(mounts, mount.Mount{
 			Type:     mount.TypeBind,
 			Source:   m.Source,
@@ -174,22 +174,14 @@ func buildContainerMounts(cfg Config) []mount.Mount {
 			ReadOnly: m.ReadOnly,
 		})
 	}
-	for _, tm := range cfg.TmpfsMounts {
-		// Mode 1777 + exec: two fixes for tmpfs mounts used by mounts.exclude.
-		//
-		// Mode 1777 (sticky world-writable) matches Docker CLI's `--tmpfs`
-		// default. Without it, runc defaults to mode 755 owned by root,
-		// causing EACCES for non-root container users writing into the tmpfs.
-		//
-		// "exec" overrides runc's default "noexec" flag. Excluded paths like
-		// node_modules contain native binaries (e.g., turbo, esbuild) that
-		// must be executable. Without "exec", any spawn from the tmpfs fails
-		// with EACCES regardless of file permissions.
+	for _, tm := range tmpfs {
+		// "exec" overrides runc's default noexec — excluded paths like
+		// node_modules contain native binaries (turbo, esbuild) that must spawn.
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeTmpfs,
 			Target: tm.Target,
 			TmpfsOptions: &mount.TmpfsOptions{
-				Mode:    0o1777,
+				Mode:    tmpfsMode,
 				Options: [][]string{{"exec"}},
 			},
 		})
@@ -209,7 +201,7 @@ func (r *DockerRuntime) CreateContainer(ctx context.Context, cfg Config) (string
 		return "", err
 	}
 
-	mounts := buildContainerMounts(cfg)
+	mounts := buildContainerMounts(cfg.Mounts, cfg.TmpfsMounts)
 
 	// Default to bridge network if not specified
 	networkMode := container.NetworkMode(cfg.NetworkMode)
@@ -1018,16 +1010,7 @@ func (m *dockerSidecarManager) StartSidecar(ctx context.Context, cfg SidecarConf
 		return "", fmt.Errorf("pulling sidecar image: %w", err)
 	}
 
-	// Prepare mounts
-	mounts := make([]mount.Mount, 0, len(cfg.Mounts))
-	for _, mt := range cfg.Mounts {
-		mounts = append(mounts, mount.Mount{
-			Type:     mount.TypeBind,
-			Source:   mt.Source,
-			Target:   mt.Target,
-			ReadOnly: mt.ReadOnly,
-		})
-	}
+	mounts := buildContainerMounts(cfg.Mounts, nil)
 
 	// Create container with labels for orphan cleanup
 	labels := make(map[string]string)

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -175,15 +175,22 @@ func buildContainerMounts(cfg Config) []mount.Mount {
 		})
 	}
 	for _, tm := range cfg.TmpfsMounts {
+		// Mode 1777 + exec: two fixes for tmpfs mounts used by mounts.exclude.
+		//
 		// Mode 1777 (sticky world-writable) matches Docker CLI's `--tmpfs`
 		// default. Without it, runc defaults to mode 755 owned by root,
-		// causing EACCES for non-root container users writing into the tmpfs
-		// (e.g., pnpm install creating its store inside an excluded path).
+		// causing EACCES for non-root container users writing into the tmpfs.
+		//
+		// "exec" overrides runc's default "noexec" flag. Excluded paths like
+		// node_modules contain native binaries (e.g., turbo, esbuild) that
+		// must be executable. Without "exec", any spawn from the tmpfs fails
+		// with EACCES regardless of file permissions.
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeTmpfs,
 			Target: tm.Target,
 			TmpfsOptions: &mount.TmpfsOptions{
-				Mode: 0o1777,
+				Mode:    0o1777,
+				Options: [][]string{{"exec"}},
 			},
 		})
 	}

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -161,6 +161,35 @@ func (r *DockerRuntime) Ping(ctx context.Context) error {
 	return nil
 }
 
+// buildContainerMounts converts moat's MountConfig and TmpfsMount entries into
+// Docker SDK mount.Mount structs. Tmpfs mounts overlay subdirectories of
+// bind-mounted paths and are appended after bind mounts so they apply on top.
+func buildContainerMounts(cfg Config) []mount.Mount {
+	mounts := make([]mount.Mount, 0, len(cfg.Mounts)+len(cfg.TmpfsMounts))
+	for _, m := range cfg.Mounts {
+		mounts = append(mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   m.Source,
+			Target:   m.Target,
+			ReadOnly: m.ReadOnly,
+		})
+	}
+	for _, tm := range cfg.TmpfsMounts {
+		// Mode 1777 (sticky world-writable) matches Docker CLI's `--tmpfs`
+		// default. Without it, runc defaults to mode 755 owned by root,
+		// causing EACCES for non-root container users writing into the tmpfs
+		// (e.g., pnpm install creating its store inside an excluded path).
+		mounts = append(mounts, mount.Mount{
+			Type:   mount.TypeTmpfs,
+			Target: tm.Target,
+			TmpfsOptions: &mount.TmpfsOptions{
+				Mode: 0o1777,
+			},
+		})
+	}
+	return mounts
+}
+
 // CreateContainer creates a new Docker container.
 func (r *DockerRuntime) CreateContainer(ctx context.Context, cfg Config) (string, error) {
 	// Verify gVisor is still available if we're configured to use it
@@ -173,24 +202,7 @@ func (r *DockerRuntime) CreateContainer(ctx context.Context, cfg Config) (string
 		return "", err
 	}
 
-	// Convert mounts
-	mounts := make([]mount.Mount, 0, len(cfg.Mounts)+len(cfg.TmpfsMounts))
-	for _, m := range cfg.Mounts {
-		mounts = append(mounts, mount.Mount{
-			Type:     mount.TypeBind,
-			Source:   m.Source,
-			Target:   m.Target,
-			ReadOnly: m.ReadOnly,
-		})
-	}
-	// Tmpfs mounts — overlays for excluded directories.
-	// Appended after bind mounts so tmpfs overlays subdirectories of bind-mounted paths.
-	for _, tm := range cfg.TmpfsMounts {
-		mounts = append(mounts, mount.Mount{
-			Type:   mount.TypeTmpfs,
-			Target: tm.Target,
-		})
-	}
+	mounts := buildContainerMounts(cfg)
 
 	// Default to bridge network if not specified
 	networkMode := container.NetworkMode(cfg.NetworkMode)

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -3,15 +3,91 @@ package container
 import (
 	"context"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 )
+
+// TestBuildContainerMounts_TmpfsWorldWritable asserts that tmpfs mounts are
+// created with mode 1777 so non-root container users can write to them.
+// Without an explicit mode, runc creates the tmpfs as mode 755 owned by root,
+// causing EACCES for non-root processes (e.g., pnpm install as moatuser).
+func TestBuildContainerMounts_TmpfsWorldWritable(t *testing.T) {
+	cfg := Config{
+		TmpfsMounts: []TmpfsMount{
+			{Target: "/workspace/node_modules"},
+		},
+	}
+
+	got := buildContainerMounts(cfg)
+
+	if len(got) != 1 {
+		t.Fatalf("got %d mounts, want 1", len(got))
+	}
+	if got[0].Type != mount.TypeTmpfs {
+		t.Errorf("Type = %v, want %v", got[0].Type, mount.TypeTmpfs)
+	}
+	if got[0].TmpfsOptions == nil {
+		t.Fatal("TmpfsOptions is nil; expected non-nil with Mode set to 0o1777")
+	}
+	if got[0].TmpfsOptions.Mode != 0o1777 {
+		t.Errorf("TmpfsOptions.Mode = %o, want %o (sticky world-writable)", got[0].TmpfsOptions.Mode, 0o1777)
+	}
+}
+
+// TestBuildContainerMounts_BindMounts asserts that bind mounts are produced
+// with the right type, source, target, and read-only flag.
+func TestBuildContainerMounts_BindMounts(t *testing.T) {
+	cfg := Config{
+		Mounts: []MountConfig{
+			{Source: "/host/project", Target: "/workspace", ReadOnly: false},
+			{Source: "/host/secret", Target: "/etc/secret", ReadOnly: true},
+		},
+	}
+
+	got := buildContainerMounts(cfg)
+
+	want := []mount.Mount{
+		{Type: mount.TypeBind, Source: "/host/project", Target: "/workspace", ReadOnly: false},
+		{Type: mount.TypeBind, Source: "/host/secret", Target: "/etc/secret", ReadOnly: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("buildContainerMounts() = %#v, want %#v", got, want)
+	}
+}
+
+// TestBuildContainerMounts_TmpfsAfterBind verifies tmpfs mounts come after bind
+// mounts in the slice. Docker applies mounts in order; tmpfs overlays of paths
+// inside a bind mount must follow the bind to take effect.
+func TestBuildContainerMounts_TmpfsAfterBind(t *testing.T) {
+	cfg := Config{
+		Mounts: []MountConfig{
+			{Source: "/host/project", Target: "/workspace"},
+		},
+		TmpfsMounts: []TmpfsMount{
+			{Target: "/workspace/node_modules"},
+		},
+	}
+
+	got := buildContainerMounts(cfg)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d mounts, want 2", len(got))
+	}
+	if got[0].Type != mount.TypeBind {
+		t.Errorf("mounts[0].Type = %v, want bind", got[0].Type)
+	}
+	if got[1].Type != mount.TypeTmpfs {
+		t.Errorf("mounts[1].Type = %v, want tmpfs", got[1].Type)
+	}
+}
 
 func TestConfig_GroupAdd(t *testing.T) {
 	// Verify that GroupAdd field can be set on Config struct

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -15,11 +15,12 @@ import (
 	"github.com/docker/docker/client"
 )
 
-// TestBuildContainerMounts_TmpfsWorldWritable asserts that tmpfs mounts are
-// created with mode 1777 so non-root container users can write to them.
-// Without an explicit mode, runc creates the tmpfs as mode 755 owned by root,
-// causing EACCES for non-root processes (e.g., pnpm install as moatuser).
-func TestBuildContainerMounts_TmpfsWorldWritable(t *testing.T) {
+// TestBuildContainerMounts_TmpfsWritableAndExec asserts that tmpfs mounts are
+// created with mode 1777 and the exec option. Mode 1777 lets non-root users
+// write (runc defaults to 755). The exec option overrides runc's default
+// noexec flag so native binaries in excluded paths (e.g., turbo in
+// node_modules) can be executed.
+func TestBuildContainerMounts_TmpfsWritableAndExec(t *testing.T) {
 	cfg := Config{
 		TmpfsMounts: []TmpfsMount{
 			{Target: "/workspace/node_modules"},
@@ -35,10 +36,14 @@ func TestBuildContainerMounts_TmpfsWorldWritable(t *testing.T) {
 		t.Errorf("Type = %v, want %v", got[0].Type, mount.TypeTmpfs)
 	}
 	if got[0].TmpfsOptions == nil {
-		t.Fatal("TmpfsOptions is nil; expected non-nil with Mode set to 0o1777")
+		t.Fatal("TmpfsOptions is nil; expected non-nil with Mode and Options set")
 	}
 	if got[0].TmpfsOptions.Mode != 0o1777 {
 		t.Errorf("TmpfsOptions.Mode = %o, want %o (sticky world-writable)", got[0].TmpfsOptions.Mode, 0o1777)
+	}
+	wantOpts := [][]string{{"exec"}}
+	if !reflect.DeepEqual(got[0].TmpfsOptions.Options, wantOpts) {
+		t.Errorf("TmpfsOptions.Options = %v, want %v (exec required for native binaries)", got[0].TmpfsOptions.Options, wantOpts)
 	}
 }
 

--- a/internal/container/docker_test.go
+++ b/internal/container/docker_test.go
@@ -15,19 +15,8 @@ import (
 	"github.com/docker/docker/client"
 )
 
-// TestBuildContainerMounts_TmpfsWritableAndExec asserts that tmpfs mounts are
-// created with mode 1777 and the exec option. Mode 1777 lets non-root users
-// write (runc defaults to 755). The exec option overrides runc's default
-// noexec flag so native binaries in excluded paths (e.g., turbo in
-// node_modules) can be executed.
 func TestBuildContainerMounts_TmpfsWritableAndExec(t *testing.T) {
-	cfg := Config{
-		TmpfsMounts: []TmpfsMount{
-			{Target: "/workspace/node_modules"},
-		},
-	}
-
-	got := buildContainerMounts(cfg)
+	got := buildContainerMounts(nil, []TmpfsMount{{Target: "/workspace/node_modules"}})
 
 	if len(got) != 1 {
 		t.Fatalf("got %d mounts, want 1", len(got))
@@ -36,28 +25,24 @@ func TestBuildContainerMounts_TmpfsWritableAndExec(t *testing.T) {
 		t.Errorf("Type = %v, want %v", got[0].Type, mount.TypeTmpfs)
 	}
 	if got[0].TmpfsOptions == nil {
-		t.Fatal("TmpfsOptions is nil; expected non-nil with Mode and Options set")
+		t.Fatal("TmpfsOptions is nil")
 	}
-	if got[0].TmpfsOptions.Mode != 0o1777 {
-		t.Errorf("TmpfsOptions.Mode = %o, want %o (sticky world-writable)", got[0].TmpfsOptions.Mode, 0o1777)
+	if got[0].TmpfsOptions.Mode != tmpfsMode {
+		t.Errorf("Mode = %o, want %o", got[0].TmpfsOptions.Mode, tmpfsMode)
 	}
 	wantOpts := [][]string{{"exec"}}
 	if !reflect.DeepEqual(got[0].TmpfsOptions.Options, wantOpts) {
-		t.Errorf("TmpfsOptions.Options = %v, want %v (exec required for native binaries)", got[0].TmpfsOptions.Options, wantOpts)
+		t.Errorf("Options = %v, want %v", got[0].TmpfsOptions.Options, wantOpts)
 	}
 }
 
-// TestBuildContainerMounts_BindMounts asserts that bind mounts are produced
-// with the right type, source, target, and read-only flag.
 func TestBuildContainerMounts_BindMounts(t *testing.T) {
-	cfg := Config{
-		Mounts: []MountConfig{
-			{Source: "/host/project", Target: "/workspace", ReadOnly: false},
-			{Source: "/host/secret", Target: "/etc/secret", ReadOnly: true},
-		},
+	binds := []MountConfig{
+		{Source: "/host/project", Target: "/workspace", ReadOnly: false},
+		{Source: "/host/secret", Target: "/etc/secret", ReadOnly: true},
 	}
 
-	got := buildContainerMounts(cfg)
+	got := buildContainerMounts(binds, nil)
 
 	want := []mount.Mount{
 		{Type: mount.TypeBind, Source: "/host/project", Target: "/workspace", ReadOnly: false},
@@ -68,20 +53,13 @@ func TestBuildContainerMounts_BindMounts(t *testing.T) {
 	}
 }
 
-// TestBuildContainerMounts_TmpfsAfterBind verifies tmpfs mounts come after bind
-// mounts in the slice. Docker applies mounts in order; tmpfs overlays of paths
-// inside a bind mount must follow the bind to take effect.
+// Tmpfs must follow binds in the output slice so overlays of paths inside a
+// bind take effect on the daemon side.
 func TestBuildContainerMounts_TmpfsAfterBind(t *testing.T) {
-	cfg := Config{
-		Mounts: []MountConfig{
-			{Source: "/host/project", Target: "/workspace"},
-		},
-		TmpfsMounts: []TmpfsMount{
-			{Target: "/workspace/node_modules"},
-		},
-	}
+	binds := []MountConfig{{Source: "/host/project", Target: "/workspace"}}
+	tmpfs := []TmpfsMount{{Target: "/workspace/node_modules"}}
 
-	got := buildContainerMounts(cfg)
+	got := buildContainerMounts(binds, tmpfs)
 
 	if len(got) != 2 {
 		t.Fatalf("got %d mounts, want 2", len(got))

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -368,6 +368,11 @@ type TmpfsMount struct {
 	Target string // absolute container path
 }
 
+// tmpfsMode is the permission mode for tmpfs overlays. Sticky world-writable
+// (01777) so non-root container users can write — runc otherwise defaults
+// tmpfs to 0755 owned by root.
+const tmpfsMode = 01777
+
 // ImageInfo contains information about a container image.
 type ImageInfo struct {
 	ID      string    `json:"id"`


### PR DESCRIPTION
## Summary

- Set explicit `TmpfsOptions{Mode: 0o1777}` on tmpfs mounts produced by the Docker runtime. Without this, runc creates tmpfs as mode `755` owned by `root`, and any non-root container user (e.g., `moatuser`) gets `EACCES` writing into directories declared via `mounts.exclude`.
- Add `exec` option to Docker tmpfs mounts to override runc default `noexec` flag. Without this, native binaries in excluded paths (e.g., turbo, esbuild in `node_modules`) fail with `EACCES` when spawned.
- Extract the inline mount-building from `DockerRuntime.CreateContainer` into a `buildContainerMounts` helper so the behavior can be unit-tested without a live Docker daemon.
- **Apple Containers**: switch from `--tmpfs` to `--mount type=tmpfs,destination=...,mode=1777` so the mode is set explicitly. Apple `--tmpfs` flag passes empty options and does not support mode syntax. Apple containers do not need `exec` — the kernel defaults to allowing exec on user-supplied tmpfs mounts.
- Unit tests covering: tmpfs mode + exec, bind mount conversion, bind-before-tmpfs ordering, and updated Apple `BuildCreateArgs` tests for the new `--mount` syntax.

## Why

A user hit this with a pnpm install inside a moat container:

```
pnpm: EACCES: permission denied, mkdir '/workspace/.pnpm-store/v11'
```

Their `moat.yaml` had `mounts.exclude: [node_modules, .pnpm-store, ...]`. The exclude correctly produced tmpfs mounts at the right paths, but the tmpfs landed as `root:root 755` — unwritable for the non-root container user, so pnpm could not even create its store directory.

Mode `1777` matches what Docker CLI `--tmpfs` flag uses by default, so the fix brings the SDK path in line with user expectations.

Additionally, even after fixing the mode, `pnpm build` failed because runc defaults tmpfs to `noexec`:

```
scripts/turbo.sh: line 11: /workspace/node_modules/.bin/turbo: Permission denied
Error: spawn .../@turbo/linux-arm64/bin/turbo EACCES
```

The `exec` option fixes this — excluded paths like `node_modules` contain native binaries that must be executable.

## Test plan

- [x] `go test -short -race ./...` — all packages green
- [x] `make lint` — 0 issues
- [x] `TestBuildContainerMounts_TmpfsWritableAndExec` verifies mode 1777 and exec option
- [x] Apple `TestBuildCreateArgs` tests updated for `--mount` syntax
- [ ] Manual: run a moat container with `mounts.exclude: [node_modules]` and confirm a non-root user can `mkdir` and execute binaries inside `/workspace/node_modules`

## Out of scope

- **Configurability** — kept `1777` hardcoded for now. If anyone wants per-mount mode control, a `mode` field on the `exclude` config can be added later without changing the default.