### PR TITLE
fix(claude): install python by default for the Claude agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ## Unreleased
 
+### Fixed
+
+- Fix Claude Code reporting `Failed with non-blocking status code: /bin/sh: 1: python3: not found` — previously, the generated image for the Claude agent had no Python interpreter, so Claude Code's security-guidance feature (which shells out to `python3`) failed. Running the Claude agent now implicitly adds `python` to the container dependencies. Specify an explicit `python@<version>` in `dependencies` to override the version. ([#369](https://github.com/majorcontext/moat/issues/369))
+
 ## v0.5.4 — 2026-06-01
 
 Patch release with three Claude Code fixes: an Ink-based TUI freeze on first paint, host/container session-directory divergence on workspaces with `.` or `_` in the path, and marketplace plugin hook scripts losing the executable bit.

--- a/docs/content/guides/01-claude-code.md
+++ b/docs/content/guides/01-claude-code.md
@@ -226,6 +226,14 @@ the version triggers an image rebuild on the next run.
 so they install the latest release. To pin, add an explicit `claude-code@<version>`
 to `dependencies` as shown above.
 
+## Python interpreter
+
+Running the Claude agent automatically adds `python` to the container
+dependencies. Claude Code's security-guidance feature shells out to `python3`,
+and without an interpreter it reports `python3: not found`. The dependency is
+implied — you don't need to list it. To control the version, add an explicit
+`python@<version>` to `dependencies` and Moat uses that instead.
+
 ## Adding GitHub access
 
 Grant GitHub access so Claude Code can interact with repositories:

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1544,6 +1544,13 @@ region = %s
 		allDeps = append(allDeps, langserver.AllDependencies(opts.Config.LanguageServers)...)
 	}
 
+	// Add dependencies implied by the agent itself (e.g., Claude needs python3).
+	// Appended after the config dependencies so a user-specified version takes
+	// precedence (deps.ParseAll dedupes by name, keeping the first occurrence).
+	if opts.Config != nil {
+		allDeps = append(allDeps, agentImpliedDependencies(opts.Config.Agent)...)
+	}
+
 	if len(allDeps) > 0 {
 		var err error
 		depList, err = deps.ParseAll(allDeps)
@@ -4071,6 +4078,16 @@ func claudeProjectsHostDir(hostHome, workspace string) string {
 // and silently fails. This is a pre-existing limitation shared with the
 // safe.directory config — both rely on the init script running as root
 // before dropping to moatuser.
+// agentImpliedDependencies returns dependencies implicitly required by an agent.
+// Claude Code's security-guidance feature shells out to python3, so a Python
+// interpreter must be present whenever the Claude agent runs. See issue #369.
+func agentImpliedDependencies(agent string) []string {
+	if strings.HasPrefix(agent, "claude") {
+		return []string{"python"}
+	}
+	return nil
+}
+
 func hostGitIdentity(depList []deps.Dependency) (env []string, hasGit bool) {
 	for _, d := range depList {
 		if d.Name == "git" {

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -4068,16 +4068,6 @@ func claudeProjectsHostDir(hostHome, workspace string) string {
 	return filepath.Join(hostHome, ".claude", "projects", claudeDir)
 }
 
-// hostGitIdentity reads the host's git user.name and user.email and returns
-// env vars for injecting them into the container. Returns nil if git is not
-// in the dependency list or the host has no identity configured.
-//
-// The env vars are consumed by moat-init.sh which writes them via
-// "git config --system". When the container runs as non-root (Linux
-// --user mode), --system writes to /etc/gitconfig which requires root
-// and silently fails. This is a pre-existing limitation shared with the
-// safe.directory config — both rely on the init script running as root
-// before dropping to moatuser.
 // agentImpliedDependencies returns dependencies implicitly required by an agent.
 // Claude Code's security-guidance feature shells out to python3, so a Python
 // interpreter must be present whenever the Claude agent runs. See issue #369.
@@ -4088,6 +4078,16 @@ func agentImpliedDependencies(agent string) []string {
 	return nil
 }
 
+// hostGitIdentity reads the host's git user.name and user.email and returns
+// env vars for injecting them into the container. Returns nil if git is not
+// in the dependency list or the host has no identity configured.
+//
+// The env vars are consumed by moat-init.sh which writes them via
+// "git config --system". When the container runs as non-root (Linux
+// --user mode), --system writes to /etc/gitconfig which requires root
+// and silently fails. This is a pre-existing limitation shared with the
+// safe.directory config — both rely on the init script running as root
+// before dropping to moatuser.
 func hostGitIdentity(depList []deps.Dependency) (env []string, hasGit bool) {
 	for _, d := range depList {
 		if d.Name == "git" {

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -1956,3 +1956,25 @@ func TestRewriteExtraHostsForCustomNetwork(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentImpliedDependencies(t *testing.T) {
+	tests := []struct {
+		name  string
+		agent string
+		want  []string
+	}{
+		{"claude implies python", "claude", []string{"python"}},
+		{"claude variant implies python", "claude-code", []string{"python"}},
+		{"codex implies nothing", "codex", nil},
+		{"gemini implies nothing", "gemini", nil},
+		{"empty agent implies nothing", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agentImpliedDependencies(tt.agent)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("agentImpliedDependencies(%q) = %v, want %v", tt.agent, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Claude Code's security-guidance feature shells out to `python3`, but the generated image for the Claude agent had no Python interpreter. Sessions surfaced:

```
Failed with non-blocking status code: security-guidance: no working Python interpreter found
```
```
Failed with non-blocking status code: /bin/sh: 1: python3: not found
```

Running the Claude agent now implicitly appends `python` to the container dependencies, so a Python interpreter is always present.

## How

- `agentImpliedDependencies()` in `internal/run/manager.go` returns `["python"]` for any agent whose name starts with `claude`. It's appended during dependency assembly, mirroring the existing agent-gated language-server injection right above it.
- Appended **after** the config dependencies, so a user-specified `python@<version>` wins (`deps.ParseAll` dedupes by name, keeping the first occurrence).
- Covers both `moat claude` and `moat run` with `agent: claude` in `moat.yaml`.

This makes the Claude image a two-runtime image (node + python); python installs as a secondary runtime via apt (`python3`/`pip`/`venv`), which is exactly what the security-guidance feature needs.

## Tests / docs

- Added `TestAgentImpliedDependencies` covering claude / claude-code / codex / gemini / empty.
- `make lint` clean; `go test ./internal/run/` passes.
- Documented the implied dependency in the Claude Code guide and added a CHANGELOG entry.

Closes #369