### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -33,7 +33,7 @@ jobs:
           fi
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: v2.8.0
 
@@ -41,10 +41,10 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
@@ -59,7 +59,7 @@ jobs:
         run: bats .claude/hooks/
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.out
           fail_ci_if_error: false
@@ -72,16 +72,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload E2E test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-test-logs
           path: /tmp/e2e-output.log

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,18 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
GitHub is forcing Node 20 actions onto Node 24 on **June 2, 2026** and removing Node 20 from runners on Sept 16 — the v0.5.3 release run flagged the deprecation. This bumps every Node-20 JavaScript action we use to its current Node-24 major.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v6** |
| `actions/setup-go` | v5 | **v6** |
| `goreleaser/goreleaser-action` | v6 | **v7** |
| `codecov/codecov-action` | v4 | **v6** |
| `actions/upload-artifact` | v4 | **v7** |
| `docker/login-action` | v3 | **v4** |
| `golangci/golangci-lint-action` | v7 | **v9** |

All targets confirmed to declare `runs.using: node24` (checked each action.yml). Inputs are unchanged and still supported (`go-version-file`/`cache`, goreleaser `version`/`args`, codecov `files`, upload-artifact `name`/`path`).

Notes:
- **`golangci-lint-action` jumps v7 → v9**: v8 is *still* Node 20, so v9 is the minimum Node-24 major. v9 keeps the `version` input, so golangci-lint stays pinned to `v2.8.0` — the CI Lint job here validates that.
- **`bats-core/bats-action` and `anthropics/claude-code-action` are composite actions** (not Node-20 JS actions), so they're left as-is.
- **`goreleaser-action@v7` is only exercised by `release.yml`**, which runs on tag push — not by this PR's CI. It'll first run for real on the next release tag.