### PR TITLE
fix(claude): write subscriptionType and scopes to container credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ## Unreleased
 
+### Fixed
+
+- Fix Claude Code showing "not logged in" / "API Usage Billing" inside containers — previously, the generated `~/.claude/.credentials.json` had `null` scopes and no `subscriptionType`, which Claude Code treats as an unauthenticated session. Moat now writes the standard OAuth scopes and a `subscriptionType` (default `max`, overridable via `claude.subscription_type`; the new `claude.rate_limit_tier` is also supported). Grants created by importing existing credentials use the real plan. The real plan is still enforced server-side via the proxy-injected token. Surfaced by v0.5.2 dropping the `CLAUDE_CODE_OAUTH_TOKEN` placeholder env var that had masked the incomplete file. ([#358](https://github.com/majorcontext/moat/pull/358))
+
 ## v0.5.1 — 2026-04-28
 
 Patch release with one security fix (IPv6 egress firewall) and a batch of run-lifecycle and proxy fixes. Adds `MOAT_HOME` for relocating moat state, a multi-runtime manager so Docker and Apple containers can coexist in one install, TUI debug shortcuts, and Python 3.13/3.14 support. Gatekeeper is extracted to its own repository.

--- a/docs/content/reference/02-moat-yaml.md
+++ b/docs/content/reference/02-moat-yaml.md
@@ -1100,6 +1100,40 @@ claude:
 - Type: `boolean`
 - Default: `true` (when `anthropic` grant is used)
 
+### claude.subscription_type
+
+Sets the `subscriptionType` written to Claude Code's `.credentials.json` inside the
+container (e.g. `pro`, `max`). Claude Code needs a non-empty subscription type to
+treat the session as a subscription rather than "API Usage Billing".
+
+```yaml
+claude:
+  subscription_type: max
+```
+
+- Type: `string`
+- Default: `max` for `claude` (OAuth) grants obtained via `setup-token` or a pasted
+  token, which don't carry plan information. Grants created with **import existing
+  credentials** use the real plan from your host login. Set this to match your plan
+  (`pro`/`max`) when it would otherwise be wrong.
+
+The real plan limits are always enforced server-side via the token the proxy injects;
+this value only affects what Claude Code displays and gates locally.
+
+### claude.rate_limit_tier
+
+Sets the `rateLimitTier` written to Claude Code's `.credentials.json` (e.g.
+`default_claude_max_20x`). Optional; mainly affects Claude Code's local rate-limit
+hints.
+
+```yaml
+claude:
+  rate_limit_tier: default_claude_max_20x
+```
+
+- Type: `string`
+- Default: unset (omitted), unless an imported grant supplied it.
+
 ### claude.plugins
 
 Enable or disable plugins. Plugins are installed during image build and cached in Docker layers, eliminating startup latency.

--- a/docs/content/reference/02-moat-yaml.md
+++ b/docs/content/reference/02-moat-yaml.md
@@ -1112,10 +1112,14 @@ claude:
 ```
 
 - Type: `string`
-- Default: `max` for `claude` (OAuth) grants obtained via `setup-token` or a pasted
-  token, which don't carry plan information. Grants created with **import existing
-  credentials** use the real plan from your host login. Set this to match your plan
-  (`pro`/`max`) when it would otherwise be wrong.
+- Default: `max`
+
+`setup-token` and pasted-token grants carry no plan information, so they always
+default to `max`. **If you are not on a Max plan and use one of those grant types,
+set `claude.subscription_type` to your actual plan (e.g. `pro`)** — otherwise Claude
+Code will show "Max" and may surface Max-only options locally that then fail
+server-side. Grants created with **import existing credentials** read the real plan
+from your host login, so they don't need this override.
 
 The real plan limits are always enforced server-side via the token the proxy injects;
 this value only affects what Claude Code displays and gates locally.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -273,6 +273,18 @@ type ClaudeConfig struct {
 	// MCP defines MCP (Model Context Protocol) server configurations.
 	MCP map[string]MCPServerSpec `yaml:"mcp,omitempty"`
 
+	// SubscriptionType overrides the subscriptionType written to Claude Code's
+	// .credentials.json (e.g. "pro", "max"). Setup-token and pasted-token grants
+	// don't carry the plan, so moat defaults to "max"; set this to match your
+	// plan. Imported grants use the real value unless this is set.
+	SubscriptionType string `yaml:"subscription_type,omitempty"`
+
+	// RateLimitTier overrides the rateLimitTier written to Claude Code's
+	// .credentials.json (e.g. "default_claude_max_20x"). Optional; mainly affects
+	// Claude Code's local rate-limit hints. Real plan limits are enforced
+	// server-side via the proxy-injected token.
+	RateLimitTier string `yaml:"rate_limit_tier,omitempty"`
+
 	// LLMGateway configures a Keep LLM gateway sidecar inside the container.
 	// Mutually exclusive with BaseURL.
 	LLMGateway *LLMGatewayConfig `yaml:"llm-gateway,omitempty"`

--- a/internal/provider/credential.go
+++ b/internal/provider/credential.go
@@ -34,6 +34,14 @@ type PrepareOpts struct {
 	// container. These are defined under agent-specific sections in moat.yaml
 	// (e.g., claude.mcp, codex.mcp, gemini.mcp).
 	LocalMCPServers map[string]LocalMCPServerConfig
+
+	// SubscriptionType and RateLimitTier override the values written to Claude
+	// Code's .credentials.json (from moat.yaml claude.subscription_type /
+	// claude.rate_limit_tier). Empty means "no override" — the provider falls
+	// back to the imported value or a default. Claude-specific; ignored by
+	// other agents.
+	SubscriptionType string
+	RateLimitTier    string
 }
 
 // MCPServerConfig defines a remote/relay MCP server configuration.

--- a/internal/providers/claude/agent.go
+++ b/internal/providers/claude/agent.go
@@ -39,7 +39,7 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 
 	// Write credentials file for OAuth tokens
 	if opts.Credential != nil {
-		if err := WriteCredentialsFile(opts.Credential, tmpDir); err != nil {
+		if err := WriteCredentialsFile(opts.Credential, tmpDir, opts.SubscriptionType, opts.RateLimitTier); err != nil {
 			return nil, fmt.Errorf("writing credentials file: %w", err)
 		}
 	}

--- a/internal/providers/claude/agent_test.go
+++ b/internal/providers/claude/agent_test.go
@@ -2,6 +2,7 @@ package claude
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -90,6 +91,41 @@ func TestPrepareContainer_skipsRemoteSettingsWhenMissing(t *testing.T) {
 	// Verify remote-settings.json was NOT created
 	if _, err := os.Stat(filepath.Join(cfg.StagingDir, "remote-settings.json")); err == nil {
 		t.Error("remote-settings.json should not exist when host file is missing")
+	}
+}
+
+func TestPrepareContainer_writesCredentialOverrides(t *testing.T) {
+	// Guards the SubscriptionType/RateLimitTier passthrough from PrepareOpts
+	// through agent.go into the container's .credentials.json.
+	t.Setenv("HOME", t.TempDir())
+	p := &OAuthProvider{}
+
+	cfg, err := p.PrepareContainer(context.Background(), provider.PrepareOpts{
+		Credential:       &provider.Credential{Provider: "claude", Token: "sk-ant-oat01-abc"},
+		SubscriptionType: "pro",
+		RateLimitTier:    "default_claude_pro",
+	})
+	if err != nil {
+		t.Fatalf("PrepareContainer() error = %v", err)
+	}
+	defer cfg.Cleanup()
+
+	data, err := os.ReadFile(filepath.Join(cfg.StagingDir, ".credentials.json"))
+	if err != nil {
+		t.Fatalf("reading .credentials.json: %v", err)
+	}
+	var creds oauthCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		t.Fatalf("parsing .credentials.json: %v", err)
+	}
+	if creds.ClaudeAiOauth == nil {
+		t.Fatal("ClaudeAiOauth should be present")
+	}
+	if creds.ClaudeAiOauth.SubscriptionType != "pro" {
+		t.Errorf("subscriptionType = %q, want %q (override not plumbed through PrepareContainer)", creds.ClaudeAiOauth.SubscriptionType, "pro")
+	}
+	if creds.ClaudeAiOauth.RateLimitTier != "default_claude_pro" {
+		t.Errorf("rateLimitTier = %q, want %q (override not plumbed through PrepareContainer)", creds.ClaudeAiOauth.RateLimitTier, "default_claude_pro")
 	}
 }
 

--- a/internal/providers/claude/config.go
+++ b/internal/providers/claude/config.go
@@ -182,7 +182,9 @@ func WriteCredentialsFile(cred *provider.Credential, stagingDir, subscriptionTyp
 	//   scopes: the grant's real scopes → default set.
 	scopes := cred.Scopes
 	if len(scopes) == 0 {
-		scopes = defaultClaudeScopes
+		// Copy, don't alias: defaultClaudeScopes is a package-level var and must
+		// not be exposed for in-place mutation by future callers.
+		scopes = append([]string(nil), defaultClaudeScopes...)
 	}
 	subType := firstNonEmpty(subscriptionType, cred.Metadata[MetaSubscriptionType], defaultSubscriptionType)
 	rateTier := firstNonEmpty(rateLimitTier, cred.Metadata[MetaRateLimitTier])

--- a/internal/providers/claude/config.go
+++ b/internal/providers/claude/config.go
@@ -273,9 +273,11 @@ type oauthCredentials struct {
 
 // oauthToken represents an individual OAuth token from Claude Code.
 type oauthToken struct {
-	AccessToken      string   `json:"accessToken"`
-	RefreshToken     string   `json:"refreshToken,omitempty"`
-	ExpiresAt        int64    `json:"expiresAt"` // Unix timestamp in milliseconds
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken,omitempty"`
+	ExpiresAt    int64  `json:"expiresAt"` // Unix timestamp in milliseconds
+	// No omitempty: Claude Code requires a non-null scopes array, and
+	// WriteCredentialsFile always populates it (real scopes or the default set).
 	Scopes           []string `json:"scopes"`
 	SubscriptionType string   `json:"subscriptionType,omitempty"`
 	RateLimitTier    string   `json:"rateLimitTier,omitempty"`

--- a/internal/providers/claude/config.go
+++ b/internal/providers/claude/config.go
@@ -147,7 +147,7 @@ func WriteClaudeConfig(stagingDir string, mcpServers map[string]MCPServerForCont
 //
 // SECURITY: The real OAuth token is NEVER written to the container filesystem.
 // Authentication is handled by the TLS-intercepting proxy at the network layer.
-func WriteCredentialsFile(cred *provider.Credential, stagingDir string) error {
+func WriteCredentialsFile(cred *provider.Credential, stagingDir, subscriptionType, rateLimitTier string) error {
 	if cred.Provider != "claude" {
 		// Only OAuth credentials (provider "claude") need credential files.
 		// API key credentials (provider "anthropic") skip this.
@@ -173,11 +173,27 @@ func WriteCredentialsFile(cred *provider.Credential, stagingDir string) error {
 	if cred.ExpiresAt.IsZero() {
 		expiresAtMs = time.Now().Add(365 * 24 * time.Hour).UnixMilli()
 	}
+
+	// Scopes, subscriptionType, and rateLimitTier: Claude Code treats a session
+	// with null scopes or no subscriptionType as unauthenticated ("API Usage
+	// Billing"). Setup-token/pasted grants carry none of these, so resolve each:
+	//   subscriptionType / rateLimitTier: moat.yaml override → value captured at
+	//     grant time (imported creds, via metadata) → default.
+	//   scopes: the grant's real scopes → default set.
+	scopes := cred.Scopes
+	if len(scopes) == 0 {
+		scopes = defaultClaudeScopes
+	}
+	subType := firstNonEmpty(subscriptionType, cred.Metadata[MetaSubscriptionType], defaultSubscriptionType)
+	rateTier := firstNonEmpty(rateLimitTier, cred.Metadata[MetaRateLimitTier])
+
 	creds := oauthCredentials{
 		ClaudeAiOauth: &oauthToken{
-			AccessToken: credential.ClaudeOAuthPlaceholder,
-			ExpiresAt:   expiresAtMs,
-			Scopes:      cred.Scopes,
+			AccessToken:      credential.ClaudeOAuthPlaceholder,
+			ExpiresAt:        expiresAtMs,
+			Scopes:           scopes,
+			SubscriptionType: subType,
+			RateLimitTier:    rateTier,
 		},
 	}
 
@@ -191,6 +207,60 @@ func WriteCredentialsFile(cred *provider.Credential, stagingDir string) error {
 	}
 
 	return nil
+}
+
+// Credential metadata keys used to thread subscription details captured at
+// grant time (e.g. from imported host credentials) through to the container's
+// .credentials.json. Setup-token and pasted-token grants don't carry these.
+const (
+	MetaSubscriptionType = "claude_subscription_type"
+	MetaRateLimitTier    = "claude_rate_limit_tier"
+)
+
+// defaultSubscriptionType is written when a grant carries no subscription type
+// and moat.yaml sets no override. Claude Code requires a non-empty
+// subscriptionType to treat the session as a subscription rather than showing
+// "API Usage Billing". The real plan is enforced server-side via the token the
+// proxy injects, so this only affects what Claude Code displays/gates locally.
+const defaultSubscriptionType = "max"
+
+// defaultClaudeScopes is written when a grant carries no scopes (setup-token /
+// pasted-token grants). These are the standard Claude Code OAuth scopes; an
+// empty/null scopes array makes Claude Code treat the session as unauthenticated.
+var defaultClaudeScopes = []string{
+	"user:file_upload",
+	"user:inference",
+	"user:mcp_servers",
+	"user:profile",
+	"user:sessions:claude_code",
+}
+
+// subscriptionMetadata builds the credential metadata that carries subscription
+// details captured at grant time through to WriteCredentialsFile. Returns nil
+// when neither value is set (setup-token/pasted grants), so callers leave
+// Metadata unset and the defaults/override apply.
+func subscriptionMetadata(subscriptionType, rateLimitTier string) map[string]string {
+	if subscriptionType == "" && rateLimitTier == "" {
+		return nil
+	}
+	m := map[string]string{}
+	if subscriptionType != "" {
+		m[MetaSubscriptionType] = subscriptionType
+	}
+	if rateLimitTier != "" {
+		m[MetaRateLimitTier] = rateLimitTier
+	}
+	return m
+}
+
+// firstNonEmpty returns the first non-empty string in vals, or "" if none.
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // oauthCredentials represents the OAuth credentials stored by Claude Code.

--- a/internal/providers/claude/config.go
+++ b/internal/providers/claude/config.go
@@ -180,10 +180,11 @@ func WriteCredentialsFile(cred *provider.Credential, stagingDir, subscriptionTyp
 	//   subscriptionType / rateLimitTier: moat.yaml override → value captured at
 	//     grant time (imported creds, via metadata) → default.
 	//   scopes: the grant's real scopes → default set.
-	scopes := cred.Scopes
+	// Copy rather than alias: scopes is always an independently-owned slice,
+	// whether it comes from the credential or the package-level default, so no
+	// later append can mutate the caller's slice or the shared default.
+	scopes := append([]string(nil), cred.Scopes...)
 	if len(scopes) == 0 {
-		// Copy, don't alias: defaultClaudeScopes is a package-level var and must
-		// not be exposed for in-place mutation by future callers.
 		scopes = append([]string(nil), defaultClaudeScopes...)
 	}
 	subType := firstNonEmpty(subscriptionType, cred.Metadata[MetaSubscriptionType], defaultSubscriptionType)

--- a/internal/providers/claude/grant.go
+++ b/internal/providers/claude/grant.go
@@ -547,6 +547,10 @@ func grantViaExistingCreds(ctx context.Context) (*provider.Credential, error) {
 		ExpiresAt: expiresAt,
 		CreatedAt: time.Now(),
 	}
+	// Preserve the real subscription details so the container's .credentials.json
+	// reflects the actual plan. Setup-token/pasted grants don't carry these and
+	// fall back to defaults (or the moat.yaml override).
+	cred.Metadata = subscriptionMetadata(token.SubscriptionType, token.RateLimitTier)
 
 	fmt.Println("\nClaude Code credentials imported.")
 	fmt.Println("You can now run 'moat claude' to start Claude Code.")

--- a/internal/providers/claude/provider_test.go
+++ b/internal/providers/claude/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -622,7 +623,7 @@ func TestWriteCredentialsFile(t *testing.T) {
 			Scopes:    []string{"user:read"},
 		}
 
-		err := WriteCredentialsFile(cred, stagingDir)
+		err := WriteCredentialsFile(cred, stagingDir, "", "")
 		if err != nil {
 			t.Fatalf("WriteCredentialsFile() error = %v", err)
 		}
@@ -660,7 +661,7 @@ func TestWriteCredentialsFile(t *testing.T) {
 			// ExpiresAt intentionally zero — simulates setup-token grants
 		}
 
-		err := WriteCredentialsFile(cred, stagingDir)
+		err := WriteCredentialsFile(cred, stagingDir, "", "")
 		if err != nil {
 			t.Fatalf("WriteCredentialsFile() error = %v", err)
 		}
@@ -690,7 +691,7 @@ func TestWriteCredentialsFile(t *testing.T) {
 			Token:    "sk-ant-api01-abc123",
 		}
 
-		err := WriteCredentialsFile(cred, stagingDir)
+		err := WriteCredentialsFile(cred, stagingDir, "", "")
 		if err != nil {
 			t.Fatalf("WriteCredentialsFile() error = %v", err)
 		}
@@ -699,6 +700,132 @@ func TestWriteCredentialsFile(t *testing.T) {
 		credsFile := filepath.Join(stagingDir, ".credentials.json")
 		if _, err := os.Stat(credsFile); err == nil {
 			t.Error("credentials file should NOT exist for API keys")
+		}
+	})
+}
+
+// writeAndReadCreds writes a credentials file and returns the parsed token.
+func writeAndReadCreds(t *testing.T, cred *provider.Credential, subType, rateTier string) *oauthToken {
+	t.Helper()
+	stagingDir := t.TempDir()
+	if err := WriteCredentialsFile(cred, stagingDir, subType, rateTier); err != nil {
+		t.Fatalf("WriteCredentialsFile() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(stagingDir, ".credentials.json"))
+	if err != nil {
+		t.Fatalf("failed to read credentials file: %v", err)
+	}
+	var creds oauthCredentials
+	if err := json.Unmarshal(data, &creds); err != nil {
+		t.Fatalf("failed to parse credentials file: %v", err)
+	}
+	if creds.ClaudeAiOauth == nil {
+		t.Fatal("ClaudeAiOauth should be present")
+	}
+	return creds.ClaudeAiOauth
+}
+
+func TestSubscriptionMetadata(t *testing.T) {
+	t.Run("both fields present", func(t *testing.T) {
+		got := subscriptionMetadata("max", "default_claude_max_20x")
+		want := map[string]string{
+			MetaSubscriptionType: "max",
+			MetaRateLimitTier:    "default_claude_max_20x",
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("subscriptionMetadata() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("only subscriptionType", func(t *testing.T) {
+		got := subscriptionMetadata("pro", "")
+		want := map[string]string{MetaSubscriptionType: "pro"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("subscriptionMetadata() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("neither field returns nil", func(t *testing.T) {
+		if got := subscriptionMetadata("", ""); got != nil {
+			t.Errorf("subscriptionMetadata() = %v, want nil", got)
+		}
+	})
+}
+
+func TestWriteCredentialsFileFields(t *testing.T) {
+	t.Run("setup-token grant gets default scopes and subscriptionType", func(t *testing.T) {
+		// No scopes, no metadata, no override — mirrors a setup-token grant.
+		cred := &provider.Credential{Provider: "claude", Token: "sk-ant-oat01-abc"}
+		tok := writeAndReadCreds(t, cred, "", "")
+
+		if len(tok.Scopes) == 0 {
+			t.Error("scopes should default to a non-empty set, got null/empty")
+		}
+		if !reflect.DeepEqual(tok.Scopes, defaultClaudeScopes) {
+			t.Errorf("scopes = %v, want default %v", tok.Scopes, defaultClaudeScopes)
+		}
+		if tok.SubscriptionType != defaultSubscriptionType {
+			t.Errorf("subscriptionType = %q, want default %q", tok.SubscriptionType, defaultSubscriptionType)
+		}
+		if tok.RateLimitTier != "" {
+			t.Errorf("rateLimitTier = %q, want empty (no guess)", tok.RateLimitTier)
+		}
+	})
+
+	t.Run("moat.yaml override wins over default", func(t *testing.T) {
+		cred := &provider.Credential{Provider: "claude", Token: "sk-ant-oat01-abc"}
+		tok := writeAndReadCreds(t, cred, "pro", "default_claude_pro")
+
+		if tok.SubscriptionType != "pro" {
+			t.Errorf("subscriptionType = %q, want override %q", tok.SubscriptionType, "pro")
+		}
+		if tok.RateLimitTier != "default_claude_pro" {
+			t.Errorf("rateLimitTier = %q, want override %q", tok.RateLimitTier, "default_claude_pro")
+		}
+	})
+
+	t.Run("imported metadata used when no override", func(t *testing.T) {
+		cred := &provider.Credential{
+			Provider: "claude",
+			Token:    "sk-ant-oat01-abc",
+			Metadata: map[string]string{
+				MetaSubscriptionType: "max",
+				MetaRateLimitTier:    "default_claude_max_20x",
+			},
+		}
+		tok := writeAndReadCreds(t, cred, "", "")
+
+		if tok.SubscriptionType != "max" {
+			t.Errorf("subscriptionType = %q, want imported %q", tok.SubscriptionType, "max")
+		}
+		if tok.RateLimitTier != "default_claude_max_20x" {
+			t.Errorf("rateLimitTier = %q, want imported %q", tok.RateLimitTier, "default_claude_max_20x")
+		}
+	})
+
+	t.Run("override beats imported metadata", func(t *testing.T) {
+		cred := &provider.Credential{
+			Provider: "claude",
+			Token:    "sk-ant-oat01-abc",
+			Metadata: map[string]string{MetaSubscriptionType: "max"},
+		}
+		tok := writeAndReadCreds(t, cred, "pro", "")
+
+		if tok.SubscriptionType != "pro" {
+			t.Errorf("subscriptionType = %q, want override %q to beat imported", tok.SubscriptionType, "pro")
+		}
+	})
+
+	t.Run("real scopes preserved", func(t *testing.T) {
+		cred := &provider.Credential{
+			Provider: "claude",
+			Token:    "sk-ant-oat01-abc",
+			Scopes:   []string{"user:inference", "user:profile"},
+		}
+		tok := writeAndReadCreds(t, cred, "", "")
+
+		if !reflect.DeepEqual(tok.Scopes, []string{"user:inference", "user:profile"}) {
+			t.Errorf("scopes = %v, want the credential's real scopes preserved", tok.Scopes)
 		}
 	})
 }

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -2035,12 +2035,19 @@ region = %s
 
 			// Call provider to prepare container config
 			var prepErr error
+			var claudeSubType, claudeRateTier string
+			if opts.Config != nil {
+				claudeSubType = opts.Config.Claude.SubscriptionType
+				claudeRateTier = opts.Config.Claude.RateLimitTier
+			}
 			claudeConfig, prepErr = claudeProvider.PrepareContainer(ctx, provider.PrepareOpts{
-				Credential:      claudeCred,
-				ContainerHome:   containerHome,
-				MCPServers:      mcpServers,
-				RuntimeContext:  renderedContext,
-				LocalMCPServers: claudeLocalMCP,
+				Credential:       claudeCred,
+				ContainerHome:    containerHome,
+				MCPServers:       mcpServers,
+				RuntimeContext:   renderedContext,
+				LocalMCPServers:  claudeLocalMCP,
+				SubscriptionType: claudeSubType,
+				RateLimitTier:    claudeRateTier,
 				// HostConfig is read automatically by the provider if nil
 			})
 			if prepErr != nil {


### PR DESCRIPTION
## Summary

Inside a container, Claude Code showed **"not logged in" / "API Usage Billing"** even after a successful `moat grant claude`. The generated `~/.claude/.credentials.json` was present and correctly placed, but had `"scopes": null` and **no `subscriptionType`** — Claude Code treats such a session as unauthenticated.

### Root cause

`WriteCredentialsFile` wrote `scopes` straight from the stored credential and never set `subscriptionType`. Setup-token and pasted-token grants carry no plan metadata, so both fields were always empty/null for the common OAuth paths.

This was *exposed* by #351 (v0.5.2), which dropped the `CLAUDE_CODE_OAUTH_TOKEN` env var that had previously masked the incomplete credentials file. (Note: #352 / the far-future-expiry change was **not** the cause.)

### Fix

`WriteCredentialsFile` now resolves each field with precedence **moat.yaml override → value captured at grant time → default**:

- `scopes`: real scopes → default to the standard Claude Code OAuth set (never `null`).
- `subscriptionType`: `claude.subscription_type` → imported value → default `"max"`.
- `rateLimitTier`: `claude.rate_limit_tier` → imported value → omitted (no wrong-tier guess).

The real plan is always enforced server-side via the token the proxy injects; these values only affect what Claude Code displays/gates locally.

### Changes

- **`internal/providers/claude/config.go`** — field resolution in `WriteCredentialsFile`; `defaultClaudeScopes`, `defaultSubscriptionType`, metadata-key consts, and `subscriptionMetadata`/`firstNonEmpty` helpers.
- **`internal/providers/claude/grant.go`** — import grant threads the real `subscriptionType`/`rateLimitTier` via credential metadata.
- **`internal/config/config.go`** — new `claude.subscription_type` / `claude.rate_limit_tier` fields.
- **`internal/provider/credential.go`** + **`internal/run/manager.go`** — plumb the overrides through `PrepareOpts`.
- **`internal/providers/claude/agent.go`** — pass overrides into `WriteCredentialsFile`.
- **Docs** — `claude.subscription_type` / `claude.rate_limit_tier` in the moat.yaml reference.

## Testing

- TDD: `TestSubscriptionMetadata`, `TestWriteCredentialsFileFields` (defaults, override-wins, imported-metadata, real-scopes-preserved).
- `go test -race ./internal/providers/claude/ ./internal/config/ ./internal/run/ ./internal/provider/` — pass.
- `make lint` — 0 issues.
- Manually confirmed: adding `subscriptionType` + non-null `scopes` to the container `.credentials.json` flips Claude Code to subscription-logged-in.