### PR TITLE
fix(tui): drain vt emulator reply pipe to prevent compositor deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ## Unreleased
 
+### Fixed
+
+- Fix Claude Code (and other Ink-based TUIs) freezing on the first paint inside the moat container — previously, when the child emitted any terminal-capability query that required a reply (CSI c Primary Device Attributes, CSI 6n cursor position, in-band resize, color queries), moat's VT compositor blocked forever on the emulator's internal reply pipe with no drain, holding `tui.Writer.mu` and starving the render goroutine. Input still reached the child, but no further output reached the host terminal, so the session appeared frozen and Ctrl+C wasn't visibly acknowledged even though it terminated the child. Surfaced 100% of the time with Claude Code 2.1.150+, which queries Device Attributes at startup. Moat now drains the emulator's reply pipe and routes replies back into the child's input stream via the existing injectable-reader chain. ([#362](https://github.com/majorcontext/moat/pull/362))
+
 ## v0.5.3 — 2026-05-25
 
 Patch release centered on Claude Code authentication inside containers — subscription detection, `setup-token` capture, and version pinning — plus a non-root tmpfs permissions fix.

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -445,6 +445,14 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	injectable := term.NewInjectableReader(stdin)
 	defer injectable.Close()
 	stdin = injectable
+
+	// Wire the injectable to receive VT-emulator reply bytes (Primary DA,
+	// cursor position, etc.). Without this, a CSI c query from the child in
+	// compositor mode blocks the emulator's reply handler while it holds
+	// the Writer's mutex, freezing the screen on the first paint.
+	if statusWriter != nil {
+		statusWriter.SetInjector(injectable)
+	}
 	if r.Clipboard {
 		stdin = term.NewClipboardProxy(stdin, func() {
 			done := make(chan struct{})

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -50,6 +50,19 @@ const renderInterval = 16 * time.Millisecond
 // mode. Output is fed to a VT emulator and the emulator screen is rendered
 // to the real terminal with the footer appended.
 //
+// Injector forwards bytes the VT emulator generates as replies (e.g.,
+// Primary Device Attributes for CSI c, cursor-position reports for CSI 6n,
+// in-band resize notifications) back into the child's input stream so the
+// child sees the responses it queried for.
+//
+// Compositor mode requires an injector to be wired up via SetInjector; the
+// emulator's reply handlers write into an internal io.Pipe and the reader
+// side MUST be drained or the next reply-bearing handler deadlocks while
+// holding the Writer's mutex, freezing the screen.
+type Injector interface {
+	Inject(b []byte) error
+}
+
 // Writer is goroutine-safe for all methods.
 type Writer struct {
 	mu     sync.Mutex
@@ -57,6 +70,13 @@ type Writer struct {
 	bar    *StatusBar
 	width  int
 	height int // Total terminal height (content + status bar)
+
+	// injector receives bytes the emulator generates as replies to child
+	// queries (Primary DA, cursor position, etc.). May be nil — in that case
+	// emulator replies are still drained (to prevent deadlock) but discarded.
+	// Protected by mu only for the SetInjector path; the drain goroutine
+	// captures the value at compositor-entry time.
+	injector Injector
 
 	// Compositor mode state
 	altScreen bool
@@ -562,6 +582,14 @@ func (w *Writer) enterCompositorLocked() error {
 		return err
 	}
 
+	// Drain the emulator's reply pipe and forward replies (Primary DA, cursor
+	// position, in-band resize, etc.) to the injector. The emulator's reply
+	// handlers write into an internal io.Pipe; without a reader, the next
+	// reply-bearing handler blocks while holding w.mu, freezing renderLoop.
+	// Closing the emulator on exit (via stopCompositorLocked) causes
+	// emulator.Read to return EOF so this goroutine exits.
+	go w.drainEmulatorReplies(w.emulator, w.injector)
+
 	// Start render ticker after the write succeeds so there's no
 	// goroutine to leak if the write fails.
 	w.dirty = false
@@ -570,6 +598,71 @@ func (w *Writer) enterCompositorLocked() error {
 	go w.renderLoop(w.renderTicker, w.stopRender)
 
 	return nil
+}
+
+// SetInjector wires up the destination for VT-emulator-generated replies.
+// Must be called before the first byte of container output reaches Write,
+// otherwise the first reply-bearing handler in compositor mode will deadlock.
+//
+// If never called, emulator replies are still drained (to prevent deadlock)
+// but discarded — terminal capability queries from the child get no answer
+// and the child falls back to defaults.
+func (w *Writer) SetInjector(injector Injector) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.injector = injector
+}
+
+// drainEmulatorReplies copies bytes from the emulator's internal reply pipe
+// to the injector. Runs as a goroutine while compositor mode is active and
+// exits when the emulator's input pipe is closed (Read returns io.EOF or
+// io.ErrClosedPipe).
+//
+// The emulator and injector are passed by value so this goroutine operates
+// on the same instances throughout its lifetime even if Writer's fields are
+// reassigned by a subsequent enter/exit cycle. If injector is nil, replies
+// are still drained so the emulator's handlers don't block — they're just
+// discarded.
+//
+// We never call vt.Emulator.Close() here; it writes e.closed concurrently
+// with Read's check of that same field (a thread-safety bug in the vt
+// package). Instead, closing the underlying io.PipeWriter — which is
+// documented as safe for parallel close-vs-read — unblocks Read cleanly.
+func (w *Writer) drainEmulatorReplies(em *vt.Emulator, inj Injector) {
+	if em == nil {
+		return
+	}
+	buf := make([]byte, 256)
+	for {
+		n, err := em.Read(buf)
+		if n > 0 && inj != nil {
+			// Best-effort: if Inject fails (e.g., injectable closed) we
+			// still keep draining so the emulator doesn't block.
+			_ = inj.Inject(buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// closeEmulatorReplyPipe closes the emulator's input pipe writer to signal
+// the drain goroutine to exit. We close the pipe directly rather than
+// calling vt.Emulator.Close() to avoid a thread-safety bug in the vt
+// package where Close writes e.closed while Read concurrently reads it.
+// io.Pipe documents Close-vs-Read as safe.
+//
+// If InputPipe ever returns something that isn't an io.Closer (it currently
+// returns *io.PipeWriter), the drain goroutine will leak until GC — but
+// the emulator's reply handlers will also not unblock, so this would be a
+// vt package breaking change worth surfacing.
+func closeEmulatorReplyPipe(em *vt.Emulator) {
+	if em == nil {
+		return
+	}
+	if pw, ok := em.InputPipe().(io.Closer); ok {
+		_ = pw.Close()
+	}
 }
 
 // exitCompositorLocked switches from compositor mode back to scroll mode.
@@ -585,6 +678,10 @@ func (w *Writer) exitCompositorLocked() error {
 	// Do a final render to flush any pending content
 	w.renderCompositorLocked()
 
+	// Close the emulator's reply pipe so the drain goroutine started in
+	// enterCompositorLocked exits. See closeEmulatorReplyPipe for why we
+	// don't call w.emulator.Close().
+	closeEmulatorReplyPipe(w.emulator)
 	w.emulator = nil
 
 	// Exit alternate screen
@@ -708,6 +805,7 @@ func (w *Writer) Reset() error {
 
 	if w.altScreen {
 		w.stopRenderLoop()
+		closeEmulatorReplyPipe(w.emulator)
 		w.emulator = nil
 		w.altScreen = false
 		buf.WriteString("\x1b[?1049l")
@@ -741,6 +839,7 @@ func (w *Writer) Cleanup() error {
 
 	// Stop compositor if running
 	w.stopRenderLoop()
+	closeEmulatorReplyPipe(w.emulator)
 	w.emulator = nil
 
 	var buf bytes.Buffer

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -600,29 +600,49 @@ func (w *Writer) enterCompositorLocked() error {
 	return nil
 }
 
-// SetInjector wires up the destination for VT-emulator-generated replies.
-// Must be called before the first byte of container output reaches Write,
-// otherwise the first reply-bearing handler in compositor mode will deadlock.
+// SetInjector wires up the destination for VT-emulator-generated replies
+// (Primary DA, cursor-position reports, in-band resize notifications, etc.).
 //
-// If never called, emulator replies are still drained (to prevent deadlock)
-// but discarded — terminal capability queries from the child get no answer
-// and the child falls back to defaults.
+// Emulator replies are ALWAYS drained from the emulator regardless of
+// whether an injector is set — that's a strict invariant of compositor
+// mode, otherwise the next reply-bearing handler deadlocks. If no injector
+// is set, drained bytes are discarded, the child's capability queries go
+// unanswered, and the child falls back to defaults.
+//
+// The drain goroutine captures the injector at compositor-entry time, so
+// SetInjector must be called BEFORE the first byte of container output
+// reaches Write to take effect for the first compositor session. Calls
+// after entry don't affect the in-flight session.
 func (w *Writer) SetInjector(injector Injector) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.injector = injector
 }
 
-// drainEmulatorReplies copies bytes from the emulator's internal reply pipe
-// to the injector. Runs as a goroutine while compositor mode is active and
-// exits when the emulator's input pipe is closed (Read returns io.EOF or
-// io.ErrClosedPipe).
+// emulatorReplyQueueDepth is the buffer size of the channel between the
+// emulator-drain goroutine and the injector-forwarder goroutine. It exists
+// solely to decouple emulator pipe drainage from injector liveness — see
+// drainEmulatorReplies for the rationale. A depth of 16 comfortably absorbs
+// a TUI's typical startup query burst (Primary DA, Secondary DA, cursor
+// position, color queries, in-band resize) without dropping; sustained
+// back-pressure beyond that drops replies, and that is the correct
+// behavior (the alternative is deadlock).
+const emulatorReplyQueueDepth = 16
+
+// drainEmulatorReplies copies bytes from the emulator's internal reply
+// pipe and forwards them to the injector via a bounded buffered channel.
+// The decoupling is load-bearing: Inject ultimately writes into an io.Pipe
+// that's drained by Docker's stdin-copy goroutine, which back-pressures if
+// the container's stdin reader stalls. If drain called Inject directly,
+// a stalled container could stall the drain, which would let the next
+// reply-bearing emulator handler block inside outputLocked under w.mu —
+// the exact deadlock this PR fixes, just one indirection deeper. The
+// channel guarantees the emulator pipe is always drained promptly; under
+// sustained injector back-pressure we drop replies on a full channel.
 //
-// The emulator and injector are passed by value so this goroutine operates
-// on the same instances throughout its lifetime even if Writer's fields are
-// reassigned by a subsequent enter/exit cycle. If injector is nil, replies
-// are still drained so the emulator's handlers don't block — they're just
-// discarded.
+// Runs as a goroutine while compositor mode is active. Exits when the
+// emulator's input pipe is closed (Read returns io.EOF or io.ErrClosedPipe),
+// at which point it closes the queue so the forwarder goroutine exits too.
 //
 // We never call vt.Emulator.Close() here; it writes e.closed concurrently
 // with Read's check of that same field (a thread-safety bug in the vt
@@ -632,15 +652,40 @@ func (w *Writer) drainEmulatorReplies(em *vt.Emulator, inj Injector) {
 	if em == nil {
 		return
 	}
+
+	queue := make(chan []byte, emulatorReplyQueueDepth)
+	forwarderDone := make(chan struct{})
+	go func() {
+		defer close(forwarderDone)
+		for b := range queue {
+			if inj == nil {
+				continue
+			}
+			// Best-effort: if Inject fails (e.g., injectable closed) we
+			// keep draining the queue so this goroutine exits cleanly
+			// when the producer closes it.
+			_ = inj.Inject(b)
+		}
+	}()
+
 	buf := make([]byte, 256)
 	for {
 		n, err := em.Read(buf)
-		if n > 0 && inj != nil {
-			// Best-effort: if Inject fails (e.g., injectable closed) we
-			// still keep draining so the emulator doesn't block.
-			_ = inj.Inject(buf[:n])
+		if n > 0 {
+			// Copy: buf is reused on the next Read and the channel may
+			// hand the slice to a slow consumer.
+			b := make([]byte, n)
+			copy(b, buf[:n])
+			select {
+			case queue <- b:
+			default:
+				log.Debug("tui: emulator reply dropped (forwarder back-pressured)",
+					"bytes", n, "queue_depth", emulatorReplyQueueDepth)
+			}
 		}
 		if err != nil {
+			close(queue)
+			<-forwarderDone
 			return
 		}
 	}
@@ -652,17 +697,21 @@ func (w *Writer) drainEmulatorReplies(em *vt.Emulator, inj Injector) {
 // package where Close writes e.closed while Read concurrently reads it.
 // io.Pipe documents Close-vs-Read as safe.
 //
-// If InputPipe ever returns something that isn't an io.Closer (it currently
-// returns *io.PipeWriter), the drain goroutine will leak until GC — but
-// the emulator's reply handlers will also not unblock, so this would be a
-// vt package breaking change worth surfacing.
+// If a future vt release changes InputPipe to return something that isn't
+// an io.Closer, we log a warning so the API drift surfaces at runtime: the
+// drain goroutine would leak unbounded and the next reply-bearing handler
+// would re-introduce the freeze this helper exists to prevent. Silent
+// degradation here would be hard to diagnose from production traces.
 func closeEmulatorReplyPipe(em *vt.Emulator) {
 	if em == nil {
 		return
 	}
-	if pw, ok := em.InputPipe().(io.Closer); ok {
-		_ = pw.Close()
+	pw, ok := em.InputPipe().(io.Closer)
+	if !ok {
+		log.Warn("tui: vt.Emulator.InputPipe() no longer satisfies io.Closer; emulator reply drain may leak and re-introduce compositor freeze")
+		return
 	}
+	_ = pw.Close()
 }
 
 // exitCompositorLocked switches from compositor mode back to scroll mode.

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -586,7 +586,8 @@ func (w *Writer) enterCompositorLocked() error {
 	// position, in-band resize, etc.) to the injector. The emulator's reply
 	// handlers write into an internal io.Pipe; without a reader, the next
 	// reply-bearing handler blocks while holding w.mu, freezing renderLoop.
-	// Closing the emulator on exit (via stopCompositorLocked) causes
+	// Closing the emulator's input pipe on exit (via closeEmulatorReplyPipe,
+	// called from exitCompositorLocked / Reset / Cleanup) causes
 	// emulator.Read to return EOF so this goroutine exits.
 	go w.drainEmulatorReplies(w.emulator, w.injector)
 
@@ -698,17 +699,20 @@ func (w *Writer) drainEmulatorReplies(em *vt.Emulator, inj Injector) {
 // io.Pipe documents Close-vs-Read as safe.
 //
 // If a future vt release changes InputPipe to return something that isn't
-// an io.Closer, we log a warning so the API drift surfaces at runtime: the
-// drain goroutine would leak unbounded and the next reply-bearing handler
-// would re-introduce the freeze this helper exists to prevent. Silent
-// degradation here would be hard to diagnose from production traces.
+// an io.Closer, we log a warning so the API drift surfaces at runtime.
+// The fallout is per-session leakage: the in-flight drain goroutine
+// stays parked on em.Read forever (no further writes arrive once we
+// orphan the emulator) and the emulator object can't be GC'd. New
+// compositor sessions still work correctly — each creates a fresh
+// emulator+drain pair — so the symptom is a slowly growing goroutine
+// count, not a recurrence of the original screen freeze.
 func closeEmulatorReplyPipe(em *vt.Emulator) {
 	if em == nil {
 		return
 	}
 	pw, ok := em.InputPipe().(io.Closer)
 	if !ok {
-		log.Warn("tui: vt.Emulator.InputPipe() no longer satisfies io.Closer; emulator reply drain may leak and re-introduce compositor freeze")
+		log.Warn("tui: vt.Emulator.InputPipe() no longer satisfies io.Closer; drain goroutine and emulator object will leak once per compositor session")
 		return
 	}
 	_ = pw.Close()

--- a/internal/tui/writer_test.go
+++ b/internal/tui/writer_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestWriter_Write(t *testing.T) {
@@ -1348,4 +1350,102 @@ func TestWriter_DECSTBM_CompositorMode_PassesToEmulator(t *testing.T) {
 		t.Errorf("in compositor mode, moat must not emit host DECSTBM, got %q", out)
 	}
 	w.Cleanup()
+}
+
+// captureInjector implements the Injector interface used by Writer to forward
+// VT-emulator-generated replies (e.g., responses to CSI c Device Attributes
+// queries) back into the child's input stream. The test variant records the
+// bytes so assertions can verify them.
+type captureInjector struct {
+	mu   sync.Mutex
+	data []byte
+}
+
+func (c *captureInjector) Inject(b []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = append(c.data, b...)
+	return nil
+}
+
+func (c *captureInjector) bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]byte, len(c.data))
+	copy(out, c.data)
+	return out
+}
+
+// TestWriter_CompositorMode_DeviceAttributesQuery_DoesNotDeadlock verifies
+// that Write does not deadlock when the child emits a CSI c (Primary Device
+// Attributes) query while moat is in compositor mode.
+//
+// The bundled vt.Emulator responds to terminal queries by writing the reply
+// to an internal io.Pipe. If nothing drains the reader side, the handler
+// blocks holding w.mu and freezes the renderer.
+func TestWriter_CompositorMode_DeviceAttributesQuery_DoesNotDeadlock(t *testing.T) {
+	var buf bytes.Buffer
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetDimensions(60, 24)
+
+	w := NewWriter(&buf, bar, "docker")
+	_ = w.Setup()
+	defer w.Cleanup()
+
+	if _, err := w.Write([]byte("\x1b[?1049h")); err != nil {
+		t.Fatalf("enter alt screen: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = w.Write([]byte("\x1b[c"))
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write deadlocked on CSI c (Device Attributes query)")
+	}
+}
+
+// TestWriter_CompositorMode_InjectsEmulatorReplies verifies that emulator
+// reply bytes (e.g., Primary Device Attributes response to CSI c) are
+// forwarded to the configured Injector so the child sees the response.
+func TestWriter_CompositorMode_InjectsEmulatorReplies(t *testing.T) {
+	var buf bytes.Buffer
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetDimensions(60, 24)
+
+	w := NewWriter(&buf, bar, "docker")
+	_ = w.Setup()
+	defer w.Cleanup()
+
+	inj := &captureInjector{}
+	w.SetInjector(inj)
+
+	if _, err := w.Write([]byte("\x1b[?1049h")); err != nil {
+		t.Fatalf("enter alt screen: %v", err)
+	}
+	if _, err := w.Write([]byte("\x1b[c")); err != nil {
+		t.Fatalf("write CSI c: %v", err)
+	}
+
+	// Poll briefly; the drain runs in a goroutine.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(inj.bytes()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	got := inj.bytes()
+	if len(got) == 0 {
+		t.Fatal("expected injector to receive Device Attributes reply, got 0 bytes")
+	}
+	// Primary DA reply begins with CSI '?' on real VT100+ terminals.
+	if !bytes.HasPrefix(got, []byte("\x1b[?")) {
+		t.Errorf("expected reply to begin with CSI '?' (Primary DA), got %q", got)
+	}
 }

--- a/internal/tui/writer_test.go
+++ b/internal/tui/writer_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -1390,7 +1391,6 @@ func TestWriter_CompositorMode_DeviceAttributesQuery_DoesNotDeadlock(t *testing.
 
 	w := NewWriter(&buf, bar, "docker")
 	_ = w.Setup()
-	defer w.Cleanup()
 
 	if _, err := w.Write([]byte("\x1b[?1049h")); err != nil {
 		t.Fatalf("enter alt screen: %v", err)
@@ -1404,8 +1404,76 @@ func TestWriter_CompositorMode_DeviceAttributesQuery_DoesNotDeadlock(t *testing.
 
 	select {
 	case <-done:
+		// Write returned normally — safe to Cleanup (it re-acquires w.mu).
+		_ = w.Cleanup()
 	case <-time.After(2 * time.Second):
+		// Write is parked holding w.mu. Calling Cleanup would block forever
+		// on the same mutex and stall the test binary until go test's outer
+		// -timeout (default 10 min). Skip Cleanup — the process exits with
+		// FailNow and the leaked goroutine dies with it.
 		t.Fatal("Write deadlocked on CSI c (Device Attributes query)")
+	}
+}
+
+// blockingInjector blocks Inject until released, simulating container-stdin
+// back-pressure on the InjectableReader pipeline. Used to verify the
+// emulator drain is decoupled from injector liveness.
+type blockingInjector struct {
+	block chan struct{}
+	calls int32
+}
+
+func newBlockingInjector() *blockingInjector {
+	return &blockingInjector{block: make(chan struct{})}
+}
+
+func (b *blockingInjector) Inject(p []byte) error {
+	atomic.AddInt32(&b.calls, 1)
+	<-b.block
+	return nil
+}
+
+func (b *blockingInjector) release() { close(b.block) }
+
+// TestWriter_CompositorMode_BlockedInjector_DoesNotBlockEmulator verifies
+// that a stalled injector (e.g., container stdin reader back-pressured)
+// does NOT propagate the stall back into the emulator's reply pipe. If it
+// did, the next reply-bearing handler — invoked from outputLocked under
+// w.mu — would block, deadlocking Write and starving renderLoop. That's
+// the bug this PR fixes; we keep that property under back-pressure too.
+func TestWriter_CompositorMode_BlockedInjector_DoesNotBlockEmulator(t *testing.T) {
+	var buf bytes.Buffer
+	bar := NewStatusBar("run_abc123", "my-agent", "docker")
+	bar.SetDimensions(60, 24)
+
+	w := NewWriter(&buf, bar, "docker")
+	_ = w.Setup()
+
+	inj := newBlockingInjector()
+	w.SetInjector(inj)
+	defer inj.release()
+
+	if _, err := w.Write([]byte("\x1b[?1049h")); err != nil {
+		t.Fatalf("enter alt screen: %v", err)
+	}
+
+	// Hammer the emulator with reply-bearing queries. Without back-pressure
+	// decoupling, the first Inject blocks → drain stalls → subsequent
+	// emulator replies block in vt.Emulator.Write while Writer.Write holds
+	// w.mu, deadlocking the loop after a few iterations.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 100; i++ {
+			_, _ = w.Write([]byte("\x1b[c"))
+		}
+	}()
+
+	select {
+	case <-done:
+		_ = w.Cleanup()
+	case <-time.After(2 * time.Second):
+		t.Fatal("Write deadlocked under blocked injector — drain not decoupled from injector back-pressure")
 	}
 }
 


### PR DESCRIPTION
Fixes moat hanging on startup every session. Not sure what changed, the issue started today and I can't use moat without this fix. Description by Claude below.

## Summary

When the child inside the container emits any terminal query that requires a reply (CSI c Primary Device Attributes, CSI 6n cursor position, in-band resize, color queries, etc.), moat's compositor freezes on the first paint. From the user's perspective the screen rendered the initial banner and then never updated again. Input still reached the child — so Ctrl+C typed twice into a "frozen" Claude actually terminated the container — but no further output reached the host terminal. With Claude Code 2.1.150+ this reproduces 100% of the time.

### Root cause

`vt.NewEmulator` constructs an internal `io.Pipe` for replies the emulator generates on the child's behalf. The handlers write replies into the pipe writer, expecting a consumer to drain the reader side. Moat never drained it. The first reply-bearing handler blocked inside `io.PipeWriter.Write` — reached from `tui.Writer.Write` under `w.mu` — so `renderLoop` could never reacquire the mutex to paint another frame.

Goroutine dump from a stuck session showed the exact chain:

```
docker.StartAttached.func1                ← io.Copy(opts.Stdout, resp.Reader)
  io.multiWriter.Write → trace.RecordingWriter.Write
    tui.Writer.Write                       (writer.go:171, HOLDS w.mu)
      processDataLocked → outputLocked
        vt.Emulator.Write → ansi.Parser.advance → handleCsi 'c'
          io.PipeWriter.Write              ← BLOCKED FOREVER (no reader)
```

And, in another goroutine, `renderLoop [sync.Mutex.Lock, 3 minutes]`.

## Changes

### `internal/tui/writer.go`

- Add `Injector` interface (single method `Inject([]byte) error`) and an `injector` field on `Writer`, plus `SetInjector` to wire it up.
- On compositor entry, spawn `drainEmulatorReplies` goroutine that copies `em.Read` → `injector.Inject`. Bytes are still drained if no injector is wired, so the deadlock can't recur regardless of caller plumbing — the child just doesn't see its replies in that case and falls back to defaults.
- On compositor exit / `Reset` / `Cleanup`: close the emulator's input pipe via `em.InputPipe().(io.Closer).Close()` to unblock `Read` and let the drain goroutine exit. We deliberately avoid `vt.Emulator.Close()` — it writes `e.closed` unsynchronized with concurrent `Read` calls and trips `-race`. The pipe close is documented as safe for parallel Close-vs-Read and achieves the same effective shutdown.

### `cmd/moat/cli/exec.go`

- After constructing the `InjectableReader` for the stdin chain, call `statusWriter.SetInjector(injectable)`. The injectable already exists for synthetic keystrokes (Ctrl+L from `resetTUI`), so emulator replies travel the same recorded path and appear in trace dumps alongside user input.

## Test plan

- [x] New test `TestWriter_CompositorMode_DeviceAttributesQuery_DoesNotDeadlock` — sends `CSI c` in compositor mode, fails (deadlock) without the fix, passes with it.
- [x] New test `TestWriter_CompositorMode_InjectsEmulatorReplies` — verifies the Primary DA reply (begins with `CSI ?`) reaches the configured injector.
- [x] `go test -race ./internal/tui/` clean.
- [x] `make test-unit` passes.
- [x] Manual: rebuilt binary, ran `moat claude` in a project with a `moat.yaml` that triggered the freeze 100% of the time before this PR — Claude now starts and accepts input normally.