### PR TITLE
fix(deps): install the pinned claude-code version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,16 +117,6 @@ linters:
           - revive
         text: "dot-imports"
 
-      # staticcheck SA5011 false positives in tests: the bundled staticcheck
-      # (golangci-lint v2.8.0) does not recognize t.Fatal/t.Fatalf as
-      # terminating, so it flags nil-guarded dereferences as possible nil
-      # derefs:  if x == nil { t.Fatal(...) }; x.Field — the guard makes the
-      # deref unreachable when nil. Production code keeps SA5011 active.
-      - path: _test\.go
-        linters:
-          - staticcheck
-        text: "SA5011"
-
       # E2E tests can have longer functions
       - path: e2e/
         linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,16 @@ linters:
           - revive
         text: "dot-imports"
 
+      # staticcheck SA5011 false positives in tests: the bundled staticcheck
+      # (golangci-lint v2.8.0) does not recognize t.Fatal/t.Fatalf as
+      # terminating, so it flags nil-guarded dereferences as possible nil
+      # derefs:  if x == nil { t.Fatal(...) }; x.Field — the guard makes the
+      # deref unreachable when nil. Production code keeps SA5011 active.
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: "SA5011"
+
       # E2E tests can have longer functions
       - path: e2e/
         linters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ## Unreleased
 
+### Fixed
+
+- Fix `claude-code@<version>` pinning being ignored — previously, specifying a version such as `claude-code@2.1.139` in `dependencies` (or relying on the dependency implied by `agent: claude-code`) still installed the latest release, because the install command dropped the version argument. The version is now passed to the official installer. This is a workaround for the Claude Code 2.1.150 text-entry regression ([#356](https://github.com/majorcontext/moat/issues/356)): pin `claude-code@2.1.139` until the regression is resolved upstream. ([#357](https://github.com/majorcontext/moat/pull/357))
+
 ## v0.5.1 — 2026-04-28
 
 Patch release with one security fix (IPv6 egress firewall) and a batch of run-lifecycle and proxy fixes. Adds `MOAT_HOME` for relocating moat state, a multi-runtime manager so Docker and Apple containers can coexist in one install, TUI debug shortcuts, and Python 3.13/3.14 support. Gatekeeper is extracted to its own repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ### Fixed
 
-- Fix `claude-code@<version>` pinning being ignored — previously, specifying a version such as `claude-code@2.1.139` in `dependencies` (or relying on the dependency implied by `agent: claude-code`) still installed the latest release, because the install command dropped the version argument. The version is now passed to the official installer. This is a workaround for the Claude Code 2.1.150 text-entry regression ([#356](https://github.com/majorcontext/moat/issues/356)): pin `claude-code@2.1.139` until the regression is resolved upstream. ([#357](https://github.com/majorcontext/moat/pull/357))
+- Fix `claude-code@<version>` pinning being ignored — previously, specifying a version such as `claude-code@2.1.139` in `dependencies` still installed the latest release, because the install command dropped the version argument. The version is now passed to the official installer. This is a workaround for the Claude Code 2.1.150 text-entry regression ([#356](https://github.com/majorcontext/moat/issues/356)): pin `claude-code@2.1.139` until the regression is resolved upstream. ([#357](https://github.com/majorcontext/moat/pull/357))
 
 ## v0.5.1 — 2026-04-28
 

--- a/docs/content/guides/01-claude-code.md
+++ b/docs/content/guides/01-claude-code.md
@@ -202,6 +202,29 @@ feature-auth  run_a1b2c3d4e5f6   running  5m ago
 $ moat logs -f run_a1b2c3d4e5f6
 ```
 
+## Pinning the Claude Code version
+
+By default, Moat installs the latest published Claude Code release when it builds
+the image. To pin a specific version, add `claude-code@<version>` to your
+`dependencies`:
+
+```yaml
+agent: claude-code
+dependencies:
+  - node@22
+  - git
+  - claude-code@2.1.139
+```
+
+The version must be a published release (for example `2.1.139`). Moat passes it to
+the official installer, so pinning works the same whether `claude-code` is listed
+explicitly or implied by `agent: claude-code`. Changing the pinned version triggers
+an image rebuild on the next run.
+
+`moat claude` (without an explicit `claude-code` dependency) always installs the
+latest release. To pin the version, add `claude-code@<version>` to `dependencies`
+as shown above.
+
 ## Adding GitHub access
 
 Grant GitHub access so Claude Code can interact with repositories:

--- a/docs/content/guides/01-claude-code.md
+++ b/docs/content/guides/01-claude-code.md
@@ -216,14 +216,15 @@ dependencies:
   - claude-code@2.1.139
 ```
 
-The version must be a published release (for example `2.1.139`). Moat passes it to
-the official installer, so pinning works the same whether `claude-code` is listed
-explicitly or implied by `agent: claude-code`. Changing the pinned version triggers
-an image rebuild on the next run.
+The version can be a release number (for example `2.1.139`), `stable`, or `latest` —
+the value is passed straight to the official installer. Moat installs it the same way
+regardless of how `claude-code` reached the dependency list, but a version specifier
+must be present: `agent: claude-code` on its own does **not** pin a version. Changing
+the version triggers an image rebuild on the next run.
 
-`moat claude` (without an explicit `claude-code` dependency) always installs the
-latest release. To pin the version, add `claude-code@<version>` to `dependencies`
-as shown above.
+`moat claude` and `agent: claude-code` inject an unversioned `claude-code` dependency,
+so they install the latest release. To pin, add an explicit `claude-code@<version>`
+to `dependencies` as shown above.
 
 ## Adding GitHub access
 

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -368,9 +368,13 @@ func getCustomCommands(name, version string) InstallCommands {
 		// (stable|latest|VERSION); with no version it installs latest. The
 		// version is validated by validateVersion() at parse time, so it only
 		// contains shell-safe characters.
+		//
+		// The "--" terminates bash's own option processing so a version that
+		// happens to start with "-" (e.g. "-n") is passed to the script as a
+		// positional arg rather than interpreted as a bash flag.
 		installCmd := "curl -fsSL https://claude.ai/install.sh | bash"
 		if version != "" {
-			installCmd = fmt.Sprintf("%s -s %s", installCmd, version)
+			installCmd = fmt.Sprintf("%s -s -- %s", installCmd, version)
 		}
 		return InstallCommands{
 			Commands: []string{installCmd},

--- a/internal/deps/install.go
+++ b/internal/deps/install.go
@@ -364,10 +364,16 @@ func getCustomCommands(name, version string) InstallCommands {
 	case "claude-code":
 		// Native installer - avoids Claude startup warnings from npm-based installs.
 		// The installer places the binary in ~/.claude/local/bin/.
+		// The installer takes an optional target as its first positional arg
+		// (stable|latest|VERSION); with no version it installs latest. The
+		// version is validated by validateVersion() at parse time, so it only
+		// contains shell-safe characters.
+		installCmd := "curl -fsSL https://claude.ai/install.sh | bash"
+		if version != "" {
+			installCmd = fmt.Sprintf("%s -s %s", installCmd, version)
+		}
 		return InstallCommands{
-			Commands: []string{
-				`curl -fsSL https://claude.ai/install.sh | bash`,
-			},
+			Commands: []string{installCmd},
 			EnvVars: map[string]string{
 				"PATH": "/home/moatuser/.claude/local/bin:/home/moatuser/.local/bin:$PATH",
 			},

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -285,7 +285,7 @@ func TestGetCustomCommandsClaudeCodeVersion(t *testing.T) {
 		{
 			name:     "pinned version",
 			version:  "2.1.139",
-			wantCmd:  "curl -fsSL https://claude.ai/install.sh | bash -s 2.1.139",
+			wantCmd:  "curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.139",
 			wantPATH: "/home/moatuser/.claude/local/bin",
 		},
 		{

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -275,6 +275,43 @@ func TestGetCustomCommands(t *testing.T) {
 	}
 }
 
+func TestGetCustomCommandsClaudeCodeVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		wantCmd  string
+		wantPATH string
+	}{
+		{
+			name:     "pinned version",
+			version:  "2.1.139",
+			wantCmd:  "curl -fsSL https://claude.ai/install.sh | bash -s 2.1.139",
+			wantPATH: "/home/moatuser/.claude/local/bin",
+		},
+		{
+			name:     "no version installs latest",
+			version:  "",
+			wantCmd:  "curl -fsSL https://claude.ai/install.sh | bash",
+			wantPATH: "/home/moatuser/.claude/local/bin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds := getCustomCommands("claude-code", tt.version)
+			if len(cmds.Commands) != 1 {
+				t.Fatalf("expected 1 command, got %d: %v", len(cmds.Commands), cmds.Commands)
+			}
+			if cmds.Commands[0] != tt.wantCmd {
+				t.Errorf("install command = %q, want %q", cmds.Commands[0], tt.wantCmd)
+			}
+			if path := cmds.EnvVars["PATH"]; !strings.Contains(path, tt.wantPATH) {
+				t.Errorf("PATH = %q, want it to contain %q", path, tt.wantPATH)
+			}
+		})
+	}
+}
+
 func TestGetCustomCommandsUnknown(t *testing.T) {
 	cmds := getCustomCommands("unknown", "1.0")
 	if len(cmds.Commands) != 0 {

--- a/internal/deps/install_test.go
+++ b/internal/deps/install_test.go
@@ -294,6 +294,14 @@ func TestGetCustomCommandsClaudeCodeVersion(t *testing.T) {
 			wantCmd:  "curl -fsSL https://claude.ai/install.sh | bash",
 			wantPATH: "/home/moatuser/.claude/local/bin",
 		},
+		{
+			// Symbolic targets (stable|latest) are valid installer args and must
+			// keep the "--" separator so a future refactor can't drop it.
+			name:     "symbolic target stable",
+			version:  "stable",
+			wantCmd:  "curl -fsSL https://claude.ai/install.sh | bash -s -- stable",
+			wantPATH: "/home/moatuser/.claude/local/bin",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Workaround for #356 (Claude Code 2.1.150 breaks text entry inside moat). `claude-code@<version>` pinning was silently ignored — Moat always installed the **latest** Claude Code release regardless of the version in `dependencies`, so there was no way to pin away from the broken 2.1.150 from inside a container. With this fix you can pin `claude-code@2.1.139` until the regression is resolved upstream.

### Root cause

In `internal/deps/install.go`, the `claude-code` install case hardcoded:

```
curl -fsSL https://claude.ai/install.sh | bash
```

and **dropped the `version` parameter** that is threaded through everywhere else. So `claude-code@2.1.139` parsed correctly, validated, and even participated in the image hash — but the install step always pulled latest. `moat claude` injects `claude-code` with no version, so it too always got latest.

The official installer accepts a target as its first positional arg (`stable|latest|VERSION`), so the fix is to forward the version:

```
curl -fsSL https://claude.ai/install.sh | bash -s <version>
```

### Changes

- **`internal/deps/install.go`** — pass the pinned version to the installer when set; with no version, install latest as before.
- **`internal/deps/install_test.go`** — new `TestGetCustomCommandsClaudeCodeVersion` covering both pinned and unversioned cases (previously there was no `claude-code` test).
- **`docs/content/guides/01-claude-code.md`** — new "Pinning the Claude Code version" section.
- **`CHANGELOG.md`** — `### Fixed` entry under Unreleased, flagged as a workaround for #356.

### Scope note

This PR only **enables** pinning as a workaround for #356. The default (`moat claude` / implicit installs) still tracks latest. Addressing the underlying 2.1.150 text-entry regression is tracked separately in #356.

> Note: an earlier revision of this branch included a `.golangci.yml` change to exclude SA5011 in tests. That was reverted — the SA5011 errors turned out to be a stale local `golangci-lint` cache, not real findings (`golangci-lint cache clean` → `make lint` reports 0 issues). The revert keeps SA5011 active.

## Testing

- `go build ./...`
- `go test -race ./internal/deps/` — pass
- `make lint` — 0 issues