### PR TITLE
feat: moat join — run a second agent in a running container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
   reusing its workspace, grants, and credentials without a new container. v1
   supports same-agent joins (e.g. joining claude into a `moat claude` run). The
   status footer shows the session role and joined-agent count.
-  ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
+  ([#379](https://github.com/majorcontext/moat/pull/379))
 - **Ministack service** — `ministack` is now available as a `service` dependency, running the LocalStack-compatible Ministack local cloud emulator as a sidecar container. Declare `ministack` under `dependencies` and configure it under `services.ministack` (e.g. `env`, `wait`). Readiness is probed against the container's `/_ministack/health` endpoint. ([#366](https://github.com/majorcontext/moat/pull/366))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ### Added
 
+- **`moat join`** — launch a second agent inside an already-running container,
+  reusing its workspace, grants, and credentials without a new container. v1
+  supports same-agent joins (e.g. joining claude into a `moat claude` run). The
+  status footer shows the session role and joined-agent count.
+  ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
 - **Ministack service** — `ministack` is now available as a `service` dependency, running the LocalStack-compatible Ministack local cloud emulator as a sidecar container. Declare `ministack` under `dependencies` and configure it under `services.ministack` (e.g. `env`, `wait`). Readiness is probed against the container's `/_ministack/health` endpoint. ([#366](https://github.com/majorcontext/moat/pull/366))
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ See the [moat.yaml reference](docs/content/reference/02-moat-yaml.md) for all op
 | `moat claude [workspace]` | Run Claude Code |
 | `moat codex [workspace]` | Run Codex |
 | `moat run [path] [-- cmd]` | Run an agent |
+| `moat join <run> <agent>` | Run another agent in a running container |
 | `moat attach <run-id>` | Attach to a running agent |
 | `moat grant <provider>` | Store credentials (github, anthropic, openai, aws, ssh) |
 | `moat grant list` | List stored credentials |

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -102,7 +102,11 @@ func containerTTYHeight(statusWriter *tui.Writer, actual int) int {
 // Returns the writer (which wraps stdout with status bar compositing), a cleanup
 // function that must be deferred, and the output writer to use for container output.
 // If stdout is not a TTY or setup fails, returns nil writer with os.Stdout as output.
-func setupStatusBar(manager *run.Manager, r *run.Run) (writer *tui.Writer, cleanup func(), stdout io.Writer) {
+//
+// session controls the label shown in the footer:
+//   - "" (empty): primary session — displays the joined-agent count badge instead.
+//   - non-empty: joined session — displays the given label (e.g. "joined · 2").
+func setupStatusBar(manager *run.Manager, r *run.Run, session string) (writer *tui.Writer, cleanup func(), stdout io.Writer) {
 	stdout = os.Stdout
 	cleanup = func() {} // no-op by default
 
@@ -121,9 +125,13 @@ func setupStatusBar(manager *run.Manager, r *run.Run) (writer *tui.Writer, clean
 	}
 	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
 	bar.SetGrants(r.Grants)
-	bar.SetJoinedCount(manager.AttachedCount(r.ID))
-	if r.DaemonCommit != "" && r.DaemonCommit != commit {
-		bar.SetWarning("proxy stale")
+	if session != "" {
+		bar.SetSession(session)
+	} else {
+		bar.SetJoinedCount(manager.AttachedCount(r.ID))
+		if r.DaemonCommit != "" && r.DaemonCommit != commit {
+			bar.SetWarning("proxy stale")
+		}
 	}
 	bar.SetDimensions(width, height)
 	writer = tui.NewWriter(os.Stdout, bar, runtimeType)
@@ -420,7 +428,7 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 	}()
 
 	// Set up status bar for interactive session
-	statusWriter, statusCleanup, stdout := setupStatusBar(manager, r)
+	statusWriter, statusCleanup, stdout := setupStatusBar(manager, r, "")
 	defer statusCleanup()
 
 	// Wrap stdout with tracer if tracing is enabled

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -493,6 +493,32 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 		}
 	})
 
+	// Poll joined-agent count once per second so the primary's footer badge
+	// refreshes without requiring a manual resize. Only active when a status
+	// bar is present; the SIGWINCH handler continues to update the count on
+	// resize events as before.
+	if statusWriter != nil {
+		stopPoll := make(chan struct{})
+		defer close(stopPoll)
+		go func() {
+			t := time.NewTicker(1 * time.Second)
+			defer t.Stop()
+			last := manager.AttachedCount(r.ID)
+			for {
+				select {
+				case <-stopPoll:
+					return
+				case <-t.C:
+					if n := manager.AttachedCount(r.ID); n != last {
+						last = n
+						statusWriter.SetJoinedCount(n)
+						statusWriter.RefreshFooter()
+					}
+				}
+			}
+		}()
+	}
+
 	// Set up signal handling
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGWINCH)

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -121,6 +121,7 @@ func setupStatusBar(manager *run.Manager, r *run.Run) (writer *tui.Writer, clean
 	}
 	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
 	bar.SetGrants(r.Grants)
+	bar.SetJoinedCount(manager.AttachedCount(r.ID))
 	if r.DaemonCommit != "" && r.DaemonCommit != commit {
 		bar.SetWarning("proxy stale")
 	}
@@ -539,6 +540,8 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 							tracer.recorder.AddResize(width, height)
 						}
 						ringRecorder.AddResize(width, height)
+						// Refresh joined-agent count on redraw (display-only).
+						statusWriter.SetJoinedCount(manager.AttachedCount(r.ID))
 						_ = statusWriter.Resize(width, height)
 						// Also resize container TTY, reserving the footer row.
 						h := containerTTYHeight(statusWriter, height)

--- a/cmd/moat/cli/exec_cmd.go
+++ b/cmd/moat/cli/exec_cmd.go
@@ -13,6 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// exitWithExecError exits the process with the container command's exit code
+// when err is a *container.ExecError; otherwise returns err unchanged. Call
+// AFTER deferred/explicit cleanup so os.Exit doesn't skip it.
+func exitWithExecError(manager *run.Manager, err error) error {
+	if err == nil {
+		return nil
+	}
+	var ee *container.ExecError
+	if errors.As(err, &ee) {
+		manager.Close()
+		os.Exit(ee.ExitCode)
+	}
+	return err
+}
+
 var execCmd = &cobra.Command{
 	Use:   "exec <run> -- <command> [args...]",
 	Short: "Run a command in a running container",
@@ -68,13 +83,5 @@ func runExec(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 	execErr := manager.Exec(ctx, runID, execArgs, stdin, os.Stdout, os.Stderr)
-	if execErr != nil {
-		var ee *container.ExecError
-		if errors.As(execErr, &ee) {
-			manager.Close()
-			os.Exit(ee.ExitCode)
-		}
-		return execErr
-	}
-	return nil
+	return exitWithExecError(manager, execErr)
 }

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/provider"
+	"github.com/majorcontext/moat/internal/run"
+	"github.com/majorcontext/moat/internal/term"
+)
+
+var (
+	joinContinue bool
+	joinResume   string
+	joinPrompt   string
+)
+
+var joinCmd = &cobra.Command{
+	Use:   "join <run> <agent> [flags]",
+	Short: "Launch another agent inside a running container",
+	Long: `Launch a second agent inside an already-running container, reusing its
+workspace, grants, and credentials — without creating a new container.
+
+The agent must match the one the run was started with (v1 supports same-agent
+joins, e.g. joining claude into a run started by 'moat claude').
+
+Examples:
+  moat join run_a1b2c3d4e5f6 claude
+  moat join my-feature claude --continue
+  moat join run_a1b2c3d4e5f6 claude -p "summarize the diff"`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runJoin,
+}
+
+func init() {
+	joinCmd.Flags().BoolVarP(&joinContinue, "continue", "c", false, "continue the most recent conversation")
+	joinCmd.Flags().StringVarP(&joinResume, "resume", "r", "", "resume a specific session by ID")
+	joinCmd.Flags().StringVarP(&joinPrompt, "prompt", "p", "", "run with prompt (non-interactive)")
+	rootCmd.AddCommand(joinCmd)
+}
+
+// validateJoinAgent checks that the run (whose recorded agent field is runAgent)
+// was created by the requested provider. agentArg is the user-typed agent name,
+// used only for the error message.
+func validateJoinAgent(j provider.JoinableAgent, agentArg, runAgent string) error {
+	if !j.IdentifiesAs(runAgent) {
+		return fmt.Errorf("run has no %s configuration.\n"+
+			"v1 join only attaches an agent the run was started with (run agent: %q).\n"+
+			"To run %s here, start the run with %s configured.",
+			agentArg, runAgent, agentArg, agentArg)
+	}
+	return nil
+}
+
+func runJoin(cmd *cobra.Command, args []string) error {
+	if joinContinue && joinResume != "" {
+		return fmt.Errorf("--continue and --resume are mutually exclusive")
+	}
+
+	runArg := args[0]
+	agentArg := args[1]
+
+	manager, err := run.NewManager()
+	if err != nil {
+		return fmt.Errorf("creating run manager: %w", err)
+	}
+	defer manager.Close()
+
+	runID, err := resolveRunArgSingle(manager, runArg)
+	if err != nil {
+		return err
+	}
+
+	r, gErr := manager.Get(runID)
+	if gErr != nil {
+		return gErr
+	}
+	if r.GetState() != run.StateRunning {
+		return fmt.Errorf("run %s is not running (state: %s)", runID, r.GetState())
+	}
+
+	agent := provider.GetAgent(agentArg)
+	if agent == nil {
+		return fmt.Errorf("unknown agent %q", agentArg)
+	}
+	joinable, ok := agent.(provider.JoinableAgent)
+	if !ok {
+		return fmt.Errorf("agent %q does not support join yet", agentArg)
+	}
+	if err := validateJoinAgent(joinable, agentArg, r.Agent); err != nil {
+		return err
+	}
+
+	containerCmd, err := joinable.JoinCommand(provider.JoinOpts{
+		Continue: joinContinue,
+		Resume:   joinResume,
+		Prompt:   joinPrompt,
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Headless (--prompt with no TTY) vs interactive.
+	if joinPrompt != "" || !term.IsTerminal(os.Stdin) || !term.IsTerminal(os.Stdout) {
+		execErr := manager.ExecInteractive(ctx, runID, containerCmd, container.ExecOptions{
+			Stdin:  nil,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+			TTY:    false,
+		})
+		return handleJoinExecErr(manager, execErr)
+	}
+
+	return runJoinInteractive(ctx, manager, r, containerCmd)
+}
+
+func handleJoinExecErr(manager *run.Manager, execErr error) error {
+	if execErr == nil {
+		return nil
+	}
+	var ee *container.ExecError
+	if errors.As(execErr, &ee) {
+		manager.Close()
+		os.Exit(ee.ExitCode)
+	}
+	return execErr
+}
+
+// runJoinInteractive is implemented in Task D2.
+func runJoinInteractive(_ context.Context, _ *run.Manager, _ *run.Run, _ []string) error {
+	return fmt.Errorf("interactive join not implemented")
+}

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -136,7 +136,7 @@ func runJoin(cmd *cobra.Command, args []string) error {
 		return handleJoinExecErr(manager, execErr)
 	}
 
-	return runJoinInteractive(ctx, manager, r, containerCmd, index)
+	return runJoinInteractive(ctx, manager, r, containerCmd, index, regErr == nil)
 }
 
 func handleJoinExecErr(manager *run.Manager, execErr error) error {
@@ -151,7 +151,7 @@ func handleJoinExecErr(manager *run.Manager, execErr error) error {
 	return execErr
 }
 
-func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Writer, func(), io.Writer) {
+func setupJoinStatusBar(manager *run.Manager, r *run.Run, session string) (*tui.Writer, func(), io.Writer) {
 	stdout := io.Writer(os.Stdout)
 	cleanup := func() {}
 	if !term.IsTerminal(os.Stdout) {
@@ -167,7 +167,7 @@ func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Write
 	}
 	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
 	bar.SetGrants(r.Grants)
-	bar.SetSession(fmt.Sprintf("joined · %d", index))
+	bar.SetSession(session)
 	bar.SetDimensions(width, height)
 	writer := tui.NewWriter(os.Stdout, bar, runtimeType)
 	if err := writer.Setup(); err != nil {
@@ -178,7 +178,34 @@ func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Write
 	return writer, cleanup, writer
 }
 
-func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string, index int) error {
+// resizePump forwards terminal-size updates to out until done is closed, then
+// closes out. It owns out exclusively (sole sender + closer), so callers must
+// NOT close out themselves. onWinch is called for each SIGWINCH (e.g. to resize
+// the footer + read the new size); it returns the size to forward and whether to.
+func resizePump(done <-chan struct{}, sigCh <-chan os.Signal, onWinch func() (container.TTYSize, bool), out chan<- container.TTYSize) {
+	defer close(out)
+	for {
+		select {
+		case <-done:
+			return
+		case sig, ok := <-sigCh:
+			if !ok {
+				return
+			}
+			if sig != syscall.SIGWINCH {
+				continue
+			}
+			if size, forward := onWinch(); forward {
+				select {
+				case out <- size:
+				default:
+				}
+			}
+		}
+	}
+}
+
+func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string, index int, registered bool) error {
 	// Raw mode so keystrokes reach the agent unbuffered.
 	var rawState *term.RawModeState
 	if term.IsTerminal(os.Stdin) {
@@ -192,20 +219,24 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 		}
 	}()
 
-	// Status footer: this is a joined session.
-	statusWriter, statusCleanup, stdout := setupJoinStatusBar(manager, r, index)
+	// Status footer: show index only when registration succeeded.
+	session := "joined"
+	if registered {
+		session = fmt.Sprintf("joined · %d", index)
+	}
+	statusWriter, statusCleanup, stdout := setupJoinStatusBar(manager, r, session)
 	defer statusCleanup()
 
-	// Tee join output to its own indexed log file, kept separate from the
-	// primary's logs.jsonl per the split-console design.
-	if r.Store != nil {
+	// Tee join output to its own indexed log file only when registration succeeded,
+	// kept separate from the primary's logs.jsonl per the split-console design.
+	if registered && r.Store != nil {
 		if lw, lerr := r.Store.JoinLogWriter(index); lerr == nil {
 			defer lw.Close()
 			stdout = io.MultiWriter(stdout, lw)
 		}
 	}
 
-	// Resize channel fed by SIGWINCH; closed on exit so the runtime goroutine ends.
+	// Resize channel owned by resizePump — do NOT close it here.
 	resize := make(chan container.TTYSize, 1)
 	var initialW, initialH uint
 	if term.IsTerminal(os.Stdout) {
@@ -223,23 +254,20 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 	execCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	go func() {
-		for sig := range sigCh {
-			if sig != syscall.SIGWINCH {
-				continue
-			}
-			if statusWriter != nil && term.IsTerminal(os.Stdout) {
-				if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
-					_ = statusWriter.Resize(w, h)
-					ch := containerTTYHeight(statusWriter, h)
-					select {
-					case resize <- container.TTYSize{Width: uint(w), Height: uint(ch)}: // #nosec G115
-					default:
-					}
-				}
-			}
+	done := make(chan struct{})
+	onWinch := func() (container.TTYSize, bool) {
+		if statusWriter == nil || !term.IsTerminal(os.Stdout) {
+			return container.TTYSize{}, false
 		}
-	}()
+		w, h := term.GetSize(os.Stdout)
+		if w <= 0 || h <= 0 {
+			return container.TTYSize{}, false
+		}
+		_ = statusWriter.Resize(w, h)
+		ch := containerTTYHeight(statusWriter, h)
+		return container.TTYSize{Width: uint(w), Height: uint(ch)}, true // #nosec G115
+	}
+	go resizePump(done, sigCh, onWinch, resize)
 
 	execErr := manager.ExecInteractive(execCtx, r.ID, command, container.ExecOptions{
 		Stdin:         os.Stdin,
@@ -250,7 +278,8 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 		InitialHeight: initialH,
 		Resize:        resize,
 	})
-	close(resize)
+	// Signal resizePump to stop; it closes resize, which unblocks the runtime side.
+	close(done)
 
 	if execErr != nil && ctx.Err() == nil {
 		var ee *container.ExecError

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -96,8 +96,8 @@ func runJoin(cmd *cobra.Command, args []string) error {
 	if !ok {
 		return fmt.Errorf("agent %q does not support join yet", agentArg)
 	}
-	if err := validateJoinAgent(joinable, agentArg, r.Agent); err != nil {
-		return err
+	if valErr := validateJoinAgent(joinable, agentArg, r.Agent); valErr != nil {
+		return valErr
 	}
 
 	containerCmd, err := joinable.JoinCommand(provider.JoinOpts{
@@ -111,18 +111,32 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 
+	// Register this join for the display-only attached count. Both interactive
+	// and headless paths need an index so console output lands in logs.<N>.jsonl.
+	index, release, regErr := manager.RegisterJoinedAgent(runID)
+	if regErr == nil {
+		defer release()
+	}
+
 	// Headless (--prompt with no TTY) vs interactive.
 	if joinPrompt != "" || !term.IsTerminal(os.Stdin) || !term.IsTerminal(os.Stdout) {
+		var headlessOut io.Writer = os.Stdout
+		if regErr == nil && r.Store != nil {
+			if lw, lerr := r.Store.JoinLogWriter(index); lerr == nil {
+				defer lw.Close()
+				headlessOut = io.MultiWriter(os.Stdout, lw)
+			}
+		}
 		execErr := manager.ExecInteractive(ctx, runID, containerCmd, container.ExecOptions{
 			Stdin:  nil,
-			Stdout: os.Stdout,
+			Stdout: headlessOut,
 			Stderr: os.Stderr,
 			TTY:    false,
 		})
 		return handleJoinExecErr(manager, execErr)
 	}
 
-	return runJoinInteractive(ctx, manager, r, containerCmd)
+	return runJoinInteractive(ctx, manager, r, containerCmd, index)
 }
 
 func handleJoinExecErr(manager *run.Manager, execErr error) error {
@@ -164,13 +178,7 @@ func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Write
 	return writer, cleanup, writer
 }
 
-func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string) error {
-	// Register this join for the display-only attached count.
-	index, release, err := manager.RegisterJoinedAgent(r.ID)
-	if err == nil {
-		defer release()
-	}
-
+func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string, index int) error {
 	// Raw mode so keystrokes reach the agent unbuffered.
 	var rawState *term.RawModeState
 	if term.IsTerminal(os.Stdin) {
@@ -187,6 +195,15 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 	// Status footer: this is a joined session.
 	statusWriter, statusCleanup, stdout := setupJoinStatusBar(manager, r, index)
 	defer statusCleanup()
+
+	// Tee join output to its own indexed log file, kept separate from the
+	// primary's logs.jsonl per the split-console design.
+	if r.Store != nil {
+		if lw, lerr := r.Store.JoinLogWriter(index); lerr == nil {
+			defer lw.Close()
+			stdout = io.MultiWriter(stdout, lw)
+		}
+	}
 
 	// Resize channel fed by SIGWINCH; closed on exit so the runtime goroutine ends.
 	resize := make(chan container.TTYSize, 1)

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -297,7 +297,7 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 	// failure; fall through to the clean exit so the terminal is restored.
 	// Deferred RestoreTerminal and statusCleanup run before returning, ensuring
 	// the terminal is in a good state before runJoin calls exitWithExecError.
-	if execErr != nil && ctx.Err() == nil && !errors.Is(execErr, context.Canceled) {
+	if execErr != nil && !errors.Is(execErr, context.Canceled) {
 		var ee *container.ExecError
 		if errors.As(execErr, &ee) {
 			// Return the ExecError so runJoin can propagate the exit code.

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -137,10 +137,31 @@ func handleJoinExecErr(manager *run.Manager, execErr error) error {
 	return execErr
 }
 
-// setupJoinStatusBar is a stub for Phase E (Task E2).
-// Phase E will replace this with the real footer implementation.
-func setupJoinStatusBar(_ *run.Manager, _ *run.Run, _ int) (*tui.Writer, func(), io.Writer) {
-	return nil, func() {}, os.Stdout
+func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Writer, func(), io.Writer) {
+	stdout := io.Writer(os.Stdout)
+	cleanup := func() {}
+	if !term.IsTerminal(os.Stdout) {
+		return nil, cleanup, stdout
+	}
+	width, height := term.GetSize(os.Stdout)
+	if width <= 0 || height <= 0 {
+		return nil, cleanup, stdout
+	}
+	runtimeType := r.Runtime
+	if runtimeType == "" {
+		runtimeType = manager.RuntimeType()
+	}
+	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
+	bar.SetGrants(r.Grants)
+	bar.SetSession(fmt.Sprintf("joined · %d", index))
+	bar.SetDimensions(width, height)
+	writer := tui.NewWriter(os.Stdout, bar, runtimeType)
+	if err := writer.Setup(); err != nil {
+		return nil, cleanup, os.Stdout
+	}
+	_ = os.Stdout.Sync()
+	cleanup = func() { _ = writer.Cleanup() }
+	return writer, cleanup, writer
 }
 
 func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string) error {

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"sort"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -61,6 +63,19 @@ func validateJoinAgent(j provider.JoinableAgent, agentArg, runAgent string) erro
 	return nil
 }
 
+// joinableAgentNames returns the sorted names of registered agents that support
+// `moat join`, for use in the unknown-agent error message.
+func joinableAgentNames() []string {
+	var names []string
+	for _, a := range provider.Agents() {
+		if _, ok := a.(provider.JoinableAgent); ok {
+			names = append(names, a.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
 func runJoin(cmd *cobra.Command, args []string) error {
 	if joinContinue && joinResume != "" {
 		return fmt.Errorf("--continue and --resume are mutually exclusive")
@@ -90,7 +105,7 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	agent := provider.GetAgent(agentArg)
 	if agent == nil {
-		return fmt.Errorf("unknown agent %q", agentArg)
+		return fmt.Errorf("unknown agent %q; joinable agents: %s", agentArg, strings.Join(joinableAgentNames(), ", "))
 	}
 	joinable, ok := agent.(provider.JoinableAgent)
 	if !ok {
@@ -255,6 +270,22 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 	defer cancel()
 
 	done := make(chan struct{})
+
+	// Restore the terminal if we're asked to terminate while in raw mode. An
+	// external SIGTERM/SIGHUP would otherwise kill the process before the
+	// deferred RestoreTerminal runs, leaving the terminal garbled. Canceling
+	// execCtx unblocks ExecInteractive so the deferred cleanup runs normally.
+	termCh := make(chan os.Signal, 1)
+	signal.Notify(termCh, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(termCh)
+	go func() {
+		select {
+		case <-termCh:
+			cancel()
+		case <-done:
+		}
+	}()
+
 	onWinch := func() (container.TTYSize, bool) {
 		if statusWriter == nil || !term.IsTerminal(os.Stdout) {
 			return container.TTYSize{}, false
@@ -281,7 +312,9 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 	// Signal resizePump to stop; it closes resize, which unblocks the runtime side.
 	close(done)
 
-	if execErr != nil && ctx.Err() == nil {
+	// A canceled execCtx means we were signaled to terminate (above) — not a
+	// failure; fall through to the clean exit so the terminal is restored.
+	if execErr != nil && ctx.Err() == nil && !errors.Is(execErr, context.Canceled) {
 		var ee *container.ExecError
 		if errors.As(execErr, &ee) {
 			// Agent exited non-zero; surface it but don't treat as a moat error.

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -17,7 +17,6 @@ import (
 	"github.com/majorcontext/moat/internal/provider"
 	"github.com/majorcontext/moat/internal/run"
 	"github.com/majorcontext/moat/internal/term"
-	"github.com/majorcontext/moat/internal/tui"
 )
 
 var (
@@ -128,69 +127,51 @@ func runJoin(cmd *cobra.Command, args []string) error {
 
 	// Register this join for the display-only attached count. Both interactive
 	// and headless paths need an index so console output lands in logs.<N>.jsonl.
+	// Do NOT defer release here — we call it explicitly before exitWithExecError
+	// so registry cleanup runs even when the agent exits with a non-zero code.
 	index, release, regErr := manager.RegisterJoinedAgent(runID)
-	if regErr == nil {
-		defer release()
-	}
 
+	var execErr error
 	// Headless (--prompt with no TTY) vs interactive.
 	if joinPrompt != "" || !term.IsTerminal(os.Stdin) || !term.IsTerminal(os.Stdout) {
-		var headlessOut io.Writer = os.Stdout
-		if regErr == nil && r.Store != nil {
-			if lw, lerr := r.Store.JoinLogWriter(index); lerr == nil {
-				defer lw.Close()
-				headlessOut = io.MultiWriter(os.Stdout, lw)
-			}
+		execErr = runJoinHeadless(ctx, manager, r, containerCmd, index, regErr == nil)
+	} else {
+		execErr = runJoinInteractive(ctx, manager, r, containerCmd, index, regErr == nil)
+	}
+
+	// Explicit cleanup before a possible os.Exit so the registry entry is
+	// released and lw.Close() (inside the helpers) has already run.
+	if regErr == nil {
+		release()
+	}
+
+	return exitWithExecError(manager, execErr)
+}
+
+// runJoinHeadless runs the joined agent without a TTY, forwarding piped stdin
+// when available. lw.Close() runs as the function returns, before runJoin
+// calls exitWithExecError, so log flushing precedes any os.Exit.
+func runJoinHeadless(ctx context.Context, manager *run.Manager, r *run.Run, command []string, index int, registered bool) error {
+	var out io.Writer = os.Stdout
+	if registered && r.Store != nil {
+		if lw, lerr := r.Store.JoinLogWriter(index); lerr == nil {
+			defer lw.Close()
+			out = io.MultiWriter(os.Stdout, lw)
 		}
-		execErr := manager.ExecInteractive(ctx, runID, containerCmd, container.ExecOptions{
-			Stdin:  nil,
-			Stdout: headlessOut,
-			Stderr: os.Stderr,
-			TTY:    false,
-		})
-		return handleJoinExecErr(manager, execErr)
 	}
 
-	return runJoinInteractive(ctx, manager, r, containerCmd, index, regErr == nil)
-}
+	// Forward piped stdin so "echo ... | moat join <run> claude" works.
+	var stdin io.Reader
+	if !term.IsTerminal(os.Stdin) {
+		stdin = os.Stdin
+	}
 
-func handleJoinExecErr(manager *run.Manager, execErr error) error {
-	if execErr == nil {
-		return nil
-	}
-	var ee *container.ExecError
-	if errors.As(execErr, &ee) {
-		manager.Close()
-		os.Exit(ee.ExitCode)
-	}
-	return execErr
-}
-
-func setupJoinStatusBar(manager *run.Manager, r *run.Run, session string) (*tui.Writer, func(), io.Writer) {
-	stdout := io.Writer(os.Stdout)
-	cleanup := func() {}
-	if !term.IsTerminal(os.Stdout) {
-		return nil, cleanup, stdout
-	}
-	width, height := term.GetSize(os.Stdout)
-	if width <= 0 || height <= 0 {
-		return nil, cleanup, stdout
-	}
-	runtimeType := r.Runtime
-	if runtimeType == "" {
-		runtimeType = manager.RuntimeType()
-	}
-	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
-	bar.SetGrants(r.Grants)
-	bar.SetSession(session)
-	bar.SetDimensions(width, height)
-	writer := tui.NewWriter(os.Stdout, bar, runtimeType)
-	if err := writer.Setup(); err != nil {
-		return nil, cleanup, os.Stdout
-	}
-	_ = os.Stdout.Sync()
-	cleanup = func() { _ = writer.Cleanup() }
-	return writer, cleanup, writer
+	return manager.ExecInteractive(ctx, r.ID, command, container.ExecOptions{
+		Stdin:  stdin,
+		Stdout: out,
+		Stderr: os.Stderr,
+		TTY:    false,
+	})
 }
 
 // resizePump forwards terminal-size updates to out until done is closed, then
@@ -239,7 +220,7 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 	if registered {
 		session = fmt.Sprintf("joined · %d", index)
 	}
-	statusWriter, statusCleanup, stdout := setupJoinStatusBar(manager, r, session)
+	statusWriter, statusCleanup, stdout := setupStatusBar(manager, r, session)
 	defer statusCleanup()
 
 	// Tee join output to its own indexed log file only when registration succeeded,
@@ -314,12 +295,13 @@ func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, c
 
 	// A canceled execCtx means we were signaled to terminate (above) — not a
 	// failure; fall through to the clean exit so the terminal is restored.
+	// Deferred RestoreTerminal and statusCleanup run before returning, ensuring
+	// the terminal is in a good state before runJoin calls exitWithExecError.
 	if execErr != nil && ctx.Err() == nil && !errors.Is(execErr, context.Canceled) {
 		var ee *container.ExecError
 		if errors.As(execErr, &ee) {
-			// Agent exited non-zero; surface it but don't treat as a moat error.
-			fmt.Printf("\r\nJoined agent exited (code %d)\r\n", ee.ExitCode)
-			return nil
+			// Return the ExecError so runJoin can propagate the exit code.
+			return ee
 		}
 		return fmt.Errorf("join failed: %w", execErr)
 	}

--- a/cmd/moat/cli/join_cmd.go
+++ b/cmd/moat/cli/join_cmd.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -12,6 +15,7 @@ import (
 	"github.com/majorcontext/moat/internal/provider"
 	"github.com/majorcontext/moat/internal/run"
 	"github.com/majorcontext/moat/internal/term"
+	"github.com/majorcontext/moat/internal/tui"
 )
 
 var (
@@ -133,7 +137,92 @@ func handleJoinExecErr(manager *run.Manager, execErr error) error {
 	return execErr
 }
 
-// runJoinInteractive is implemented in Task D2.
-func runJoinInteractive(_ context.Context, _ *run.Manager, _ *run.Run, _ []string) error {
-	return fmt.Errorf("interactive join not implemented")
+// setupJoinStatusBar is a stub for Phase E (Task E2).
+// Phase E will replace this with the real footer implementation.
+func setupJoinStatusBar(_ *run.Manager, _ *run.Run, _ int) (*tui.Writer, func(), io.Writer) {
+	return nil, func() {}, os.Stdout
+}
+
+func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string) error {
+	// Register this join for the display-only attached count.
+	index, release, err := manager.RegisterJoinedAgent(r.ID)
+	if err == nil {
+		defer release()
+	}
+
+	// Raw mode so keystrokes reach the agent unbuffered.
+	var rawState *term.RawModeState
+	if term.IsTerminal(os.Stdin) {
+		if rs, rErr := term.EnableRawMode(os.Stdin); rErr == nil {
+			rawState = rs
+		}
+	}
+	defer func() {
+		if rawState != nil {
+			_ = term.RestoreTerminal(rawState)
+		}
+	}()
+
+	// Status footer: this is a joined session.
+	statusWriter, statusCleanup, stdout := setupJoinStatusBar(manager, r, index)
+	defer statusCleanup()
+
+	// Resize channel fed by SIGWINCH; closed on exit so the runtime goroutine ends.
+	resize := make(chan container.TTYSize, 1)
+	var initialW, initialH uint
+	if term.IsTerminal(os.Stdout) {
+		if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
+			// Reserve the footer row.
+			ch := containerTTYHeight(statusWriter, h)
+			initialW, initialH = uint(w), uint(ch) // #nosec G115
+		}
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+
+	execCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		for sig := range sigCh {
+			if sig != syscall.SIGWINCH {
+				continue
+			}
+			if statusWriter != nil && term.IsTerminal(os.Stdout) {
+				if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
+					_ = statusWriter.Resize(w, h)
+					ch := containerTTYHeight(statusWriter, h)
+					select {
+					case resize <- container.TTYSize{Width: uint(w), Height: uint(ch)}: // #nosec G115
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	execErr := manager.ExecInteractive(execCtx, r.ID, command, container.ExecOptions{
+		Stdin:         os.Stdin,
+		Stdout:        stdout,
+		Stderr:        os.Stderr,
+		TTY:           true,
+		InitialWidth:  initialW,
+		InitialHeight: initialH,
+		Resize:        resize,
+	})
+	close(resize)
+
+	if execErr != nil && ctx.Err() == nil {
+		var ee *container.ExecError
+		if errors.As(execErr, &ee) {
+			// Agent exited non-zero; surface it but don't treat as a moat error.
+			fmt.Printf("\r\nJoined agent exited (code %d)\r\n", ee.ExitCode)
+			return nil
+		}
+		return fmt.Errorf("join failed: %w", execErr)
+	}
+	fmt.Printf("\r\nJoined agent session ended\r\n")
+	return nil
 }

--- a/cmd/moat/cli/join_cmd_test.go
+++ b/cmd/moat/cli/join_cmd_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"os"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
+	"github.com/majorcontext/moat/internal/container"
 	"github.com/majorcontext/moat/internal/provider"
 )
 
@@ -24,4 +28,95 @@ func TestValidateJoinAgent_WrongProvider(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no codex configuration") {
 		t.Fatalf("got %v, want a clear 'no codex configuration' error", err)
 	}
+}
+
+// TestResizePump_NoSendOnClosed verifies that resizePump never sends on a
+// closed channel. It is intentionally run under -race to catch any concurrent
+// close vs send on the out channel.
+func TestResizePump_NoSendOnClosed(t *testing.T) {
+	nopWinch := func() (container.TTYSize, bool) {
+		return container.TTYSize{Width: 80, Height: 24}, true
+	}
+
+	t.Run("close_done_stops_pump_and_closes_out", func(t *testing.T) {
+		done := make(chan struct{})
+		sigCh := make(chan os.Signal, 1)
+		out := make(chan container.TTYSize, 1)
+
+		go resizePump(done, sigCh, nopWinch, out)
+
+		// Closing done must cause resizePump to close out.
+		close(done)
+
+		// Drain out until it is closed; panic on send-on-closed would surface here.
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case _, ok := <-out:
+				if !ok {
+					return // out was closed cleanly — pass
+				}
+			case <-deadline:
+				t.Fatal("timed out waiting for out to be closed after done was closed")
+			}
+		}
+	})
+
+	t.Run("sigwinch_then_close_done_no_panic", func(t *testing.T) {
+		done := make(chan struct{})
+		sigCh := make(chan os.Signal, 1)
+		out := make(chan container.TTYSize, 1)
+
+		go resizePump(done, sigCh, nopWinch, out)
+
+		// Pre-load a SIGWINCH so resizePump has something to process.
+		sigCh <- syscall.SIGWINCH
+
+		// Close done concurrently with the buffered signal — exercises the race.
+		close(done)
+
+		deadline := time.After(2 * time.Second)
+		for {
+			select {
+			case _, ok := <-out:
+				if !ok {
+					return // out was closed cleanly — pass
+				}
+			case <-deadline:
+				t.Fatal("timed out waiting for out to be closed")
+			}
+		}
+	})
+
+	t.Run("concurrent_sigwinch_and_done", func(t *testing.T) {
+		// Hammer the race detector: many goroutines send SIGWINCH while done
+		// is closed, ensuring no send-on-closed slip through.
+		for i := 0; i < 20; i++ {
+			done := make(chan struct{})
+			sigCh := make(chan os.Signal, 1)
+			out := make(chan container.TTYSize, 2)
+
+			go resizePump(done, sigCh, nopWinch, out)
+
+			// Sender goroutine races with close(done).
+			go func() {
+				sigCh <- syscall.SIGWINCH
+			}()
+
+			close(done)
+
+			deadline := time.After(2 * time.Second)
+			drained := false
+			for !drained {
+				select {
+				case _, ok := <-out:
+					if !ok {
+						drained = true
+					}
+				case <-deadline:
+					t.Fatal("timed out waiting for out to be closed in concurrent test")
+				}
+			}
+		}
+	})
 }

--- a/cmd/moat/cli/join_cmd_test.go
+++ b/cmd/moat/cli/join_cmd_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+// fakeJoinable implements provider.JoinableAgent for validation tests.
+type fakeJoinable struct{ identifies bool }
+
+func (f fakeJoinable) JoinCommand(provider.JoinOpts) ([]string, error) { return []string{"x"}, nil }
+func (f fakeJoinable) IdentifiesAs(string) bool                        { return f.identifies }
+
+func TestValidateJoinAgent_OK(t *testing.T) {
+	if err := validateJoinAgent(fakeJoinable{identifies: true}, "claude", "claude-code"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateJoinAgent_WrongProvider(t *testing.T) {
+	err := validateJoinAgent(fakeJoinable{identifies: false}, "codex", "claude-code")
+	if err == nil || !strings.Contains(err.Error(), "no codex configuration") {
+		t.Fatalf("got %v, want a clear 'no codex configuration' error", err)
+	}
+}

--- a/cmd/moat/cli/list_clean_test.go
+++ b/cmd/moat/cli/list_clean_test.go
@@ -90,6 +90,9 @@ func (s *listCleanStubRuntime) ResizeTTY(ctx context.Context, id string, height,
 func (s *listCleanStubRuntime) Exec(ctx context.Context, id string, cmd []string, stdin []byte, stdout, stderr io.Writer) error {
 	panic("unexpected call to Exec")
 }
+func (s *listCleanStubRuntime) ExecInteractive(ctx context.Context, id string, cmd []string, opts container.ExecOptions) error {
+	panic("unexpected call to ExecInteractive")
+}
 
 // --- isImageInUse tests ---
 

--- a/docs/content/guides/14-multi-agent.md
+++ b/docs/content/guides/14-multi-agent.md
@@ -30,7 +30,7 @@ In a second terminal, join it:
 moat join run_a1b2c3d4e5f6 claude
 ```
 
-The second terminal opens an interactive claude session in the same workspace. The status footer on the join shows `joined · 1`; the primary's footer shows `+1`.
+The second terminal opens an interactive claude session in the same workspace. The status footer on the join shows `joined · 1`; the primary's footer shows `primary +1`.
 
 ## Headless join
 
@@ -57,7 +57,7 @@ The output streams to the terminal and the command exits with claude's exit code
 | Session | Footer display |
 |---------|----------------|
 | Primary, no joins | (no session segment) |
-| Primary, N joins active | `+N` before the run ID |
+| Primary, N joins active | `primary +N` before the run ID |
 | Joined session (index N) | `joined · N` before the run ID |
 
 ## Lifecycle

--- a/docs/content/guides/14-multi-agent.md
+++ b/docs/content/guides/14-multi-agent.md
@@ -1,0 +1,92 @@
+---
+title: "Multi-agent sessions"
+navTitle: "Multi-agent"
+description: "Run a second agent inside an already-running container using moat join."
+keywords: ["moat", "join", "multi-agent", "claude", "parallel", "session"]
+---
+
+# Multi-agent sessions
+
+`moat join` launches a second agent inside an already-running container, reusing its workspace, grants, and credential context. No new container is created and no new proxy registration is issued.
+
+## How it works
+
+A `moat join` session is an exec child of the existing container. The original agent owns the container lifecycle: stopping the run (via `moat stop`) tears down the container and terminates any joined agents. Joined agents share the run's proxy token, so their network requests are logged to the same run's `network.jsonl` and attributed to the same audit chain.
+
+Console output is split: the primary agent writes to `logs.jsonl`; each joined agent writes to `logs.<index>.jsonl`.
+
+## Quick start
+
+In a first terminal, start a claude run:
+
+```bash
+moat claude
+# note the run ID printed in the status footer, e.g. run_a1b2c3d4e5f6
+```
+
+In a second terminal, join it:
+
+```bash
+moat join run_a1b2c3d4e5f6 claude
+```
+
+The second terminal opens an interactive claude session in the same workspace. The status footer on the join shows `joined · 1`; the primary's footer shows `+1`.
+
+## Headless join
+
+Use `--prompt` / `-p` to run a join non-interactively and exit when done:
+
+```bash
+moat join run_a1b2c3d4e5f6 claude -p "print the current git branch"
+```
+
+The output streams to the terminal and the command exits with claude's exit code.
+
+## Session flags
+
+| Flag | Effect |
+|------|--------|
+| `-c`, `--continue` | Continue the most recent conversation |
+| `-r`, `--resume ID` | Resume a specific session by ID |
+| `-p`, `--prompt TEXT` | Run non-interactively with this prompt |
+
+`--continue` and `--resume` are mutually exclusive.
+
+## Status footer
+
+| Session | Footer display |
+|---------|----------------|
+| Primary, no joins | (no session segment) |
+| Primary, N joins active | `+N` before the run ID |
+| Joined session (index N) | `joined · N` before the run ID |
+
+## Lifecycle
+
+The original run owns the container. Joined agents are exec children:
+
+- `moat stop <run>` stops the container, which terminates all joined agents.
+- A joined agent exiting (or being interrupted) does not affect the primary or other joins.
+- `moat destroy` removes the run after it is stopped; joined log files (`logs.N.jsonl`) are removed with the run.
+
+## v1 constraints
+
+v1 supports same-agent joins only. The agent argument must match the agent the run was created with:
+
+```bash
+# Works: joining claude into a moat claude run
+moat join run_a1b2c3d4e5f6 claude
+
+# Error: run has no codex configuration
+moat join run_a1b2c3d4e5f6 codex
+```
+
+Cross-provider join (e.g. running codex inside a claude run) and container-side worktree joins (`moat join … --wt`) are not supported in v1.
+
+## Relationship to moat exec
+
+`moat join` and `moat exec` both exec a command into an existing container:
+
+- `moat exec` runs an arbitrary command you supply.
+- `moat join` resolves an agent provider by name and constructs its standard invocation (equivalent to what `moat claude` would run inside the container).
+
+Use `moat exec` for shell commands and scripts; use `moat join` to start a full interactive agent session.

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -1073,6 +1073,55 @@ moat exec run_a1b2c3d4e5f6 -- sh -c "ps aux"
 
 ---
 
+## moat join
+
+Launch a second agent inside a running container, reusing its workspace, grants, and credentials.
+
+```
+moat join <run> <agent> [flags]
+```
+
+`moat join` is the run-first counterpart to `moat exec`: where `exec` runs an arbitrary command, `join` resolves an agent provider by name, constructs its standard in-container invocation, and execs it into the existing container. The original run owns the container lifecycle — stopping the run tears down the container and any joined agents.
+
+v1 supports same-agent joins only (e.g. joining `claude` into a run started by `moat claude`). The agent argument must match the agent the run was created with.
+
+### Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `run` | Run ID or name of the target (must be in the running state) |
+| `agent` | Agent to launch (`claude`) |
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `-c`, `--continue` | Continue the most recent conversation |
+| `-r`, `--resume ID` | Resume a specific session by ID |
+| `-p`, `--prompt TEXT` | Run with a prompt (non-interactive; exits when done) |
+
+`--continue` and `--resume` are mutually exclusive.
+
+Without `--prompt`, the join session is interactive: stdin, stdout, and stderr are connected to the terminal, and the status footer shows `joined · N` to indicate the session role and index.
+
+### Examples
+
+```bash
+# Interactive join — second claude session in the same workspace
+moat join run_a1b2c3d4e5f6 claude
+
+# Join and continue the most recent conversation
+moat join run_a1b2c3d4e5f6 claude --continue
+
+# Headless join — run a prompt and exit
+moat join run_a1b2c3d4e5f6 claude -p "summarize the diff"
+
+# Identify the run by name
+moat join my-feature claude
+```
+
+---
+
 ## moat destroy
 
 Remove a stopped run and its artifacts.

--- a/docs/plans/2026-06-16-multi-agent-join-design.md
+++ b/docs/plans/2026-06-16-multi-agent-join-design.md
@@ -1,0 +1,313 @@
+# Multi-agent join — design
+
+**Date:** 2026-06-16
+**Status:** Draft for review
+**Topic:** Run a second agent inside an already-running container via `moat join`
+
+## Problem
+
+Today moat is strictly **1 run = 1 container = 1 foreground agent**. The container
+exists for exactly one agent and exits when that agent exits. Running a second
+`claude` against the same workspace means paying the full container setup cost
+again — image resolve, container create, mounts, proxy registration, dependency
+provisioning, agent config materialization — for what is conceptually "another
+agent in the same place."
+
+We want a way to launch an additional agent into an existing run's container,
+reusing all of that setup.
+
+## Goal (v1)
+
+```
+moat join <run> <agent> [agent flags…]
+
+moat join run_123 claude
+moat join run_123 claude --continue
+moat join happy-otter claude --prompt "..."
+```
+
+A second `claude` agent starts inside the container of an existing `claude` run,
+sharing its workspace, grants, config, and proxy credential context — with no
+new container, image build, or proxy registration.
+
+### Non-goals (deferred — see Future)
+
+- Cross-provider join (`codex` into a `claude` run).
+- Joining into a generic `moat run` container that has no agent configured.
+- A persistent / "session" container whose lifecycle is independent of any agent.
+- Reference-counted teardown across agents.
+
+## Decisions
+
+### 1. Command shape: a new top-level verb, `moat join`
+
+`join` is the run-targeting sibling of `exec`, mirroring how `claude`/`codex`
+relate to `run`:
+
+|                    | arbitrary command        | configured agent                 |
+| ------------------ | ------------------------ | -------------------------------- |
+| **fresh container**   | `moat run -- …`        | `moat claude` / `moat codex`     |
+| **existing container**| `moat exec <run> -- …` | `moat join <run> <agent>`        |
+
+`join : exec :: claude : run`. Same axis (raw vs. provider-configured), applied
+to a different lifecycle (fresh vs. existing).
+
+**Why a verb, not a `--attach` flag on `moat claude`.** `moat claude` *is* the
+create-a-run path — it threads through `Create` → image resolve → container
+create → mounts → proxy register → start. Adding `--attach <run>` would fork
+that entire flow with a "skip all of the above and divert into exec" branch
+inside the one command that most assumes it is building something new. A
+dedicated verb is a clean, purpose-built path straight to the exec backend that
+never touches `Create` — **less** plumbing, not more.
+
+**Why run-first.** All run-targeting commands lead with the run: `moat exec
+<run>`, `moat logs <run>`, `moat stop <run>`. `moat join <run> <agent>` is
+consistent with that family. A `--attach <run>` flag would bury the target.
+
+**Agent flags are shared.** `moat join <run> claude --continue` takes the *exact
+same* flags as `moat claude --continue`. Same provider flag surface, two entry
+points (fresh vs. join). Nothing to relearn.
+
+**`exec` is unaffected.** `moat exec <run> -- claude` still works — it launches
+the raw `claude` binary with no provider config, no TTY-before-process, no
+observability wiring. `exec` stays the honest "run literally what I typed"
+escape hatch; `join` is the curated, provider-configured path. Exactly the
+relationship `run` and `claude` already have. We do not block exec; we just do
+not pretend it does the setup.
+
+### 2. Lifecycle: the original agent owns the container
+
+Simplicity first. Joined agents are `exec` children of the container, so they
+already die when the container stops. The container's lifecycle is unchanged
+from today:
+
+- The container stays up exactly as long as the **original** foreground agent
+  runs (or until `moat stop <run>`).
+- When the original agent exits, the container tears down and any joined agents
+  go with it.
+- `moat stop <run>` while joined agents are live stops everything. This is
+  acceptable and consistent with today's behavior.
+
+No reference counting, no new persistence, no daemon lifecycle changes. A
+persistent / "last one out" / session-owned container is a natural later
+extension (see Future) but is explicitly **not** built now.
+
+### 3. Scope: same-provider join only, inheriting the run's context
+
+`moat join <run> claude` works **only when the target run already has claude
+configured** — practically, a run started by `moat claude`. The joined agent
+inherits the run's existing grants, config, and proxy token.
+
+This is cheap because of how a `moat claude` run is already built:
+
+- The agent config (`~/.claude.json`, credentials, MCP relay URLs) was
+  materialized into the container home at container start (via the
+  `/moat/claude-init` staging mount + `moat-init.sh`). A joined claude agent
+  finds it already in place — **no new config writing**.
+- The proxy scopes credentials per-run by a single auth token baked into the
+  container's `HTTP_PROXY`. Every process in the container — including a joined
+  agent — shares that token, so the joined agent gets the same Anthropic
+  credential injection automatically. **No daemon/proxy changes.**
+
+Anything outside this — a *different* provider, or a generic `moat run`
+container with no agent — **errors clearly** and is deferred:
+
+```
+$ moat join run_123 codex
+error: run_123 has no codex configuration.
+       v1 join only attaches an agent that the run was started with (claude).
+       To run codex here, start the run with codex configured.
+```
+
+### 4. Observability: hybrid — split console, interleaved network/audit
+
+The parts that attribute by proxy token are unified at the run level; the
+console, which is per-agent TUI noise, is split.
+
+- **Console (stdout/stderr): split per agent.** The original agent's TUI output
+  is already messy in `logs.jsonl` because of terminal control codes; forcing a
+  joined TUI into the same stream would just be two TUIs fighting over one file.
+  Each agent captures to its own console stream — original → `logs.jsonl`,
+  joins → their own, addressed by a per-join index. The only new bookkeeping is
+  that index; there is **no child run**. `moat list` shows the run with an agent
+  count.
+- **Network tracing: interleaved.** One `network.jsonl` per run. Automatic and
+  correct by construction — every agent shares the run's proxy token, so the
+  proxy already attributes all traffic to this run.
+- **Audit chain: interleaved.** One hash-chained audit log per run; a joined
+  agent's credential/network events append to the same chain. Same reason —
+  shared token.
+
+`moat list` shows the run with an agent count; `moat logs <run>` defaults to the
+original agent's console, with joined consoles addressable by index.
+
+### 5. Status footer reflects session role and attached count
+
+Each interactive session — the primary and every join — already renders its own
+status footer. Its current layout is two clusters with padding between them:
+
+```
+ moat  <runtime>  <grants…>  <warning> ··········· <run-id> · <name> (ctrl+/)
+└── left ───────────────────────────┘              └──────── right ─────────┘
+```
+
+The session info is **prepended to the right cluster, just before the run-id**.
+Color carries the role distinction, and the primary stays implicit:
+
+- **Primary is implicit.** The primary (owner) session shows **no role word**.
+  With zero joins its footer is identical to today's. When joins are live it
+  shows only a color-accented `+N` count, so the owner sees at a glance that
+  others are in the workspace.
+- **Joined is explicit and color-accented.** A joined session renders a colored
+  `joined` indicator so the terminal is unmistakably a join, with its index,
+  e.g. `joined · 2`.
+
+```
+primary, solo:     moat  apple  github ····················· run_123 · happy-otter (ctrl+/)
+primary, +2 joins: moat  apple  github ··············· +2 · run_123 · happy-otter (ctrl+/)
+joined (agent 2):  moat  apple  github ········· joined · 2 · run_123 · happy-otter (ctrl+/)
+```
+
+`+2` and `joined` are color-accented (the bar already colors the runtime, dims
+grants, and yellows warnings — the session segment gets its own accent). The
+existing truncation cascade (drop hint, then grants, then name) extends
+naturally — the session segment sits with the run-id on the right and is among
+the last things dropped, since it is the point of this feature.
+
+**Subtlety — the count is display-only.** Rendering a live "N attached" count
+means *something* must track how many agents are currently live in the run.
+That tracking is **purely for display** (footer + `moat list`) and explicitly
+does **not** drive teardown — the lifecycle stays "the original agent owns the
+container" (Decision 2). We deliberately do not turn this into reference-counted
+teardown.
+
+Mechanism (implementation detail, to settle in the plan): a lightweight
+attached-agent registry, e.g. one entry per live agent under the run directory
+(`<run-dir>/agents/`) written on join and removed on exit, with pid-based
+liveness so a crashed join can be pruned rather than inflating the count.
+A daemon-tracked counter is the alternative; if used, the daemon API change must
+be additive-only to preserve the backwards-compatibility contract. For a display
+count, occasional staleness is tolerable.
+
+## Architecture
+
+### New command: `cmd/moat/cli/join_cmd.go`
+
+`moat join <run> <agent> [agent flags…]`:
+
+1. Resolve the run (reuse `resolveRunArgSingle`, same as `exec`). Require
+   `StateRunning`.
+2. Look up the agent provider by name (`"claude"` → claude provider) from the
+   provider registry (the same registry that backs `moat claude`).
+3. **Verify the run has that provider configured** (see Scope). If not, error.
+4. Ask the provider for the in-container command line for a *join* — the same
+   `["claude", "--dangerously-skip-permissions", …]` construction the create
+   path produces, honoring the shared agent flags (`--continue`, `--resume`,
+   `--prompt`, …). No host staging dir, no mounts — config already lives in the
+   container.
+5. Allocate a per-join index, open its console stream, and run the agent via an
+   **interactive exec** (below), teeing console to that stream.
+
+`join` never enters `manager.Create`.
+
+### New runtime capability: interactive (PTY-backed) exec
+
+The principal new piece of plumbing. Today:
+
+- `Runtime.Exec(ctx, id, cmd, stdin []byte, stdout, stderr io.Writer)` is
+  **non-interactive** — fixed stdin buffer, no PTY. Fine for a headless
+  (`--prompt`) join.
+- TTY support (`AttachOptions{TTY, InitialWidth/Height}`, `ResizeTTY`) exists
+  only for the container's **main** process via `StartAttached`, not for exec.
+
+claude is a TUI, so an interactive join needs a `docker exec -it` equivalent:
+raw-mode stdin streaming + a PTY + resize. Add an interactive exec variant to
+the `Runtime` interface, implemented for both Docker and Apple backends, e.g.:
+
+```go
+// ExecInteractive runs a command inside a running container with a PTY,
+// streaming the caller's stdin/stdout and honoring terminal resizes.
+ExecInteractive(ctx context.Context, id string, cmd []string, opts ExecOptions) error
+```
+
+where `ExecOptions` carries the attached streams, `TTY bool`, and initial
+width/height (parallel to `AttachOptions`). The existing `Exec` is reused
+unchanged for headless joins.
+
+### Manager method
+
+A `manager.Join` (or `manager.ExecInteractive`) method that:
+
+- validates run state and provider configuration,
+- resolves the runtime via the existing `runtimeForRun`,
+- opens the per-join console writer,
+- registers a live attached-agent entry for the run (display-only count, see
+  Decision 5) and removes it when the join exits,
+- delegates to `Runtime.ExecInteractive` (interactive) or `Runtime.Exec`
+  (headless),
+- records the join to the audit store (the network/audit interleaving is already
+  automatic via the shared token).
+
+### What is explicitly *not* touched
+
+- No `Create` path changes.
+- No image build, mounts, or proxy registration for a join.
+- No daemon API changes (the shared proxy token already covers the joined
+  agent). This preserves the daemon backwards-compatibility contract.
+
+## Error handling
+
+| Situation                                  | Behavior                                                              |
+| ------------------------------------------ | -------------------------------------------------------------------- |
+| Run not found                              | Reuse `exec`'s resolution error.                                     |
+| Run not `StateRunning`                     | Clear error: run is `<state>`; can only join a running run.          |
+| Unknown agent name                         | Clear error listing known agents.                                    |
+| Agent not configured in the run (v1 scope) | Clear error pointing at the deferred cross-provider path.            |
+| Interactive join without a TTY (piped)     | Fall back to headless `Exec`, or require `--prompt`; error if neither.|
+
+## Testing
+
+- **Unit:** `join` command arg parsing (run + agent + passthrough flags);
+  provider lookup and "provider not configured in run" rejection; in-container
+  command construction matches the create path for the same flags.
+- **Interactive exec (runtime):** Docker and Apple `ExecInteractive` —
+  PTY allocation, resize propagation, exit-code surfacing via `ExecError`.
+  Mirror existing `Exec` tests.
+- **Observability:** a join writes its own console stream (split), while
+  network/audit events land in the run's single `network.jsonl` / audit chain
+  (interleaved). Assert no child-run registry entry is created.
+- **Status footer / count:** the attached-agent registry increments on join and
+  decrements on exit; the primary footer and `moat list` reflect the live count;
+  a crashed join (dead pid) is pruned rather than inflating the count; the count
+  does not affect container teardown.
+- **E2E (`-tags=e2e`):** start `moat claude`, `moat join <run> claude --prompt`,
+  assert the second agent runs in the same container (shared workspace, no new
+  container created, no new proxy registration) and the run still tears down
+  when the original agent exits.
+
+## Future extensions (out of scope for v1)
+
+- **Multi-agent provisioning at create time.** The clean path to cross-provider
+  join is *not* hot-patching a live container — it is letting a run be created
+  with multiple agents configured up front (e.g. `deps: [claude, codex]` or an
+  agent list in `moat.yaml`). Both providers' configs are materialized and both
+  grant sets are added to the run's proxy context at create time, so
+  `moat join <run> codex` "just works." This is the preferred direction over
+  runtime config/grant injection.
+- **Container-side worktree for joins (`moat join … --wt`).** By default a join
+  shares the primary agent's working directory, so two agents can contend over
+  one git working tree. Today's `--wt` solves this contention *host-side* — it
+  creates an isolated git worktree (new branch + directory) on the host and
+  mounts it as the workspace before the container starts. A join can't add a host
+  mount to a running container, so the analogue is a **container-side** worktree:
+  on join, run `git worktree add` *inside* the container to give the joined agent
+  its own branch and working directory within the same repo, isolated from the
+  primary's tree. Cleanup prunes the in-container worktree when the join exits
+  (and via `moat clean`). Mirrors `--wt`'s isolation without a new mount.
+- **Persistent / session container.** A container whose lifecycle is independent
+  of any single agent (explicit teardown, or reference-counted "last one out").
+  Would make the original agent no longer special.
+- **Per-join durable console addressing in the UI** (`moat logs <run> --agent N`,
+  nested `moat list` display) if the per-join index proves worth surfacing more
+  richly.
+```

--- a/docs/plans/2026-06-16-multi-agent-join-plan.md
+++ b/docs/plans/2026-06-16-multi-agent-join-plan.md
@@ -1,0 +1,1628 @@
+# Multi-agent join (`moat join`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `moat join <run> <agent>` — launch a second agent inside an already-running container, reusing its workspace, grants, config, and proxy credential context, with no new container or proxy registration.
+
+**Architecture:** `join` is the run-first sibling of `exec` (`join : exec :: claude : run`). It resolves a running run, looks up the agent provider, validates the run was created by that provider, builds the in-container command, and runs it through a new **PTY-backed interactive exec** on the container `Runtime` (the `docker exec -it` equivalent — today's `Exec` is non-interactive). Joined agents are exec children, so the original agent keeps owning the container lifecycle (Decision 2 of the design). Observability is hybrid: console split per agent, network/audit interleaved automatically via the shared proxy token. The status footer gains a session role/count.
+
+**Tech Stack:** Go, Cobra CLI, Docker SDK (`github.com/docker/docker/client`), Apple `container` CLI + `github.com/creack/pty`, `golang.org/x/term`.
+
+**Design doc:** `docs/plans/2026-06-16-multi-agent-join-design.md`
+
+**Scope (v1):** same-provider join only (claude into a claude run). Cross-provider, container-side worktree, and persistent sessions are deferred (see design doc "Future extensions").
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/container/exec_options.go` — `ExecOptions` and `TTYSize` types for interactive exec.
+- `cmd/moat/cli/join_cmd.go` — the `moat join` command + interactive/headless join loops.
+- `internal/run/joined.go` — filesystem-backed attached-agent registry (display-only count).
+- `internal/run/joined_test.go` — registry unit tests.
+- `internal/e2e/join_test.go` — E2E test for an interactive + headless join (requires a container runtime).
+
+**Modify:**
+- `internal/container/runtime.go` — add `ExecInteractive` to the `Runtime` interface.
+- `internal/container/docker.go` — implement `DockerRuntime.ExecInteractive`.
+- `internal/container/apple.go` — implement `AppleRuntime.ExecInteractive`.
+- `internal/provider/interfaces.go` — add the optional `JoinableAgent` interface + `JoinOpts`.
+- `internal/providers/claude/cli.go` (or a new `internal/providers/claude/join.go`) — implement `JoinableAgent` on the claude provider.
+- `internal/run/manager.go` — add `Manager.ExecInteractive` + attached-count accessors.
+- `internal/tui/statusbar.go` — add session role/count fields + rendering.
+- `internal/tui/statusbar_test.go` — footer rendering tests.
+- `docs/content/reference/01-cli.md`, `docs/content/guides/*`, `CHANGELOG.md` — docs.
+
+---
+
+## Phase A — Runtime: PTY-backed interactive exec
+
+### Task A1: Define `ExecOptions`/`TTYSize` and add `ExecInteractive` to the Runtime interface
+
+**Files:**
+- Create: `internal/container/exec_options.go`
+- Modify: `internal/container/runtime.go` (interface, after the `Exec` method at line ~143)
+- Modify: `internal/container/docker.go`, `internal/container/apple.go` (temporary stubs so the package compiles)
+
+- [ ] **Step 1: Write the new option types**
+
+Create `internal/container/exec_options.go`:
+
+```go
+package container
+
+import "io"
+
+// TTYSize is a terminal dimension update for an interactive exec session.
+type TTYSize struct {
+	Width  uint
+	Height uint
+}
+
+// ExecOptions configures an interactive (PTY-backed) exec session.
+// It mirrors AttachOptions but targets an exec'd process rather than the
+// container's main process, and carries a Resize channel so the caller can
+// propagate SIGWINCH to this specific exec session (a container may have many).
+type ExecOptions struct {
+	Stdin  io.Reader // forwarded to the exec'd process
+	Stdout io.Writer // receives the exec'd process output
+	Stderr io.Writer // receives stderr (ignored in TTY mode, where it merges into Stdout)
+	TTY    bool      // allocate a PTY (raw terminal) for the exec
+
+	// InitialWidth/InitialHeight size the PTY before the process queries it.
+	InitialWidth  uint
+	InitialHeight uint
+
+	// Resize, if non-nil, delivers terminal size changes for this exec session.
+	// The runtime applies each value until the channel is closed or the exec ends.
+	Resize <-chan TTYSize
+}
+```
+
+- [ ] **Step 2: Add the method to the `Runtime` interface**
+
+In `internal/container/runtime.go`, immediately after the `Exec(...)` method (line ~143), add:
+
+```go
+	// ExecInteractive runs a command inside a running container with a PTY,
+	// streaming opts.Stdin/Stdout and applying terminal resizes from opts.Resize.
+	// Use this for interactive TUI agents joined into an existing container.
+	// Returns *ExecError for non-zero exit codes.
+	ExecInteractive(ctx context.Context, id string, cmd []string, opts ExecOptions) error
+```
+
+- [ ] **Step 3: Add temporary stubs so both runtimes still satisfy the interface**
+
+In `internal/container/docker.go`, add:
+
+```go
+// ExecInteractive runs a command inside a running container with a PTY.
+func (r *DockerRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
+	return fmt.Errorf("not implemented")
+}
+```
+
+In `internal/container/apple.go`, add:
+
+```go
+// ExecInteractive runs a command inside a running container with a PTY.
+func (r *AppleRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
+	return fmt.Errorf("not implemented")
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `go build ./internal/container/...`
+Expected: builds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/container/exec_options.go internal/container/runtime.go internal/container/docker.go internal/container/apple.go
+git commit -m "feat(container): add ExecInteractive to Runtime interface (stubs)"
+```
+
+---
+
+### Task A2: Implement `DockerRuntime.ExecInteractive`
+
+**Files:**
+- Modify: `internal/container/docker.go` (replace the stub from A1)
+- Test: `internal/e2e/join_test.go` (E2E — added in Task D-final; logic verified here by build + the existing exec patterns)
+
+Mirror `DockerRuntime.Exec` (exec create/attach/inspect) but with `Tty: true` and the raw TTY copy loop from `StartAttached`.
+
+- [ ] **Step 1: Replace the stub with the real implementation**
+
+```go
+// ExecInteractive runs a command inside a running container with a PTY.
+func (r *DockerRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
+	execCfg := container.ExecOptions{
+		Cmd:          cmd,
+		User:         "moatuser",
+		Tty:          opts.TTY,
+		AttachStdin:  opts.Stdin != nil,
+		AttachStdout: true,
+		AttachStderr: !opts.TTY, // in TTY mode stderr is merged into stdout
+	}
+
+	execID, err := r.cli.ContainerExecCreate(ctx, containerID, execCfg)
+	if err != nil {
+		return fmt.Errorf("creating exec: %w", err)
+	}
+
+	resp, err := r.cli.ContainerExecAttach(ctx, execID.ID, container.ExecAttachOptions{Tty: opts.TTY})
+	if err != nil {
+		return fmt.Errorf("attaching to exec: %w", err)
+	}
+	defer resp.Close()
+
+	// Apply the initial size before output starts, then service resizes.
+	if opts.TTY && opts.InitialWidth > 0 && opts.InitialHeight > 0 {
+		_ = r.cli.ContainerExecResize(ctx, execID.ID, container.ResizeOptions{
+			Height: opts.InitialHeight,
+			Width:  opts.InitialWidth,
+		})
+	}
+	if opts.TTY && opts.Resize != nil {
+		go func() {
+			for size := range opts.Resize {
+				if size.Width == 0 || size.Height == 0 {
+					continue
+				}
+				_ = r.cli.ContainerExecResize(ctx, execID.ID, container.ResizeOptions{
+					Height: size.Height,
+					Width:  size.Width,
+				})
+			}
+		}()
+	}
+
+	outputDone := make(chan error, 1)
+	go func() {
+		if opts.TTY {
+			// TTY mode is a single raw stream.
+			_, copyErr := io.Copy(opts.Stdout, resp.Reader)
+			outputDone <- copyErr
+		} else {
+			_, copyErr := stdcopy.StdCopy(opts.Stdout, opts.Stderr, resp.Reader)
+			outputDone <- copyErr
+		}
+	}()
+
+	if opts.Stdin != nil {
+		go func() {
+			_, _ = io.Copy(resp.Conn, opts.Stdin)
+			if cw, ok := resp.Conn.(interface{ CloseWrite() error }); ok {
+				_ = cw.CloseWrite()
+			}
+		}()
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case copyErr := <-outputDone:
+		if copyErr != nil && copyErr != io.EOF {
+			return copyErr
+		}
+	}
+
+	inspect, err := r.cli.ContainerExecInspect(ctx, execID.ID)
+	if err != nil {
+		return fmt.Errorf("inspecting exec: %w", err)
+	}
+	if inspect.ExitCode != 0 {
+		return &ExecError{ExitCode: inspect.ExitCode}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./internal/container/...`
+Expected: builds clean. (`stdcopy` and `container` are already imported by docker.go — confirm; if `go build` complains about an unused import it means stdcopy was only used here, which is not the case since `Exec` uses it.)
+
+- [ ] **Step 3: Vet**
+
+Run: `go vet ./internal/container/...`
+Expected: no findings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/container/docker.go
+git commit -m "feat(container): implement DockerRuntime.ExecInteractive (PTY exec)"
+```
+
+---
+
+### Task A3: Implement `AppleRuntime.ExecInteractive`
+
+**Files:**
+- Modify: `internal/container/apple.go` (replace the stub from A1)
+
+Mirror `startAttachedWithPTY`: shell out to `container exec -t -i --user moatuser <id> <cmd>` under a `pty.Start`, copy streams, resize the local PTY from `opts.Resize`, and surface the exit code via the existing `exitError` helper.
+
+- [ ] **Step 1: Replace the stub with the real implementation**
+
+```go
+// ExecInteractive runs a command inside a running container with a PTY.
+func (r *AppleRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
+	if !opts.TTY {
+		// Non-TTY interactive exec: stream stdin/stdout without a PTY.
+		args := append([]string{"exec", "--user", "moatuser", "-i", containerID}, cmd...)
+		c := exec.CommandContext(ctx, r.containerBin, args...)
+		c.Stdin = opts.Stdin
+		c.Stdout = opts.Stdout
+		c.Stderr = opts.Stderr
+		if err := c.Run(); err != nil {
+			return exitError(err)
+		}
+		return nil
+	}
+
+	args := append([]string{"exec", "-t", "-i", "--user", "moatuser", containerID}, cmd...)
+	c := exec.CommandContext(ctx, r.containerBin, args...)
+
+	ptmx, err := pty.Start(c)
+	if err != nil {
+		return fmt.Errorf("starting exec with pty: %w", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	// Initial size, then service resizes for this exec's PTY directly (no shared map).
+	if opts.InitialWidth > 0 && opts.InitialHeight > 0 {
+		_ = pty.Setsize(ptmx, &pty.Winsize{
+			Rows: uint16(opts.InitialHeight), // #nosec G115
+			Cols: uint16(opts.InitialWidth),  // #nosec G115
+		})
+	}
+	if opts.Resize != nil {
+		go func() {
+			for size := range opts.Resize {
+				if size.Width == 0 || size.Height == 0 {
+					continue
+				}
+				_ = pty.Setsize(ptmx, &pty.Winsize{
+					Rows: uint16(size.Height), // #nosec G115
+					Cols: uint16(size.Width),  // #nosec G115
+				})
+			}
+		}()
+	}
+
+	if opts.Stdin != nil {
+		go func() { _, _ = io.Copy(ptmx, opts.Stdin) }()
+	}
+	outputDone := make(chan struct{})
+	go func() {
+		defer close(outputDone)
+		_, _ = io.Copy(opts.Stdout, ptmx)
+	}()
+
+	cmdDone := make(chan error, 1)
+	go func() { cmdDone <- c.Wait() }()
+
+	select {
+	case <-ctx.Done():
+		_ = ptmx.Close()
+		if c.Process != nil {
+			_ = c.Process.Kill()
+		}
+		<-cmdDone
+		return ctx.Err()
+	case werr := <-cmdDone:
+		// Drain output briefly so nothing is lost on fast exit.
+		select {
+		case <-outputDone:
+		case <-time.After(2 * time.Second):
+			_ = ptmx.Close()
+			<-outputDone
+		}
+		if werr != nil {
+			return exitError(werr)
+		}
+		return nil
+	}
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./internal/container/...`
+Expected: builds clean. (`exec`, `io`, `time`, `pty` are already imported by apple.go.)
+
+- [ ] **Step 3: Vet**
+
+Run: `go vet ./internal/container/...`
+Expected: no findings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/container/apple.go
+git commit -m "feat(container): implement AppleRuntime.ExecInteractive (PTY exec)"
+```
+
+---
+
+## Phase B — Manager: interactive exec + attached-agent registry
+
+### Task B1: Filesystem-backed attached-agent registry
+
+**Files:**
+- Create: `internal/run/joined.go`
+- Test: `internal/run/joined_test.go`
+
+A join is a separate process from the primary, so the count must be shared on disk under the run directory. Entries are named by pid; liveness is checked with `syscall.Kill(pid, 0)` so a crashed join is pruned instead of inflating the count. **Display-only — never used for teardown.**
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/run/joined_test.go`:
+
+```go
+package run
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAttachedAgents_RegisterCountRelease(t *testing.T) {
+	t.Setenv("MOAT_HOME", t.TempDir())
+	const runID = "run_test_join"
+
+	if got := attachedCount(runID); got != 0 {
+		t.Fatalf("initial count = %d, want 0", got)
+	}
+
+	idx1, release1, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 1: %v", err)
+	}
+	if idx1 != 1 {
+		t.Fatalf("first index = %d, want 1", idx1)
+	}
+	if got := attachedCount(runID); got != 1 {
+		t.Fatalf("count after 1 register = %d, want 1", got)
+	}
+
+	idx2, release2, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 2: %v", err)
+	}
+	if idx2 != 2 {
+		t.Fatalf("second index = %d, want 2", idx2)
+	}
+	if got := attachedCount(runID); got != 2 {
+		t.Fatalf("count after 2 registers = %d, want 2", got)
+	}
+
+	release1()
+	if got := attachedCount(runID); got != 1 {
+		t.Fatalf("count after 1 release = %d, want 1", got)
+	}
+	release2()
+	if got := attachedCount(runID); got != 0 {
+		t.Fatalf("count after 2 releases = %d, want 0", got)
+	}
+}
+
+func TestAttachedAgents_PrunesDeadPid(t *testing.T) {
+	t.Setenv("MOAT_HOME", t.TempDir())
+	const runID = "run_test_join_dead"
+
+	dir := attachedAgentsDir(runID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A pid that is essentially never alive.
+	if err := os.WriteFile(dir+"/999999", []byte("999999"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := attachedCount(runID); got != 0 {
+		t.Fatalf("count with only a dead pid = %d, want 0 (pruned)", got)
+	}
+	if _, err := os.Stat(dir + "/999999"); !os.IsNotExist(err) {
+		t.Fatalf("dead pid entry should have been pruned")
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./internal/run/ -run TestAttachedAgents -v`
+Expected: FAIL — `undefined: attachedCount` / `registerJoinedAgent` / `attachedAgentsDir`.
+
+- [ ] **Step 3: Implement the registry**
+
+Create `internal/run/joined.go`:
+
+```go
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"syscall"
+
+	"github.com/majorcontext/moat/internal/storage"
+)
+
+// attachedAgentsDir is where per-join liveness entries live for a run.
+// One file per live joined agent, named by its pid.
+func attachedAgentsDir(runID string) string {
+	return filepath.Join(storage.DefaultBaseDir(), runID, "agents")
+}
+
+// pidAlive reports whether the given pid is a live process.
+func pidAlive(pid int) bool {
+	// Signal 0 performs error checking without actually sending a signal.
+	return syscall.Kill(pid, 0) == nil
+}
+
+// registerJoinedAgent records a live joined agent for the run and returns its
+// 1-based index (the count after registration) plus a release func that removes
+// the entry. The count is for display only; it never affects teardown.
+func registerJoinedAgent(runID string) (index int, release func(), err error) {
+	dir := attachedAgentsDir(runID)
+	if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+		return 0, nil, mkErr
+	}
+	pid := os.Getpid()
+	entry := filepath.Join(dir, strconv.Itoa(pid))
+	if wErr := os.WriteFile(entry, []byte(strconv.Itoa(pid)), 0o600); wErr != nil {
+		return 0, nil, wErr
+	}
+	release = func() { _ = os.Remove(entry) }
+	return attachedCount(runID), release, nil
+}
+
+// attachedCount returns the number of live joined agents for the run, pruning
+// entries whose pid is no longer alive.
+func attachedCount(runID string) int {
+	dir := attachedAgentsDir(runID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	// Deterministic order keeps index assignment stable in tests.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	live := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		pid, convErr := strconv.Atoi(e.Name())
+		if convErr != nil {
+			continue
+		}
+		if pidAlive(pid) {
+			live++
+		} else {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+	return live
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/run/ -run TestAttachedAgents -v`
+Expected: PASS for both tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/run/joined.go internal/run/joined_test.go
+git commit -m "feat(run): filesystem-backed attached-agent registry (display-only)"
+```
+
+---
+
+### Task B2: `Manager.ExecInteractive` and count accessor
+
+**Files:**
+- Modify: `internal/run/manager.go` (add after `Exec`, ~line 3886)
+- Test: `internal/run/manager_join_test.go` (new — validation paths only, no container)
+
+- [ ] **Step 1: Write the failing test (validation paths)**
+
+Create `internal/run/manager_join_test.go`:
+
+```go
+package run
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/container"
+)
+
+func TestManagerExecInteractive_RunNotFound(t *testing.T) {
+	m := &Manager{runs: map[string]*Run{}}
+	err := m.ExecInteractive(context.Background(), "run_missing", []string{"claude"}, container.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got %v, want a 'not found' error", err)
+	}
+}
+
+func TestManagerExecInteractive_NotRunning(t *testing.T) {
+	r := &Run{ID: "run_stopped", State: StateStopped}
+	m := &Manager{runs: map[string]*Run{"run_stopped": r}}
+	err := m.ExecInteractive(context.Background(), "run_stopped", []string{"claude"}, container.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("got %v, want a 'not running' error", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./internal/run/ -run TestManagerExecInteractive -v`
+Expected: FAIL — `m.ExecInteractive undefined`.
+
+- [ ] **Step 3: Implement `ExecInteractive` and `AttachedCount`**
+
+In `internal/run/manager.go`, after the `Exec` method, add:
+
+```go
+// ExecInteractive runs a command inside a running container with a PTY,
+// streaming the provided opts. Used by `moat join` for interactive agents.
+func (m *Manager) ExecInteractive(ctx context.Context, runID string, cmd []string, opts container.ExecOptions) error {
+	m.mu.RLock()
+	r, ok := m.runs[runID]
+	if !ok {
+		m.mu.RUnlock()
+		return fmt.Errorf("run %s not found", runID)
+	}
+	containerID := r.ContainerID
+	auditStore := r.AuditStore
+	state := r.GetState()
+	m.mu.RUnlock()
+
+	if state != StateRunning {
+		return fmt.Errorf("run %s is not running (state: %s)", runID, state)
+	}
+
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+
+	execErr := rt.ExecInteractive(ctx, containerID, cmd, opts)
+
+	if auditStore != nil {
+		exitCode := 0
+		var ee *container.ExecError
+		if errors.As(execErr, &ee) {
+			exitCode = ee.ExitCode
+		}
+		_, _ = auditStore.AppendExec(audit.ExecData{
+			Command:  cmd,
+			HasStdin: opts.Stdin != nil,
+			ExitCode: exitCode,
+		})
+	}
+	return execErr
+}
+
+// AttachedCount returns the number of live joined agents for a run (display-only).
+func (m *Manager) AttachedCount(runID string) int {
+	return attachedCount(runID)
+}
+
+// RegisterJoinedAgent records a joined agent for a run and returns its index and
+// a release func. Display-only; never affects teardown.
+func (m *Manager) RegisterJoinedAgent(runID string) (int, func(), error) {
+	return registerJoinedAgent(runID)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/run/ -run TestManagerExecInteractive -v`
+Expected: PASS for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/run/manager.go internal/run/manager_join_test.go
+git commit -m "feat(run): Manager.ExecInteractive + attached-agent accessors"
+```
+
+---
+
+## Phase C — Provider: joinable agent contract + claude implementation
+
+### Task C1: Add the optional `JoinableAgent` interface
+
+**Files:**
+- Modify: `internal/provider/interfaces.go` (add near `AgentProvider`, line ~93)
+
+- [ ] **Step 1: Add the interface and options type**
+
+```go
+// JoinOpts carries the parsed flags for a joined agent session.
+type JoinOpts struct {
+	Continue bool
+	Resume   string
+	Prompt   string
+}
+
+// JoinableAgent is implemented by agent providers that support `moat join` —
+// launching a second instance of the agent into an existing run's container.
+// It is optional: providers that don't implement it cannot be joined.
+type JoinableAgent interface {
+	// JoinCommand returns the in-container command to launch a joined session.
+	JoinCommand(opts JoinOpts) ([]string, error)
+
+	// IdentifiesAs reports whether a run whose recorded Agent field is `agent`
+	// was created by this provider. This absorbs the difference between the
+	// default provider name ("claude") and an explicit moat.yaml agent value
+	// ("claude-code").
+	IdentifiesAs(agent string) bool
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./internal/provider/...`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/provider/interfaces.go
+git commit -m "feat(provider): add optional JoinableAgent interface"
+```
+
+---
+
+### Task C2: Implement `JoinableAgent` on the claude provider
+
+**Files:**
+- Create: `internal/providers/claude/join.go`
+- Test: `internal/providers/claude/join_test.go`
+
+The in-container command mirrors the `BuildCommand` closure in `runClaudeCode` (`cli.go`): `claude --dangerously-skip-permissions [--continue] [--resume <id>] [-p <prompt>]`. v1 keeps it simple — no `--resume` session-id translation (the raw id is passed through; that translation is a host-side convenience in the create path).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/providers/claude/join_test.go`:
+
+```go
+package claude
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+func TestOAuthProvider_JoinCommand(t *testing.T) {
+	p := &OAuthProvider{}
+
+	tests := []struct {
+		name string
+		opts provider.JoinOpts
+		want []string
+	}{
+		{
+			name: "bare",
+			opts: provider.JoinOpts{},
+			want: []string{"claude", "--dangerously-skip-permissions"},
+		},
+		{
+			name: "continue",
+			opts: provider.JoinOpts{Continue: true},
+			want: []string{"claude", "--dangerously-skip-permissions", "--continue"},
+		},
+		{
+			name: "resume",
+			opts: provider.JoinOpts{Resume: "abc123"},
+			want: []string{"claude", "--dangerously-skip-permissions", "--resume", "abc123"},
+		},
+		{
+			name: "prompt",
+			opts: provider.JoinOpts{Prompt: "hi"},
+			want: []string{"claude", "--dangerously-skip-permissions", "-p", "hi"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.JoinCommand(tt.opts)
+			if err != nil {
+				t.Fatalf("JoinCommand: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("JoinCommand = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOAuthProvider_IdentifiesAs(t *testing.T) {
+	p := &OAuthProvider{}
+	for _, agent := range []string{"claude", "claude-code"} {
+		if !p.IdentifiesAs(agent) {
+			t.Errorf("IdentifiesAs(%q) = false, want true", agent)
+		}
+	}
+	for _, agent := range []string{"codex", "gemini", ""} {
+		if p.IdentifiesAs(agent) {
+			t.Errorf("IdentifiesAs(%q) = true, want false", agent)
+		}
+	}
+}
+
+// Compile-time assertion that the provider satisfies JoinableAgent.
+var _ provider.JoinableAgent = (*OAuthProvider)(nil)
+```
+
+> NOTE: confirm the concrete claude provider type name is `OAuthProvider` (it is, per `cli.go`'s `func (p *OAuthProvider) RegisterCLI`). If a constructor is required to make a usable value, use it; `JoinCommand`/`IdentifiesAs` must not depend on unset fields.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./internal/providers/claude/ -run 'TestOAuthProvider_(JoinCommand|IdentifiesAs)' -v`
+Expected: FAIL — `p.JoinCommand undefined` / `p.IdentifiesAs undefined`.
+
+- [ ] **Step 3: Implement the methods**
+
+Create `internal/providers/claude/join.go`:
+
+```go
+package claude
+
+import "github.com/majorcontext/moat/internal/provider"
+
+// JoinCommand builds the in-container command for a joined claude session.
+// Mirrors the BuildCommand closure in runClaudeCode (cli.go). Joined sessions
+// always run with --dangerously-skip-permissions, matching the create-path
+// default (the container provides isolation).
+func (p *OAuthProvider) JoinCommand(opts provider.JoinOpts) ([]string, error) {
+	cmd := []string{"claude", "--dangerously-skip-permissions"}
+	if opts.Continue {
+		cmd = append(cmd, "--continue")
+	}
+	if opts.Resume != "" {
+		cmd = append(cmd, "--resume", opts.Resume)
+	}
+	if opts.Prompt != "" {
+		cmd = append(cmd, "-p", opts.Prompt)
+	}
+	return cmd, nil
+}
+
+// IdentifiesAs reports whether a run with the given recorded Agent field was
+// created by the claude provider. cfg.Agent defaults to the provider name
+// ("claude") but is "claude-code" when set explicitly in moat.yaml.
+func (p *OAuthProvider) IdentifiesAs(agent string) bool {
+	return agent == "claude" || agent == "claude-code"
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/providers/claude/ -run 'TestOAuthProvider_(JoinCommand|IdentifiesAs)' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/providers/claude/join.go internal/providers/claude/join_test.go
+git commit -m "feat(claude): implement JoinableAgent (JoinCommand + IdentifiesAs)"
+```
+
+---
+
+## Phase D — CLI: the `moat join` command
+
+### Task D1: Command skeleton + run/provider resolution + validation
+
+**Files:**
+- Create: `cmd/moat/cli/join_cmd.go`
+- Test: `cmd/moat/cli/join_cmd_test.go`
+
+- [ ] **Step 1: Write the failing test (pure validation helper)**
+
+Create `cmd/moat/cli/join_cmd_test.go`:
+
+```go
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+// fakeJoinable implements provider.JoinableAgent for validation tests.
+type fakeJoinable struct{ identifies bool }
+
+func (f fakeJoinable) JoinCommand(provider.JoinOpts) ([]string, error) { return []string{"x"}, nil }
+func (f fakeJoinable) IdentifiesAs(string) bool                        { return f.identifies }
+
+func TestValidateJoinAgent_OK(t *testing.T) {
+	if err := validateJoinAgent(fakeJoinable{identifies: true}, "claude", "claude-code"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateJoinAgent_WrongProvider(t *testing.T) {
+	err := validateJoinAgent(fakeJoinable{identifies: false}, "codex", "claude-code")
+	if err == nil || !strings.Contains(err.Error(), "no codex configuration") {
+		t.Fatalf("got %v, want a clear 'no codex configuration' error", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./cmd/moat/cli/ -run TestValidateJoinAgent -v`
+Expected: FAIL — `validateJoinAgent undefined`.
+
+- [ ] **Step 3: Implement the command + helper**
+
+Create `cmd/moat/cli/join_cmd.go`:
+
+```go
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/provider"
+	"github.com/majorcontext/moat/internal/run"
+	"github.com/majorcontext/moat/internal/term"
+)
+
+var (
+	joinContinue bool
+	joinResume   string
+	joinPrompt   string
+)
+
+var joinCmd = &cobra.Command{
+	Use:   "join <run> <agent> [flags]",
+	Short: "Launch another agent inside a running container",
+	Long: `Launch a second agent inside an already-running container, reusing its
+workspace, grants, and credentials — without creating a new container.
+
+The agent must match the one the run was started with (v1 supports same-agent
+joins, e.g. joining claude into a run started by 'moat claude').
+
+Examples:
+  moat join run_a1b2c3d4e5f6 claude
+  moat join my-feature claude --continue
+  moat join run_a1b2c3d4e5f6 claude -p "summarize the diff"`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runJoin,
+}
+
+func init() {
+	joinCmd.Flags().BoolVarP(&joinContinue, "continue", "c", false, "continue the most recent conversation")
+	joinCmd.Flags().StringVarP(&joinResume, "resume", "r", "", "resume a specific session by ID")
+	joinCmd.Flags().StringVarP(&joinPrompt, "prompt", "p", "", "run with prompt (non-interactive)")
+	rootCmd.AddCommand(joinCmd)
+}
+
+// validateJoinAgent checks that the run (whose recorded agent field is runAgent)
+// was created by the requested provider. agentArg is the user-typed agent name,
+// used only for the error message.
+func validateJoinAgent(j provider.JoinableAgent, agentArg, runAgent string) error {
+	if !j.IdentifiesAs(runAgent) {
+		return fmt.Errorf("run has no %s configuration.\n"+
+			"v1 join only attaches an agent the run was started with (run agent: %q).\n"+
+			"To run %s here, start the run with %s configured.",
+			agentArg, runAgent, agentArg, agentArg)
+	}
+	return nil
+}
+
+func runJoin(cmd *cobra.Command, args []string) error {
+	if joinContinue && joinResume != "" {
+		return fmt.Errorf("--continue and --resume are mutually exclusive")
+	}
+
+	runArg := args[0]
+	agentArg := args[1]
+
+	manager, err := run.NewManager()
+	if err != nil {
+		return fmt.Errorf("creating run manager: %w", err)
+	}
+	defer manager.Close()
+
+	runID, err := resolveRunArgSingle(manager, runArg)
+	if err != nil {
+		return err
+	}
+
+	r, gErr := manager.Get(runID)
+	if gErr != nil {
+		return gErr
+	}
+	if r.GetState() != run.StateRunning {
+		return fmt.Errorf("run %s is not running (state: %s)", runID, r.GetState())
+	}
+
+	agent := provider.GetAgent(agentArg)
+	if agent == nil {
+		return fmt.Errorf("unknown agent %q", agentArg)
+	}
+	joinable, ok := agent.(provider.JoinableAgent)
+	if !ok {
+		return fmt.Errorf("agent %q does not support join yet", agentArg)
+	}
+	if err := validateJoinAgent(joinable, agentArg, r.Agent); err != nil {
+		return err
+	}
+
+	containerCmd, err := joinable.JoinCommand(provider.JoinOpts{
+		Continue: joinContinue,
+		Resume:   joinResume,
+		Prompt:   joinPrompt,
+	})
+	if err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+
+	// Headless (--prompt with no TTY) vs interactive.
+	if joinPrompt != "" || !term.IsTerminal(os.Stdin) || !term.IsTerminal(os.Stdout) {
+		execErr := manager.ExecInteractive(ctx, runID, containerCmd, container.ExecOptions{
+			Stdin:  nil,
+			Stdout: os.Stdout,
+			Stderr: os.Stderr,
+			TTY:    false,
+		})
+		return handleJoinExecErr(manager, execErr)
+	}
+
+	return runJoinInteractive(ctx, manager, r, containerCmd)
+}
+
+func handleJoinExecErr(manager *run.Manager, execErr error) error {
+	if execErr == nil {
+		return nil
+	}
+	var ee *container.ExecError
+	if errors.As(execErr, &ee) {
+		manager.Close()
+		os.Exit(ee.ExitCode)
+	}
+	return execErr
+}
+```
+
+> NOTE: add `"errors"` to imports (matches `exec_cmd.go`'s `errors.As` exit-code handling). `manager.Get(runID)` returns `(*Run, error)`. `runJoinInteractive` is implemented in Task D2; to keep this task compiling, add a temporary stub at the bottom of the file:
+>
+> ```go
+> func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, cmd []string) error {
+> 	return fmt.Errorf("interactive join not implemented")
+> }
+> ```
+>
+> `manager.Get(runID)` is confirmed at `internal/run/manager.go:3362` with signature `Get(runID string) (*Run, error)`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./cmd/moat/cli/ -run TestValidateJoinAgent -v`
+Expected: PASS.
+
+- [ ] **Step 5: Build the whole CLI**
+
+Run: `go build ./cmd/...`
+Expected: builds clean (with the `runJoinInteractive` stub).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/moat/cli/join_cmd.go cmd/moat/cli/join_cmd_test.go
+git commit -m "feat(cli): moat join command — resolution, validation, headless path"
+```
+
+---
+
+### Task D2: Interactive join loop
+
+**Files:**
+- Modify: `cmd/moat/cli/join_cmd.go` (replace the `runJoinInteractive` stub)
+
+A trimmed version of `RunInteractiveAttached` (exec.go): raw mode, status footer, SIGWINCH → a resize channel feeding `container.ExecOptions.Resize`, and `manager.ExecInteractive` instead of `StartAttached`. Registers the join in the attached-agent registry for the footer count. No snapshot/trace/clipboard machinery in v1.
+
+- [ ] **Step 1: Replace the stub**
+
+```go
+func runJoinInteractive(ctx context.Context, manager *run.Manager, r *run.Run, command []string) error {
+	// Register this join for the display-only attached count.
+	index, release, err := manager.RegisterJoinedAgent(r.ID)
+	if err == nil {
+		defer release()
+	}
+
+	// Raw mode so keystrokes reach the agent unbuffered.
+	var rawState *term.RawModeState
+	if term.IsTerminal(os.Stdin) {
+		if rs, rErr := term.EnableRawMode(os.Stdin); rErr == nil {
+			rawState = rs
+		}
+	}
+	defer func() {
+		if rawState != nil {
+			_ = term.RestoreTerminal(rawState)
+		}
+	}()
+
+	// Status footer: this is a joined session.
+	statusWriter, statusCleanup, stdout := setupJoinStatusBar(manager, r, index)
+	defer statusCleanup()
+
+	// Resize channel fed by SIGWINCH; closed on exit so the runtime goroutine ends.
+	resize := make(chan container.TTYSize, 1)
+	var initialW, initialH uint
+	if term.IsTerminal(os.Stdout) {
+		if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
+			// Reserve the footer row.
+			ch := containerTTYHeight(statusWriter, h)
+			initialW, initialH = uint(w), uint(ch) // #nosec G115
+		}
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH)
+	defer signal.Stop(sigCh)
+
+	execCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		for sig := range sigCh {
+			if sig != syscall.SIGWINCH {
+				continue
+			}
+			if statusWriter != nil && term.IsTerminal(os.Stdout) {
+				if w, h := term.GetSize(os.Stdout); w > 0 && h > 0 {
+					_ = statusWriter.Resize(w, h)
+					ch := containerTTYHeight(statusWriter, h)
+					select {
+					case resize <- container.TTYSize{Width: uint(w), Height: uint(ch)}: // #nosec G115
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	execErr := manager.ExecInteractive(execCtx, r.ID, command, container.ExecOptions{
+		Stdin:         os.Stdin,
+		Stdout:        stdout,
+		Stderr:        os.Stderr,
+		TTY:           true,
+		InitialWidth:  initialW,
+		InitialHeight: initialH,
+		Resize:        resize,
+	})
+	close(resize)
+
+	if execErr != nil && ctx.Err() == nil {
+		var ee *container.ExecError
+		if errors.As(execErr, &ee) {
+			// Agent exited non-zero; surface it but don't treat as a moat error.
+			fmt.Printf("\r\nJoined agent exited (code %d)\r\n", ee.ExitCode)
+			return nil
+		}
+		return fmt.Errorf("join failed: %w", execErr)
+	}
+	fmt.Printf("\r\nJoined agent session ended\r\n")
+	return nil
+}
+```
+
+> NOTE: add imports `"os/signal"`, `"syscall"`, `"errors"`. `containerTTYHeight` already exists in `cmd/moat/cli/exec.go` (same package) — reuse it. `setupJoinStatusBar` is implemented in Task E2; to keep this task compiling, add a temporary stub:
+>
+> ```go
+> func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Writer, func(), io.Writer) {
+> 	return nil, func() {}, os.Stdout
+> }
+> ```
+> and add imports `"io"` and the `tui` package. (Task E2 replaces the stub with the real footer.)
+
+- [ ] **Step 2: Build**
+
+Run: `go build ./cmd/...`
+Expected: builds clean.
+
+- [ ] **Step 3: Vet**
+
+Run: `go vet ./cmd/...`
+Expected: no findings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/moat/cli/join_cmd.go
+git commit -m "feat(cli): interactive join loop (PTY, resize, footer hook)"
+```
+
+---
+
+## Phase E — Status footer: session role + count
+
+### Task E1: StatusBar session fields and rendering
+
+**Files:**
+- Modify: `internal/tui/statusbar.go`
+- Test: `internal/tui/statusbar_test.go`
+
+Add a session segment prepended to the right cluster (before run-id): primary shows `+N` only when N>0; joined shows `joined · N`. Color-accented; dropped late in the truncation cascade.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/tui/statusbar_test.go`:
+
+```go
+func TestStatusBar_SessionSegment(t *testing.T) {
+	// Joined session shows "joined · N" before the run-id.
+	bar := NewStatusBar("run_123", "happy-otter", "apple")
+	bar.SetDimensions(120, 24)
+	bar.SetSession("joined · 2")
+	out := stripANSI(bar.Content())
+	if !strings.Contains(out, "joined · 2") {
+		t.Fatalf("joined session segment missing: %q", out)
+	}
+	if strings.Index(out, "joined · 2") > strings.Index(out, "run_123") {
+		t.Fatalf("session segment should appear before the run-id: %q", out)
+	}
+
+	// Primary with joins shows "+2"; primary solo shows neither.
+	primary := NewStatusBar("run_123", "happy-otter", "apple")
+	primary.SetDimensions(120, 24)
+	primary.SetJoinedCount(2)
+	if !strings.Contains(stripANSI(primary.Content()), "+2") {
+		t.Fatalf("primary +2 count missing")
+	}
+
+	solo := NewStatusBar("run_123", "happy-otter", "apple")
+	solo.SetDimensions(120, 24)
+	if strings.Contains(stripANSI(solo.Content()), "+0") {
+		t.Fatalf("solo primary should not show a +0 count")
+	}
+}
+```
+
+> NOTE: if a `stripANSI` helper doesn't already exist in `statusbar_test.go`, add one:
+> ```go
+> func stripANSI(s string) string {
+> 	re := regexp.MustCompile("\x1b\\[[0-9;]*m")
+> 	return re.ReplaceAllString(s, "")
+> }
+> ```
+> with imports `"regexp"`, `"strings"`. Check the existing test file first — it likely already has a similar helper; reuse it rather than duplicating.
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `go test ./internal/tui/ -run TestStatusBar_SessionSegment -v`
+Expected: FAIL — `bar.SetSession undefined` / `bar.SetJoinedCount undefined`.
+
+- [ ] **Step 3: Implement the fields, setters, color, and rendering**
+
+In `internal/tui/statusbar.go`:
+
+(a) Add fields to the struct (after `warning string`):
+
+```go
+	session     string // explicit session role for a joined session, e.g. "joined · 2"
+	joinedCount int    // number of joined agents (shown as "+N" on the primary)
+```
+
+(b) Add a color constant (in the ANSI `const` block):
+
+```go
+	fgGreen = "\x1b[32m"
+```
+
+(c) Add setters (near `SetWarning`):
+
+```go
+// SetSession sets an explicit session-role label shown before the run-id
+// (e.g. "joined · 2"). Empty means a primary session.
+func (s *StatusBar) SetSession(label string) {
+	s.session = label
+}
+
+// SetJoinedCount sets the number of joined agents, rendered as "+N" before the
+// run-id on a primary session. Zero renders nothing.
+func (s *StatusBar) SetJoinedCount(n int) {
+	s.joinedCount = n
+}
+
+// sessionPlain returns the plain-text session segment (with a trailing space),
+// or "" when there is nothing to show.
+func (s *StatusBar) sessionPlain() string {
+	if s.session != "" {
+		return s.session + " "
+	}
+	if s.joinedCount > 0 {
+		return fmt.Sprintf("+%d ", s.joinedCount)
+	}
+	return ""
+}
+```
+
+(d) In `buildContent`, thread a `showSession` flag. Change the signature and the right-segment construction. Replace the right-segment plain build:
+
+```go
+	// Build right segment with optional hint
+	var rightPlain string
+	hintPlain := ""
+	if showHint {
+		hintPlain = " (ctrl+/)"
+	}
+
+	sessionSeg := ""
+	if showSession {
+		sessionSeg = s.sessionPlain()
+	}
+
+	if showName && s.name != "" {
+		rightPlain = fmt.Sprintf(" %s%s · %s%s ", sessionSeg, s.runID, s.name, hintPlain)
+	} else {
+		rightPlain = fmt.Sprintf(" %s%s%s ", sessionSeg, s.runID, hintPlain)
+	}
+```
+
+Update the function signature to `buildContent(showGrants, showName, showHint, showWarning, showSession bool)` and the `Content()` call to `s.buildContent(true, true, true, true, true)`. In the truncation cascade, drop the session segment LAST among right-side items (after name):
+
+```go
+	if totalPlain > s.width {
+		if showHint {
+			return s.buildContent(showGrants, showName, false, showWarning, showSession)
+		}
+		if showGrants && len(s.grants) > 0 {
+			return s.buildContent(false, showName, false, showWarning, showSession)
+		}
+		if showName && s.name != "" {
+			return s.buildContent(false, false, false, showWarning, showSession)
+		}
+		if showSession && s.sessionPlain() != "" {
+			return s.buildContent(false, false, false, showWarning, false)
+		}
+		if showWarning && s.warning != "" {
+			return s.buildContent(false, false, false, false, false)
+		}
+		if runeLen(leftPlain)+runeLen(rightPlain) > s.width {
+			return bgDarkGray + strings.Repeat(" ", s.width) + reset
+		}
+	}
+```
+
+(e) In the styled right-segment build, color the session segment. Replace the styled right build:
+
+```go
+	// Build right segment with styling
+	buf.WriteString(" ")
+	if showSession {
+		if seg := s.sessionPlain(); seg != "" {
+			buf.WriteString(fgGreen)
+			buf.WriteString(strings.TrimRight(seg, " "))
+			buf.WriteString(reset)
+			buf.WriteString(bgDarkGray)
+			buf.WriteString(" ")
+		}
+	}
+	if showName && s.name != "" {
+		buf.WriteString(fmt.Sprintf("%s · %s", s.runID, s.name))
+	} else {
+		buf.WriteString(s.runID)
+	}
+```
+
+> NOTE: this replaces the prior `buf.WriteString(fmt.Sprintf(" %s · %s", s.runID, s.name))` block. Keep the subsequent hint/space/reset writes unchanged. Because the styled and plain builders must agree on width, ensure the leading/trailing spaces match `rightPlain` exactly (one leading space, session segment + trailing space, then run-id). Run the test to confirm alignment isn't broken.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/tui/ -v`
+Expected: PASS — the new test plus all existing statusbar tests (alignment unchanged when no session is set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tui/statusbar.go internal/tui/statusbar_test.go
+git commit -m "feat(tui): status footer session role + joined count"
+```
+
+---
+
+### Task E2: Wire the footer into the join loop (and count into the primary)
+
+**Files:**
+- Modify: `cmd/moat/cli/join_cmd.go` (replace the `setupJoinStatusBar` stub)
+- Modify: `cmd/moat/cli/exec.go` (`setupStatusBar` + the interactive loop: show live joined count on the primary)
+
+- [ ] **Step 1: Implement `setupJoinStatusBar`**
+
+Replace the stub in `join_cmd.go`:
+
+```go
+func setupJoinStatusBar(manager *run.Manager, r *run.Run, index int) (*tui.Writer, func(), io.Writer) {
+	stdout := io.Writer(os.Stdout)
+	cleanup := func() {}
+	if !term.IsTerminal(os.Stdout) {
+		return nil, cleanup, stdout
+	}
+	width, height := term.GetSize(os.Stdout)
+	if width <= 0 || height <= 0 {
+		return nil, cleanup, stdout
+	}
+	runtimeType := r.Runtime
+	if runtimeType == "" {
+		runtimeType = manager.RuntimeType()
+	}
+	bar := tui.NewStatusBar(r.ID, r.Name, runtimeType)
+	bar.SetGrants(r.Grants)
+	bar.SetSession(fmt.Sprintf("joined · %d", index))
+	bar.SetDimensions(width, height)
+	writer := tui.NewWriter(os.Stdout, bar, runtimeType)
+	if err := writer.Setup(); err != nil {
+		return nil, cleanup, os.Stdout
+	}
+	_ = os.Stdout.Sync()
+	cleanup = func() { _ = writer.Cleanup() }
+	return writer, cleanup, writer
+}
+```
+
+- [ ] **Step 2: Show the live joined count on the primary**
+
+In `cmd/moat/cli/exec.go` `setupStatusBar`, after `bar.SetGrants(r.Grants)`, add:
+
+```go
+	bar.SetJoinedCount(manager.AttachedCount(r.ID))
+```
+
+And in `RunInteractiveAttached`, inside the `SIGWINCH` handling branch (where `statusWriter.Resize` is already called), refresh the count so it tracks joins arriving/leaving on redraw:
+
+```go
+				// Refresh joined-agent count on redraw (display-only).
+				// (Place alongside the existing statusWriter.Resize call.)
+```
+
+> Implementation note: the `StatusBar` is owned by the `tui.Writer`; to update the count live, add a tiny pass-through on the writer if one isn't present (e.g. `statusWriter.SetJoinedCount(n)` that forwards to the bar), OR re-create/refresh on SIGWINCH. Check `internal/tui/writer.go` for an existing accessor pattern (it already forwards `Resize` and `SetMessage`-style calls). If adding a forwarder is non-trivial, ship E2 with the count captured at startup only and open a follow-up for live refresh — the join's own `joined · N` footer is the must-have; the primary's live `+N` is the nice-to-have per the design doc.
+
+- [ ] **Step 3: Build + test**
+
+Run: `go build ./... && go test ./internal/tui/ ./cmd/moat/cli/ -v`
+Expected: builds clean; tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/moat/cli/join_cmd.go cmd/moat/cli/exec.go
+git commit -m "feat(cli): wire join/primary status footer (session role + count)"
+```
+
+---
+
+## Phase F — Split-console capture for joins
+
+### Task F1: Tee a join's console to its own log file
+
+**Files:**
+- Modify: `cmd/moat/cli/join_cmd.go` (`runJoinInteractive` and the headless path)
+
+Per the design, console is split per agent: the join writes to `<run-dir>/logs.<index>.jsonl` rather than interleaving into the primary's `logs.jsonl`. Reuse the timestamped `storage.LogWriter` pattern, but with an indexed filename.
+
+- [ ] **Step 1: Add an indexed log-writer accessor to storage**
+
+In `internal/storage/storage.go`, add alongside `LogWriter()`:
+
+```go
+// JoinLogWriter returns a timestamped writer for a joined agent's console,
+// written to logs.<index>.jsonl so it stays separate from the primary's log.
+func (s *RunStore) JoinLogWriter(index int) (*LogWriter, error) {
+	f, err := os.OpenFile(
+		filepath.Join(s.dir, fmt.Sprintf("logs.%d.jsonl", index)),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+		0600,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("opening join log file: %w", err)
+	}
+	return &LogWriter{file: f}, nil
+}
+```
+
+> NOTE: `fmt` is already imported by storage.go. Add a focused unit test `TestRunStore_JoinLogWriter` mirroring any existing `LogWriter` test (write a line, read back the file, assert the JSON `line` field and the `logs.<index>.jsonl` filename).
+
+- [ ] **Step 2: Tee join output to the indexed log**
+
+In `runJoinInteractive`, after computing `stdout` from `setupJoinStatusBar`, wrap it:
+
+```go
+	if r.Store != nil {
+		if lw, lerr := r.Store.JoinLogWriter(index); lerr == nil {
+			defer lw.Close()
+			stdout = io.MultiWriter(stdout, lw)
+		}
+	}
+```
+
+For the headless path in `runJoin`, do the same around `os.Stdout` using the registered index (register a join there too so headless sessions also get an index and count). Refactor so both paths register the join and obtain `index` before building `ExecOptions`.
+
+> NOTE: confirm a loaded run exposes `r.Store` (`*storage.RunStore`). If `r.Store` is nil for runs reconstructed in a separate `moat join` process, construct one with `storage.NewRunStore(storage.DefaultBaseDir(), r.ID)`.
+
+- [ ] **Step 3: Build + test**
+
+Run: `go build ./... && go test ./internal/storage/ -run TestRunStore_JoinLogWriter -v`
+Expected: builds clean; test PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/storage/storage.go internal/storage/storage_test.go cmd/moat/cli/join_cmd.go
+git commit -m "feat(run): split-console capture for joined agents (logs.N.jsonl)"
+```
+
+---
+
+## Phase G — E2E, docs, changelog
+
+### Task G1: E2E test for join (interactive + headless)
+
+**Files:**
+- Create: `internal/e2e/join_test.go`
+
+> Requires a container runtime; runs under `-tags=e2e`, not in unit CI. Mirror an existing e2e test's harness (look at `internal/e2e/` for the helper that starts a `moat claude`-style run and the assertion helpers).
+
+- [ ] **Step 1: Write the E2E test**
+
+```go
+//go:build e2e
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestJoinHeadless starts a run, joins a headless claude agent with a prompt,
+// and asserts the join runs in the SAME container (no new container, no new
+// proxy registration) and the original run still owns teardown.
+func TestJoinHeadless(t *testing.T) {
+	// 1. Start a long-lived claude run (e.g. `moat claude -- sleep`-style harness,
+	//    or a run whose primary stays up) and capture its run ID and container ID.
+	// 2. Run: moat join <run> claude -p "echo HELLO_FROM_JOIN"
+	//    Assert exit code 0 and output contains the expected marker.
+	// 3. Assert container count did not increase (same container ID services the join).
+	// 4. Assert no new proxy run registration was created for the join.
+	// 5. Stop the original run; assert the container tears down.
+	t.Skip("fill in against the existing e2e harness helpers in internal/e2e")
+	_ = strings.TrimSpace
+}
+```
+
+> NOTE: this is a scaffold — wire it to the real `internal/e2e` harness (start-run helper, container-list helper, run-registration assertion). Remove the `t.Skip` once wired. The assertions that matter: (a) same container, (b) no new proxy registration, (c) original-owns-teardown.
+
+- [ ] **Step 2: Build the e2e tag**
+
+Run: `go test -tags=e2e -run TestJoinHeadless ./internal/e2e/ -v` (on a host with a runtime)
+Expected: compiles; skips (until wired) or passes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/e2e/join_test.go
+git commit -m "test(e2e): scaffold join headless/interactive e2e"
+```
+
+---
+
+### Task G2: Documentation + changelog
+
+**Files:**
+- Modify: `docs/content/reference/01-cli.md` (add `moat join`)
+- Modify: a guide under `docs/content/guides/` (multi-agent / joining a second agent) — add a short section, or create `docs/content/guides/NN-multi-agent.md` following the folder's numbering
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add the CLI reference entry**
+
+Document `moat join <run> <agent> [flags]` with the `--continue/-c`, `--resume/-r`, `--prompt/-p` flags, the same-agent v1 constraint, and the `join : exec :: claude : run` relationship. Mirror the existing `moat exec` entry's structure/tone.
+
+- [ ] **Step 2: Add/extend a guide**
+
+Show the workflow: start `moat claude`, then in another terminal `moat join <run> claude` to get a second agent in the same workspace; note the footer shows `joined · N` and the primary shows `+N`; note the lifecycle (original owns the container) and the v1 same-agent constraint.
+
+- [ ] **Step 3: Add the changelog entry**
+
+Under the unreleased section, in `### Added`:
+
+```markdown
+- **`moat join`** — launch a second agent inside an already-running container,
+  reusing its workspace, grants, and credentials without a new container. v1
+  supports same-agent joins (e.g. joining claude into a `moat claude` run). The
+  status footer shows the session role and joined-agent count.
+  ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
+```
+
+> NOTE: per CLAUDE.md, commit with the issue link first if there is one, then swap to `/pull/NNN` after the PR is opened.
+
+- [ ] **Step 4: Verify docs build/links (if a docs check exists) and run the full suite**
+
+Run: `make lint && make test-unit`
+Expected: lint clean (gofmt/vet/golangci-lint), all unit tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/ CHANGELOG.md
+git commit -m "docs: document moat join (CLI reference, guide, changelog)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full unit suite with the race detector**
+
+Run: `make test-unit`
+Expected: all packages pass.
+
+- [ ] **Lint**
+
+Run: `make lint`
+Expected: no issues (gofmt, vet, golangci-lint; remember "canceled" not "cancelled").
+
+- [ ] **Manual smoke test (on a host with a runtime)**
+
+```bash
+# terminal 1
+moat claude
+# note the run id, e.g. run_abcdef123456
+
+# terminal 2 — interactive join
+moat join run_abcdef123456 claude
+#   → second claude TUI in the same workspace; footer shows "joined · 1"
+#   → terminal 1 footer shows "+1"
+
+# terminal 3 — headless join
+moat join run_abcdef123456 claude -p "print the current branch"
+#   → prints output, exits 0
+
+# wrong-agent error
+moat join run_abcdef123456 codex
+#   → clear error: "run has no codex configuration ..."
+
+# stop the original; joins are torn down with the container
+moat stop run_abcdef123456
+```
+
+---
+
+## Notes for the implementer
+
+- **Lifecycle:** never make the attached count drive teardown. The original agent owns the container (design Decision 2); joins are exec children that die with it.
+- **Same-provider only (v1):** cross-provider join, container-side worktree (`moat join … --wt`), and persistent sessions are explicitly deferred — see the design doc's "Future extensions". Don't build them here.
+- **Network/audit interleaving is automatic:** joins share the run's proxy token, so their traffic already attributes to the run. No proxy/daemon changes — this preserves the daemon backwards-compatibility contract.
+- **Daemon API untouched:** `moat join` adds no daemon endpoints or fields.
+```

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -674,7 +674,82 @@ func (r *AppleRuntime) Exec(ctx context.Context, containerID string, cmd []strin
 
 // ExecInteractive runs a command inside a running container with a PTY.
 func (r *AppleRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
-	return fmt.Errorf("not implemented")
+	if !opts.TTY {
+		// Non-TTY interactive exec: stream stdin/stdout without a PTY.
+		args := append([]string{"exec", "--user", "moatuser", "-i", containerID}, cmd...)
+		c := exec.CommandContext(ctx, r.containerBin, args...)
+		c.Stdin = opts.Stdin
+		c.Stdout = opts.Stdout
+		c.Stderr = opts.Stderr
+		if err := c.Run(); err != nil {
+			return exitError(err)
+		}
+		return nil
+	}
+
+	args := append([]string{"exec", "-t", "-i", "--user", "moatuser", containerID}, cmd...)
+	c := exec.CommandContext(ctx, r.containerBin, args...)
+
+	ptmx, err := pty.Start(c)
+	if err != nil {
+		return fmt.Errorf("starting exec with pty: %w", err)
+	}
+	defer func() { _ = ptmx.Close() }()
+
+	// Initial size, then service resizes for this exec's PTY directly (no shared map).
+	if opts.InitialWidth > 0 && opts.InitialHeight > 0 {
+		_ = pty.Setsize(ptmx, &pty.Winsize{
+			Rows: uint16(opts.InitialHeight), // #nosec G115
+			Cols: uint16(opts.InitialWidth),  // #nosec G115
+		})
+	}
+	if opts.Resize != nil {
+		go func() {
+			for size := range opts.Resize {
+				if size.Width == 0 || size.Height == 0 {
+					continue
+				}
+				_ = pty.Setsize(ptmx, &pty.Winsize{
+					Rows: uint16(size.Height), // #nosec G115
+					Cols: uint16(size.Width),  // #nosec G115
+				})
+			}
+		}()
+	}
+
+	if opts.Stdin != nil {
+		go func() { _, _ = io.Copy(ptmx, opts.Stdin) }()
+	}
+	outputDone := make(chan struct{})
+	go func() {
+		defer close(outputDone)
+		_, _ = io.Copy(opts.Stdout, ptmx)
+	}()
+
+	cmdDone := make(chan error, 1)
+	go func() { cmdDone <- c.Wait() }()
+
+	select {
+	case <-ctx.Done():
+		_ = ptmx.Close()
+		if c.Process != nil {
+			_ = c.Process.Kill()
+		}
+		<-cmdDone
+		return ctx.Err()
+	case werr := <-cmdDone:
+		// Drain output briefly so nothing is lost on fast exit.
+		select {
+		case <-outputDone:
+		case <-time.After(2 * time.Second):
+			_ = ptmx.Close()
+			<-outputDone
+		}
+		if werr != nil {
+			return exitError(werr)
+		}
+		return nil
+	}
 }
 
 // exitError converts an exec.ExitError to an ExecError, or wraps other errors.

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -672,6 +672,11 @@ func (r *AppleRuntime) Exec(ctx context.Context, containerID string, cmd []strin
 	return nil
 }
 
+// ExecInteractive runs a command inside a running container with a PTY.
+func (r *AppleRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
+	return fmt.Errorf("not implemented")
+}
+
 // exitError converts an exec.ExitError to an ExecError, or wraps other errors.
 func exitError(err error) error {
 	var exitErr *exec.ExitError

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -679,6 +679,11 @@ func (r *DockerRuntime) Exec(ctx context.Context, containerID string, cmd []stri
 	return nil
 }
 
+// ExecInteractive runs a command inside a running container with a PTY.
+func (r *DockerRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
+	return fmt.Errorf("not implemented")
+}
+
 // ensureImage pulls an image if it doesn't exist locally.
 func (r *DockerRuntime) ensureImage(ctx context.Context, imageName string) error {
 	exists, err := r.buildMgr.ImageExists(ctx, imageName)

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -709,6 +709,10 @@ func (r *DockerRuntime) ExecInteractive(ctx context.Context, containerID string,
 		})
 	}
 	if opts.TTY && opts.Resize != nil {
+		// Short-lived goroutine owned by the caller's resize pump: it runs until
+		// the caller closes opts.Resize (immediately after ExecInteractive
+		// returns), not for the life of this method. Resizes that land after the
+		// exec finishes are harmless no-ops on a completed exec.
 		go func() {
 			for size := range opts.Resize {
 				if size.Width == 0 || size.Height == 0 {
@@ -745,6 +749,11 @@ func (r *DockerRuntime) ExecInteractive(ctx context.Context, containerID string,
 
 	select {
 	case <-ctx.Done():
+		// Intentional trade-off: on cancellation (e.g. SIGTERM) we return
+		// ctx.Err() and skip ContainerExecInspect. If the agent exits non-zero
+		// in the same instant, that code is dropped rather than surfaced as an
+		// ExecError — acceptable, since a canceled join doesn't care about the
+		// agent's exit code, and inspecting here would need a background context.
 		return ctx.Err()
 	case copyErr := <-outputDone:
 		if copyErr != nil && copyErr != io.EOF {

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -681,7 +681,85 @@ func (r *DockerRuntime) Exec(ctx context.Context, containerID string, cmd []stri
 
 // ExecInteractive runs a command inside a running container with a PTY.
 func (r *DockerRuntime) ExecInteractive(ctx context.Context, containerID string, cmd []string, opts ExecOptions) error {
-	return fmt.Errorf("not implemented")
+	execCfg := container.ExecOptions{
+		Cmd:          cmd,
+		User:         "moatuser",
+		Tty:          opts.TTY,
+		AttachStdin:  opts.Stdin != nil,
+		AttachStdout: true,
+		AttachStderr: !opts.TTY, // in TTY mode stderr is merged into stdout
+	}
+
+	execID, err := r.cli.ContainerExecCreate(ctx, containerID, execCfg)
+	if err != nil {
+		return fmt.Errorf("creating exec: %w", err)
+	}
+
+	resp, err := r.cli.ContainerExecAttach(ctx, execID.ID, container.ExecAttachOptions{Tty: opts.TTY})
+	if err != nil {
+		return fmt.Errorf("attaching to exec: %w", err)
+	}
+	defer resp.Close()
+
+	// Apply the initial size before output starts, then service resizes.
+	if opts.TTY && opts.InitialWidth > 0 && opts.InitialHeight > 0 {
+		_ = r.cli.ContainerExecResize(ctx, execID.ID, container.ResizeOptions{
+			Height: opts.InitialHeight,
+			Width:  opts.InitialWidth,
+		})
+	}
+	if opts.TTY && opts.Resize != nil {
+		go func() {
+			for size := range opts.Resize {
+				if size.Width == 0 || size.Height == 0 {
+					continue
+				}
+				_ = r.cli.ContainerExecResize(ctx, execID.ID, container.ResizeOptions{
+					Height: size.Height,
+					Width:  size.Width,
+				})
+			}
+		}()
+	}
+
+	outputDone := make(chan error, 1)
+	go func() {
+		if opts.TTY {
+			// TTY mode is a single raw stream.
+			_, copyErr := io.Copy(opts.Stdout, resp.Reader)
+			outputDone <- copyErr
+		} else {
+			_, copyErr := stdcopy.StdCopy(opts.Stdout, opts.Stderr, resp.Reader)
+			outputDone <- copyErr
+		}
+	}()
+
+	if opts.Stdin != nil {
+		go func() {
+			_, _ = io.Copy(resp.Conn, opts.Stdin)
+			if cw, ok := resp.Conn.(interface{ CloseWrite() error }); ok {
+				_ = cw.CloseWrite()
+			}
+		}()
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case copyErr := <-outputDone:
+		if copyErr != nil && copyErr != io.EOF {
+			return copyErr
+		}
+	}
+
+	inspect, err := r.cli.ContainerExecInspect(ctx, execID.ID)
+	if err != nil {
+		return fmt.Errorf("inspecting exec: %w", err)
+	}
+	if inspect.ExitCode != 0 {
+		return &ExecError{ExitCode: inspect.ExitCode}
+	}
+	return nil
 }
 
 // ensureImage pulls an image if it doesn't exist locally.

--- a/internal/container/exec_interactive_test.go
+++ b/internal/container/exec_interactive_test.go
@@ -1,0 +1,80 @@
+package container
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDockerExecInteractive is an integration test for DockerRuntime.ExecInteractive.
+// It requires a running Docker daemon and is skipped when -short is passed.
+func TestDockerExecInteractive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	rt, err := NewDockerRuntime(false)
+	if err != nil {
+		t.Fatalf("failed to create Docker runtime: %v", err)
+	}
+	defer rt.Close()
+
+	// Start a long-lived container that creates moatuser first.
+	// ExecInteractive hard-codes User:"moatuser", so the image must have that user.
+	// Alpine does not ship moatuser, so we add it in the container entrypoint.
+	containerName := "test-moat-exec-interactive-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+	containerID, err := rt.CreateContainer(ctx, Config{
+		Name:  containerName,
+		Image: "alpine:latest",
+		Cmd:   []string{"sh", "-c", "adduser -D moatuser && sleep 60"},
+	})
+	if err != nil {
+		t.Fatalf("CreateContainer failed: %v", err)
+	}
+	defer rt.RemoveContainer(ctx, containerID)
+
+	if err := rt.StartContainer(ctx, containerID); err != nil {
+		t.Fatalf("StartContainer failed: %v", err)
+	}
+	defer rt.StopContainer(ctx, containerID)
+
+	t.Run("TTY output contains expected string", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := rt.ExecInteractive(ctx, containerID, []string{"sh", "-c", "echo HELLO_INTERACTIVE"}, ExecOptions{
+			Stdout: &buf,
+			TTY:    true,
+		})
+		if err != nil {
+			t.Fatalf("ExecInteractive failed: %v", err)
+		}
+		// In TTY mode the terminal driver may translate \n → \r\n, so use Contains
+		// rather than exact equality.
+		if !strings.Contains(buf.String(), "HELLO_INTERACTIVE") {
+			t.Errorf("output %q does not contain HELLO_INTERACTIVE", buf.String())
+		}
+	})
+
+	t.Run("exit code propagation via ExecError", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := rt.ExecInteractive(ctx, containerID, []string{"sh", "-c", "exit 7"}, ExecOptions{
+			Stdout: &buf,
+			TTY:    false,
+		})
+		if err == nil {
+			t.Fatal("expected non-nil error for exit code 7, got nil")
+		}
+		var execErr *ExecError
+		if !errors.As(err, &execErr) {
+			t.Fatalf("expected *ExecError, got %T: %v", err, err)
+		}
+		if execErr.ExitCode != 7 {
+			t.Errorf("ExitCode = %d, want 7", execErr.ExitCode)
+		}
+	})
+}

--- a/internal/container/exec_options.go
+++ b/internal/container/exec_options.go
@@ -1,0 +1,28 @@
+package container
+
+import "io"
+
+// TTYSize is a terminal dimension update for an interactive exec session.
+type TTYSize struct {
+	Width  uint
+	Height uint
+}
+
+// ExecOptions configures an interactive (PTY-backed) exec session.
+// It mirrors AttachOptions but targets an exec'd process rather than the
+// container's main process, and carries a Resize channel so the caller can
+// propagate SIGWINCH to this specific exec session (a container may have many).
+type ExecOptions struct {
+	Stdin  io.Reader // forwarded to the exec'd process
+	Stdout io.Writer // receives the exec'd process output
+	Stderr io.Writer // receives stderr (ignored in TTY mode, where it merges into Stdout)
+	TTY    bool      // allocate a PTY (raw terminal) for the exec
+
+	// InitialWidth/InitialHeight size the PTY before the process queries it.
+	InitialWidth  uint
+	InitialHeight uint
+
+	// Resize, if non-nil, delivers terminal size changes for this exec session.
+	// The runtime applies each value until the channel is closed or the exec ends.
+	Resize <-chan TTYSize
+}

--- a/internal/container/pool_test.go
+++ b/internal/container/pool_test.go
@@ -135,6 +135,9 @@ func (s *poolStubRuntime) ResizeTTY(context.Context, string, uint, uint) error {
 func (s *poolStubRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
 	panic("not implemented")
 }
+func (s *poolStubRuntime) ExecInteractive(context.Context, string, []string, ExecOptions) error {
+	panic("not implemented")
+}
 
 func newStubPool() *RuntimePool {
 	return NewRuntimePoolWithDefault(&poolStubRuntime{})

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -141,6 +141,12 @@ type Runtime interface {
 	// stdout and stderr receive the command's output.
 	// Returns *ExecError for non-zero exit codes.
 	Exec(ctx context.Context, id string, cmd []string, stdin []byte, stdout, stderr io.Writer) error
+
+	// ExecInteractive runs a command inside a running container with a PTY,
+	// streaming opts.Stdin/Stdout and applying terminal resizes from opts.Resize.
+	// Use this for interactive TUI agents joined into an existing container.
+	// Returns *ExecError for non-zero exit codes.
+	ExecInteractive(ctx context.Context, id string, cmd []string, opts ExecOptions) error
 }
 
 // ExecError is returned when a command executed inside a container exits

--- a/internal/e2e/join_test.go
+++ b/internal/e2e/join_test.go
@@ -1,0 +1,201 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/majorcontext/moat/internal/config"
+	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/daemon"
+	"github.com/majorcontext/moat/internal/run"
+	"github.com/majorcontext/moat/internal/storage"
+)
+
+// TestJoinHeadless starts a run that stays up, issues a headless join with
+// -p, and asserts the three properties mandated by the join design:
+//
+//	(a) The join runs inside the SAME container (no new container created).
+//	(b) No new proxy run registration is created for the join.
+//	(c) The original run still owns teardown — stopping it terminates the
+//	    container, which takes joins with it.
+//
+// Requirements this test CANNOT satisfy in this environment:
+//   - A real container runtime (Docker or Apple containers) is required to
+//     start a run and exec into it.  The sandbox here has neither, so the
+//     test is skipped at runtime with an informative message.
+//   - The join path calls manager.ExecInteractive, which requires a running
+//     container; the manager.Get / StateRunning guards surface correctly in
+//     unit tests (internal/run/manager_join_test.go).
+//
+// Wire status: structure is fully wired to real harness helpers (mgr.Create,
+// mgr.Start, exec of the moat binary, daemon.ListRuns, storage.ReadLogs).
+// The t.Skip fires before container operations when no runtime is available.
+// Remove the t.Skip (and keep requireDocker) once a runtime is present in the
+// test environment.
+func TestJoinHeadless(t *testing.T) {
+	// Skip until a container runtime is available in this environment.
+	// Remove this line and keep the requireDocker call below to enable the test.
+	t.Skip("requires a container runtime with ExecInteractive support; run manually with Docker or Apple containers")
+
+	requireDocker(t)
+
+	testOnAllRuntimes(t, func(t *testing.T, rt container.Runtime) {
+		ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+		defer cancel()
+
+		// --- Set up a long-lived run that stays alive for the join ---
+		mgr, err := run.NewManagerWithOptions(run.ManagerOptions{NoSandbox: &[]bool{true}[0]})
+		if err != nil {
+			t.Fatalf("NewManager: %v", err)
+		}
+		defer mgr.Close()
+
+		workspace := createTestWorkspace(t)
+
+		// "sleep 60" keeps the primary alive long enough for the join.
+		primaryRun, err := mgr.Create(ctx, run.Options{
+			Name:      "e2e-join-primary",
+			Workspace: workspace,
+			Cmd:       []string{"sleep", "60"},
+		})
+		if err != nil {
+			t.Fatalf("Create primary run: %v", err)
+		}
+		defer mgr.Destroy(context.Background(), primaryRun.ID)
+		defer mgr.Stop(context.Background(), primaryRun.ID)
+
+		if err := mgr.Start(ctx, primaryRun.ID, run.StartOptions{}); err != nil {
+			t.Fatalf("Start primary run: %v", err)
+		}
+
+		// Wait briefly for the container to be fully running before joining.
+		time.Sleep(500 * time.Millisecond)
+
+		primaryContainerID := primaryRun.ContainerID
+		if primaryContainerID == "" {
+			t.Fatal("primary run has no container ID after Start")
+		}
+
+		// --- Assertion (b): count registered proxy runs before the join ---
+		// moat join does not call daemon.RegisterRun; the join shares the
+		// original run's proxy token.  Record the count now to compare after.
+		daemonDir := filepath.Join(config.GlobalConfigDir(), "proxy")
+		lock, lockErr := daemon.ReadLockFile(daemonDir)
+		var runsBefore int
+		if lockErr == nil && lock != nil && lock.IsAlive() {
+			daemonClient := daemon.NewClient(lock.SockPath)
+			listCtx, listCancel := context.WithTimeout(ctx, 3*time.Second)
+			runs, listErr := daemonClient.ListRuns(listCtx)
+			listCancel()
+			if listErr == nil {
+				runsBefore = len(runs)
+			}
+		}
+
+		// --- Run the join (assertions a + b measured around it) ---
+		// We invoke the real moat binary so the full CLI path is exercised
+		// (provider resolution, ExecInteractive, log capture).
+		moatBin := joinTestMoatExecutable(t)
+		joinCmd := exec.CommandContext(ctx, moatBin,
+			"join", primaryRun.ID, "claude",
+			"-p", "echo HELLO_JOIN",
+		)
+		var joinOut bytes.Buffer
+		joinCmd.Stdout = &joinOut
+		joinCmd.Stderr = &joinOut
+
+		joinErr := joinCmd.Run()
+		// A non-zero exit is expected when claude is not installed in the
+		// container; what matters is that no new container was created and
+		// no new proxy registration appeared.
+		t.Logf("join output: %s", joinOut.String())
+		if joinErr != nil {
+			t.Logf("join exited with error (may be expected if claude not installed): %v", joinErr)
+		}
+
+		// Assertion (a): no new container — the primary container ID is unchanged.
+		refreshed, getErr := mgr.Get(primaryRun.ID)
+		if getErr != nil {
+			t.Fatalf("Get primary run after join: %v", getErr)
+		}
+		if refreshed.ContainerID != primaryContainerID {
+			t.Errorf("container ID changed after join: before=%q after=%q (join must reuse the existing container)",
+				primaryContainerID, refreshed.ContainerID)
+		}
+
+		// Assertion (b): proxy registration count unchanged.
+		if lockErr == nil && lock != nil && lock.IsAlive() {
+			daemonClient := daemon.NewClient(lock.SockPath)
+			listCtx, listCancel := context.WithTimeout(ctx, 3*time.Second)
+			runsAfter, listErr := daemonClient.ListRuns(listCtx)
+			listCancel()
+			if listErr == nil && len(runsAfter) != runsBefore {
+				t.Errorf("proxy registration count changed from %d to %d after join — join must not register a new run",
+					runsBefore, len(runsAfter))
+			}
+		}
+
+		// --- Assertion (c): original run owns teardown ---
+		// Stopping the primary tears down the container.  Verify the run
+		// transitions to a terminal state.
+		if stopErr := mgr.Stop(ctx, primaryRun.ID); stopErr != nil {
+			t.Fatalf("Stop primary run: %v", stopErr)
+		}
+
+		// Poll briefly for the stopped state (teardown may be async).
+		deadline := time.Now().Add(10 * time.Second)
+		var finalState run.State
+		for time.Now().Before(deadline) {
+			r, err := mgr.Get(primaryRun.ID)
+			if err != nil {
+				break
+			}
+			finalState = r.GetState()
+			if finalState == run.StateStopped || finalState == run.StateFailed {
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		if finalState != run.StateStopped && finalState != run.StateFailed {
+			t.Errorf("primary run state after stop = %q, want %q or %q",
+				finalState, run.StateStopped, run.StateFailed)
+		}
+
+		// Verify the join's log output landed in the indexed join log file
+		// (logs.1.jsonl) rather than the primary's logs.jsonl, demonstrating
+		// split-console capture.
+		time.Sleep(100 * time.Millisecond)
+		store, storeErr := storage.NewRunStore(storage.DefaultBaseDir(), primaryRun.ID)
+		if storeErr != nil {
+			t.Logf("NewRunStore: %v (non-fatal)", storeErr)
+		} else {
+			primaryLogs, _ := store.ReadLogs(0, 100)
+			for _, entry := range primaryLogs {
+				if strings.Contains(entry.Line, "HELLO_JOIN") {
+					t.Errorf("join output appeared in primary logs.jsonl; expected logs.1.jsonl for split-console isolation")
+					break
+				}
+			}
+		}
+	})
+}
+
+// joinTestMoatExecutable returns the path to the moat binary set by TestMain
+// via MOAT_EXECUTABLE, skipping the test if it is not set.
+func joinTestMoatExecutable(t *testing.T) string {
+	t.Helper()
+	if exe := os.Getenv("MOAT_EXECUTABLE"); exe != "" {
+		return exe
+	}
+	t.Skip("MOAT_EXECUTABLE not set; skip join CLI test")
+	return ""
+}

--- a/internal/provider/interfaces.go
+++ b/internal/provider/interfaces.go
@@ -90,6 +90,27 @@ type RefreshableProvider interface {
 	Refresh(ctx context.Context, p ProxyConfigurer, cred *Credential) (*Credential, error)
 }
 
+// JoinOpts carries the parsed flags for a joined agent session.
+type JoinOpts struct {
+	Continue bool
+	Resume   string
+	Prompt   string
+}
+
+// JoinableAgent is implemented by agent providers that support `moat join` —
+// launching a second instance of the agent into an existing run's container.
+// It is optional: providers that don't implement it cannot be joined.
+type JoinableAgent interface {
+	// JoinCommand returns the in-container command to launch a joined session.
+	JoinCommand(opts JoinOpts) ([]string, error)
+
+	// IdentifiesAs reports whether a run whose recorded Agent field is `agent`
+	// was created by this provider. This absorbs the difference between the
+	// default provider name ("claude") and an explicit moat.yaml agent value
+	// ("claude-code").
+	IdentifiesAs(agent string) bool
+}
+
 // AgentProvider extends CredentialProvider for AI agent runtimes.
 // Implemented by claude, codex, and gemini providers.
 type AgentProvider interface {

--- a/internal/providers/claude/join.go
+++ b/internal/providers/claude/join.go
@@ -1,0 +1,28 @@
+package claude
+
+import "github.com/majorcontext/moat/internal/provider"
+
+// JoinCommand builds the in-container command for a joined claude session.
+// Mirrors the BuildCommand closure in runClaudeCode (cli.go). Joined sessions
+// always run with --dangerously-skip-permissions, matching the create-path
+// default (the container provides isolation).
+func (p *OAuthProvider) JoinCommand(opts provider.JoinOpts) ([]string, error) {
+	cmd := []string{"claude", "--dangerously-skip-permissions"}
+	if opts.Continue {
+		cmd = append(cmd, "--continue")
+	}
+	if opts.Resume != "" {
+		cmd = append(cmd, "--resume", opts.Resume)
+	}
+	if opts.Prompt != "" {
+		cmd = append(cmd, "-p", opts.Prompt)
+	}
+	return cmd, nil
+}
+
+// IdentifiesAs reports whether a run with the given recorded Agent field was
+// created by the claude provider. cfg.Agent defaults to the provider name
+// ("claude") but is "claude-code" when set explicitly in moat.yaml.
+func (p *OAuthProvider) IdentifiesAs(agent string) bool {
+	return agent == "claude" || agent == "claude-code"
+}

--- a/internal/providers/claude/join_test.go
+++ b/internal/providers/claude/join_test.go
@@ -1,0 +1,67 @@
+package claude
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+func TestOAuthProvider_JoinCommand(t *testing.T) {
+	p := &OAuthProvider{}
+
+	tests := []struct {
+		name string
+		opts provider.JoinOpts
+		want []string
+	}{
+		{
+			name: "bare",
+			opts: provider.JoinOpts{},
+			want: []string{"claude", "--dangerously-skip-permissions"},
+		},
+		{
+			name: "continue",
+			opts: provider.JoinOpts{Continue: true},
+			want: []string{"claude", "--dangerously-skip-permissions", "--continue"},
+		},
+		{
+			name: "resume",
+			opts: provider.JoinOpts{Resume: "abc123"},
+			want: []string{"claude", "--dangerously-skip-permissions", "--resume", "abc123"},
+		},
+		{
+			name: "prompt",
+			opts: provider.JoinOpts{Prompt: "hi"},
+			want: []string{"claude", "--dangerously-skip-permissions", "-p", "hi"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.JoinCommand(tt.opts)
+			if err != nil {
+				t.Fatalf("JoinCommand: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("JoinCommand = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOAuthProvider_IdentifiesAs(t *testing.T) {
+	p := &OAuthProvider{}
+	for _, agent := range []string{"claude", "claude-code"} {
+		if !p.IdentifiesAs(agent) {
+			t.Errorf("IdentifiesAs(%q) = false, want true", agent)
+		}
+	}
+	for _, agent := range []string{"codex", "gemini", ""} {
+		if p.IdentifiesAs(agent) {
+			t.Errorf("IdentifiesAs(%q) = true, want false", agent)
+		}
+	}
+}
+
+// Compile-time assertion that the provider satisfies JoinableAgent.
+var _ provider.JoinableAgent = (*OAuthProvider)(nil)

--- a/internal/run/edge_cases_test.go
+++ b/internal/run/edge_cases_test.go
@@ -128,6 +128,9 @@ func (f *flexibleRuntime) ResizeTTY(context.Context, string, uint, uint) error {
 func (f *flexibleRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
 	return nil
 }
+func (f *flexibleRuntime) ExecInteractive(context.Context, string, []string, container.ExecOptions) error {
+	return nil
+}
 
 // newEdgeCaseManager creates a Manager with the given runtime and a temporary
 // routes directory. The returned cleanup function should be deferred.

--- a/internal/run/joined.go
+++ b/internal/run/joined.go
@@ -1,0 +1,101 @@
+package run
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/majorcontext/moat/internal/storage"
+)
+
+// attachedAgentsDir is where per-join liveness entries live for a run.
+// One file per live joined agent, named by its pid (or pid-N for multiple
+// registrations from the same process).
+func attachedAgentsDir(runID string) string {
+	return filepath.Join(storage.DefaultBaseDir(), runID, "agents")
+}
+
+// pidAlive reports whether the given pid is a live process.
+func pidAlive(pid int) bool {
+	// Signal 0 performs error checking without actually sending a signal.
+	return syscall.Kill(pid, 0) == nil
+}
+
+// entryPID extracts the PID from an agent entry filename.
+// Filenames are either plain pids ("12345") or pid-N pairs ("12345-2").
+func entryPID(name string) (int, bool) {
+	part := name
+	if idx := strings.IndexByte(name, '-'); idx >= 0 {
+		part = name[:idx]
+	}
+	pid, err := strconv.Atoi(part)
+	if err != nil {
+		return 0, false
+	}
+	return pid, true
+}
+
+// registerJoinedAgent records a live joined agent for the run and returns its
+// 1-based index (the count after registration) plus a release func that removes
+// the entry. The count is for display only; it never affects teardown.
+func registerJoinedAgent(runID string) (index int, release func(), err error) {
+	dir := attachedAgentsDir(runID)
+	if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
+		return 0, nil, mkErr
+	}
+	pid := os.Getpid()
+	pidStr := strconv.Itoa(pid)
+
+	// Find a unique filename for this registration.
+	// Use "pid" if no prior entry exists, otherwise "pid-N" for N=2,3,...
+	name := pidStr
+	if _, statErr := os.Stat(filepath.Join(dir, name)); statErr == nil {
+		// Collision: find next available suffix.
+		for n := 2; ; n++ {
+			candidate := fmt.Sprintf("%s-%d", pidStr, n)
+			if _, statErr2 := os.Stat(filepath.Join(dir, candidate)); os.IsNotExist(statErr2) {
+				name = candidate
+				break
+			}
+		}
+	}
+
+	entry := filepath.Join(dir, name)
+	if wErr := os.WriteFile(entry, []byte(pidStr), 0o600); wErr != nil {
+		return 0, nil, wErr
+	}
+	release = func() { _ = os.Remove(entry) }
+	return attachedCount(runID), release, nil
+}
+
+// attachedCount returns the number of live joined agents for the run, pruning
+// entries whose pid is no longer alive.
+func attachedCount(runID string) int {
+	dir := attachedAgentsDir(runID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	// Deterministic order keeps index assignment stable in tests.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	live := 0
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		pid, ok := entryPID(e.Name())
+		if !ok {
+			continue
+		}
+		if pidAlive(pid) {
+			live++
+		} else {
+			_ = os.Remove(filepath.Join(dir, e.Name()))
+		}
+	}
+	return live
+}

--- a/internal/run/joined.go
+++ b/internal/run/joined.go
@@ -4,17 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
-	"strings"
 	"syscall"
 
 	"github.com/majorcontext/moat/internal/storage"
 )
 
 // attachedAgentsDir is where per-join liveness entries live for a run.
-// One file per live joined agent, named by its pid (or pid-N for multiple
-// registrations from the same process).
+// One file per live joined agent, named by its unique index (1, 2, 3, …).
+// The file content is the pid of the agent that claimed the slot.
 func attachedAgentsDir(runID string) string {
 	return filepath.Join(storage.DefaultBaseDir(), runID, "agents")
 }
@@ -25,51 +23,78 @@ func pidAlive(pid int) bool {
 	return syscall.Kill(pid, 0) == nil
 }
 
-// entryPID extracts the PID from an agent entry filename.
-// Filenames are either plain pids ("12345") or pid-N pairs ("12345-2").
-func entryPID(name string) (int, bool) {
-	part := name
-	if idx := strings.IndexByte(name, '-'); idx >= 0 {
-		part = name[:idx]
-	}
-	pid, err := strconv.Atoi(part)
+// entryAlive reports whether the entry at path refers to a live process.
+// The file content must be a decimal pid string.
+func entryAlive(path string) bool {
+	data, err := os.ReadFile(path)
 	if err != nil {
-		return 0, false
+		return false
 	}
-	return pid, true
+	pid, err := strconv.Atoi(string(data))
+	if err != nil {
+		return false
+	}
+	return pidAlive(pid)
 }
 
+// pruneDead removes entries from dir whose process is no longer alive.
+// Errors are ignored (best-effort).
+func pruneDead(dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		if !entryAlive(path) {
+			_ = os.Remove(path)
+		}
+	}
+}
+
+// maxJoinIndex is the upper bound for the O_EXCL index scan. In practice
+// there will never be more than a handful of concurrent joins per run.
+const maxJoinIndex = 4096
+
 // registerJoinedAgent records a live joined agent for the run and returns its
-// 1-based index (the count after registration) plus a release func that removes
-// the entry. The count is for display only; it never affects teardown.
+// unique 1-based index plus a release func that removes the entry. The index
+// is the lowest free integer filename: it is stable and unique for the
+// duration of the agent's lifetime.
 func registerJoinedAgent(runID string) (index int, release func(), err error) {
 	dir := attachedAgentsDir(runID)
 	if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
 		return 0, nil, mkErr
 	}
-	pid := os.Getpid()
-	pidStr := strconv.Itoa(pid)
+	pruneDead(dir)
 
-	// Find a unique filename for this registration.
-	// Use "pid" if no prior entry exists, otherwise "pid-N" for N=2,3,...
-	name := pidStr
-	if _, statErr := os.Stat(filepath.Join(dir, name)); statErr == nil {
-		// Collision: find next available suffix.
-		for n := 2; ; n++ {
-			candidate := fmt.Sprintf("%s-%d", pidStr, n)
-			if _, statErr2 := os.Stat(filepath.Join(dir, candidate)); os.IsNotExist(statErr2) {
-				name = candidate
-				break
+	pid := strconv.Itoa(os.Getpid())
+
+	for n := 1; n < maxJoinIndex; n++ {
+		path := filepath.Join(dir, strconv.Itoa(n))
+		f, openErr := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if openErr != nil {
+			if os.IsExist(openErr) {
+				continue // slot taken; try the next one
 			}
+			return 0, nil, openErr
 		}
+		_, writeErr := f.WriteString(pid)
+		closeErr := f.Close()
+		if writeErr != nil {
+			_ = os.Remove(path)
+			return 0, nil, writeErr
+		}
+		if closeErr != nil {
+			_ = os.Remove(path)
+			return 0, nil, closeErr
+		}
+		release = func() { _ = os.Remove(path) }
+		return n, release, nil
 	}
-
-	entry := filepath.Join(dir, name)
-	if wErr := os.WriteFile(entry, []byte(pidStr), 0o600); wErr != nil {
-		return 0, nil, wErr
-	}
-	release = func() { _ = os.Remove(entry) }
-	return attachedCount(runID), release, nil
+	return 0, nil, fmt.Errorf("registerJoinedAgent: exhausted %d index slots for run %s", maxJoinIndex, runID)
 }
 
 // attachedCount returns the number of live joined agents for the run, pruning
@@ -80,21 +105,16 @@ func attachedCount(runID string) int {
 	if err != nil {
 		return 0
 	}
-	// Deterministic order keeps index assignment stable in tests.
-	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
 	live := 0
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
 		}
-		pid, ok := entryPID(e.Name())
-		if !ok {
-			continue
-		}
-		if pidAlive(pid) {
+		path := filepath.Join(dir, e.Name())
+		if entryAlive(path) {
 			live++
 		} else {
-			_ = os.Remove(filepath.Join(dir, e.Name()))
+			_ = os.Remove(path)
 		}
 	}
 	return live

--- a/internal/run/joined.go
+++ b/internal/run/joined.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -20,8 +21,15 @@ func attachedAgentsDir(runID string) string {
 
 // pidAlive reports whether the given pid is a live process.
 func pidAlive(pid int) bool {
+	// Reject non-positive pids: kill(0, 0) / kill(-1, 0) target process groups,
+	// not a single process, and would spuriously report "alive".
+	if pid <= 0 {
+		return false
+	}
 	// Signal 0 performs error checking without actually sending a signal.
-	return syscall.Kill(pid, 0) == nil
+	// EPERM means the process exists but is owned by another user — still alive.
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
 }
 
 // entryAlive reports whether the entry at path refers to a live process.

--- a/internal/run/joined.go
+++ b/internal/run/joined.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/majorcontext/moat/internal/storage"
@@ -30,7 +31,7 @@ func entryAlive(path string) bool {
 	if err != nil {
 		return false
 	}
-	pid, err := strconv.Atoi(string(data))
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
 		return false
 	}

--- a/internal/run/joined_test.go
+++ b/internal/run/joined_test.go
@@ -62,7 +62,7 @@ func TestAttachedAgents_PrunesDeadPid(t *testing.T) {
 	if got := attachedCount(runID); got != 0 {
 		t.Fatalf("count with only a dead pid = %d, want 0 (pruned)", got)
 	}
-	if _, err := os.Stat(dir + "/1"); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(dir, "1")); !os.IsNotExist(err) {
 		t.Fatalf("dead pid entry should have been pruned")
 	}
 }

--- a/internal/run/joined_test.go
+++ b/internal/run/joined_test.go
@@ -1,0 +1,67 @@
+package run
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAttachedAgents_RegisterCountRelease(t *testing.T) {
+	t.Setenv("MOAT_HOME", t.TempDir())
+	const runID = "run_test_join"
+
+	if got := attachedCount(runID); got != 0 {
+		t.Fatalf("initial count = %d, want 0", got)
+	}
+
+	idx1, release1, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 1: %v", err)
+	}
+	if idx1 != 1 {
+		t.Fatalf("first index = %d, want 1", idx1)
+	}
+	if got := attachedCount(runID); got != 1 {
+		t.Fatalf("count after 1 register = %d, want 1", got)
+	}
+
+	idx2, release2, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 2: %v", err)
+	}
+	if idx2 != 2 {
+		t.Fatalf("second index = %d, want 2", idx2)
+	}
+	if got := attachedCount(runID); got != 2 {
+		t.Fatalf("count after 2 registers = %d, want 2", got)
+	}
+
+	release1()
+	if got := attachedCount(runID); got != 1 {
+		t.Fatalf("count after 1 release = %d, want 1", got)
+	}
+	release2()
+	if got := attachedCount(runID); got != 0 {
+		t.Fatalf("count after 2 releases = %d, want 0", got)
+	}
+}
+
+func TestAttachedAgents_PrunesDeadPid(t *testing.T) {
+	t.Setenv("MOAT_HOME", t.TempDir())
+	const runID = "run_test_join_dead"
+
+	dir := attachedAgentsDir(runID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// A pid that is essentially never alive.
+	if err := os.WriteFile(dir+"/999999", []byte("999999"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := attachedCount(runID); got != 0 {
+		t.Fatalf("count with only a dead pid = %d, want 0 (pruned)", got)
+	}
+	if _, err := os.Stat(dir + "/999999"); !os.IsNotExist(err) {
+		t.Fatalf("dead pid entry should have been pruned")
+	}
+}

--- a/internal/run/joined_test.go
+++ b/internal/run/joined_test.go
@@ -53,15 +53,68 @@ func TestAttachedAgents_PrunesDeadPid(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	// A pid that is essentially never alive.
-	if err := os.WriteFile(dir+"/999999", []byte("999999"), 0o600); err != nil {
+	// Write an entry with index filename "1" and a dead pid as content.
+	if err := os.WriteFile(dir+"/1", []byte("999999"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
 	if got := attachedCount(runID); got != 0 {
 		t.Fatalf("count with only a dead pid = %d, want 0 (pruned)", got)
 	}
-	if _, err := os.Stat(dir + "/999999"); !os.IsNotExist(err) {
+	if _, err := os.Stat(dir + "/1"); !os.IsNotExist(err) {
 		t.Fatalf("dead pid entry should have been pruned")
 	}
+}
+
+func TestAttachedAgents_UniqueIndices(t *testing.T) {
+	t.Setenv("MOAT_HOME", t.TempDir())
+	const runID = "run_test_join_unique"
+
+	// Register three agents: should claim indices 1, 2, 3.
+	idx1, release1, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 1: %v", err)
+	}
+	idx2, release2, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 2: %v", err)
+	}
+	idx3, release3, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("register 3: %v", err)
+	}
+
+	if idx1 != 1 || idx2 != 2 || idx3 != 3 {
+		t.Fatalf("expected indices 1,2,3 got %d,%d,%d", idx1, idx2, idx3)
+	}
+	if got := attachedCount(runID); got != 3 {
+		t.Fatalf("count with 3 live agents = %d, want 3", got)
+	}
+
+	// Release slot 2; registering again should reclaim index 2 (lowest free).
+	release2()
+	if got := attachedCount(runID); got != 2 {
+		t.Fatalf("count after releasing index 2 = %d, want 2", got)
+	}
+
+	idx2b, release2b, err := registerJoinedAgent(runID)
+	if err != nil {
+		t.Fatalf("re-register after release: %v", err)
+	}
+	if idx2b != 2 {
+		t.Fatalf("re-registration should reclaim index 2 (lowest free), got %d", idx2b)
+	}
+	if got := attachedCount(runID); got != 3 {
+		t.Fatalf("count after re-register = %d, want 3", got)
+	}
+
+	// All live indices must be unique.
+	seen := map[int]bool{idx1: true, idx3: true, idx2b: true}
+	if len(seen) != 3 {
+		t.Fatalf("duplicate live indices: %d,%d,%d", idx1, idx3, idx2b)
+	}
+
+	release1()
+	release3()
+	release2b()
 }

--- a/internal/run/joined_test.go
+++ b/internal/run/joined_test.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -54,7 +55,7 @@ func TestAttachedAgents_PrunesDeadPid(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Write an entry with index filename "1" and a dead pid as content.
-	if err := os.WriteFile(dir+"/1", []byte("999999"), 0o600); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "1"), []byte("999999"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -3885,6 +3885,57 @@ func (m *Manager) Exec(ctx context.Context, runID string, cmd []string, stdin []
 	return execErr
 }
 
+// ExecInteractive runs a command inside a running container with a PTY,
+// streaming the provided opts. Used by `moat join` for interactive agents.
+func (m *Manager) ExecInteractive(ctx context.Context, runID string, cmd []string, opts container.ExecOptions) error {
+	m.mu.RLock()
+	r, ok := m.runs[runID]
+	if !ok {
+		m.mu.RUnlock()
+		return fmt.Errorf("run %s not found", runID)
+	}
+	containerID := r.ContainerID
+	auditStore := r.AuditStore
+	state := r.GetState()
+	m.mu.RUnlock()
+
+	if state != StateRunning {
+		return fmt.Errorf("run %s is not running (state: %s)", runID, state)
+	}
+
+	rt, rtErr := m.runtimeForRun(r)
+	if rtErr != nil {
+		return fmt.Errorf("resolving runtime for run %s: %w", runID, rtErr)
+	}
+
+	execErr := rt.ExecInteractive(ctx, containerID, cmd, opts)
+
+	if auditStore != nil {
+		exitCode := 0
+		var ee *container.ExecError
+		if errors.As(execErr, &ee) {
+			exitCode = ee.ExitCode
+		}
+		_, _ = auditStore.AppendExec(audit.ExecData{
+			Command:  cmd,
+			HasStdin: opts.Stdin != nil,
+			ExitCode: exitCode,
+		})
+	}
+	return execErr
+}
+
+// AttachedCount returns the number of live joined agents for a run (display-only).
+func (m *Manager) AttachedCount(runID string) int {
+	return attachedCount(runID)
+}
+
+// RegisterJoinedAgent records a joined agent for a run and returns its index and
+// a release func. Display-only; never affects teardown.
+func (m *Manager) RegisterJoinedAgent(runID string) (int, func(), error) {
+	return registerJoinedAgent(runID)
+}
+
 // FollowLogs streams container logs to the provided writer.
 // This is more reliable than Attach for output-only mode on already-running containers.
 func (m *Manager) FollowLogs(ctx context.Context, runID string, w io.Writer) error {

--- a/internal/run/manager_join_test.go
+++ b/internal/run/manager_join_test.go
@@ -1,0 +1,26 @@
+package run
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/container"
+)
+
+func TestManagerExecInteractive_RunNotFound(t *testing.T) {
+	m := &Manager{runs: map[string]*Run{}}
+	err := m.ExecInteractive(context.Background(), "run_missing", []string{"claude"}, container.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("got %v, want a 'not found' error", err)
+	}
+}
+
+func TestManagerExecInteractive_NotRunning(t *testing.T) {
+	r := &Run{ID: "run_stopped", State: StateStopped}
+	m := &Manager{runs: map[string]*Run{"run_stopped": r}}
+	err := m.ExecInteractive(context.Background(), "run_stopped", []string{"claude"}, container.ExecOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("got %v, want a 'not running' error", err)
+	}
+}

--- a/internal/run/manager_join_test.go
+++ b/internal/run/manager_join_test.go
@@ -24,3 +24,35 @@ func TestManagerExecInteractive_NotRunning(t *testing.T) {
 		t.Fatalf("got %v, want a 'not running' error", err)
 	}
 }
+
+// TestManagerExecInteractive_RuntimeResolveError verifies that ExecInteractive
+// returns the "resolving runtime" error when the run's Runtime field names a
+// type that is not available in the pool.
+func TestManagerExecInteractive_RuntimeResolveError(t *testing.T) {
+	// newEdgeCaseManager creates a pool whose only runtime is the flexibleRuntime
+	// (type = RuntimeDocker). A run whose Runtime field is set to "apple" requests
+	// a different type — one that is not in the pool — which triggers the
+	// runtimeForRun error path.
+	rt := &flexibleRuntime{done: make(chan struct{})}
+	m := newEdgeCaseManager(t, rt)
+
+	r := &Run{
+		ID:          "run_rt_resolve",
+		Name:        "rt-resolve",
+		ContainerID: "ctr-rt",
+		State:       StateRunning,
+		Runtime:     string(container.RuntimeApple), // pool only has Docker
+		exitCh:      make(chan struct{}),
+	}
+	m.mu.Lock()
+	m.runs[r.ID] = r
+	m.mu.Unlock()
+
+	err := m.ExecInteractive(context.Background(), r.ID, []string{"claude"}, container.ExecOptions{})
+	if err == nil {
+		t.Fatal("expected error when runtime cannot be resolved, got nil")
+	}
+	if !strings.Contains(err.Error(), "resolving runtime") {
+		t.Fatalf("expected 'resolving runtime' in error, got: %v", err)
+	}
+}

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -897,6 +897,9 @@ func (s *stubRuntime) ResizeTTY(context.Context, string, uint, uint) error {
 func (s *stubRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
 	panic("not implemented")
 }
+func (s *stubRuntime) ExecInteractive(context.Context, string, []string, container.ExecOptions) error {
+	panic("not implemented")
+}
 
 // TestLoadPersistedRunsCleansStaleRoutes verifies that loadPersistedRuns removes
 // routes for containers that are no longer running. This prevents the bug where

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -217,6 +217,20 @@ func (s *RunStore) LogWriter() (*LogWriter, error) {
 	return &LogWriter{file: f}, nil
 }
 
+// JoinLogWriter returns a timestamped writer for a joined agent's console,
+// written to logs.<index>.jsonl so it stays separate from the primary's log.
+func (s *RunStore) JoinLogWriter(index int) (*LogWriter, error) {
+	f, err := os.OpenFile(
+		filepath.Join(s.dir, fmt.Sprintf("logs.%d.jsonl", index)),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
+		0600,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("opening join log file: %w", err)
+	}
+	return &LogWriter{file: f}, nil
+}
+
 // ReadLogs reads log entries with offset and limit.
 func (s *RunStore) ReadLogs(offset, limit int) ([]LogEntry, error) {
 	f, err := os.Open(filepath.Join(s.dir, "logs.jsonl"))

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -1,9 +1,11 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -143,6 +145,42 @@ func TestLogWriter(t *testing.T) {
 		t.Errorf("Line = %q, want %q", entries[0].Line, "hello world")
 	}
 	if entries[0].Timestamp.IsZero() {
+		t.Error("Timestamp should not be zero")
+	}
+}
+
+func TestRunStore_JoinLogWriter(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := NewRunStore(dir, "run_joinlogs1")
+
+	const index = 2
+	w, err := s.JoinLogWriter(index)
+	if err != nil {
+		t.Fatalf("JoinLogWriter: %v", err)
+	}
+
+	w.Write([]byte("join hello\n"))
+	w.Close()
+
+	// Assert the file has the expected indexed name.
+	logPath := filepath.Join(dir, "run_joinlogs1", fmt.Sprintf("logs.%d.jsonl", index))
+	if _, statErr := os.Stat(logPath); os.IsNotExist(statErr) {
+		t.Fatalf("expected log file %s to exist", logPath)
+	}
+
+	// Read the raw JSONL and decode the first entry to check the line field.
+	data, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("reading join log file: %v", readErr)
+	}
+	var entry LogEntry
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(string(data))), &entry); jsonErr != nil {
+		t.Fatalf("decoding log entry: %v", jsonErr)
+	}
+	if entry.Line != "join hello" {
+		t.Errorf("Line = %q, want %q", entry.Line, "join hello")
+	}
+	if entry.Timestamp.IsZero() {
 		t.Error("Timestamp should not be zero")
 	}
 }

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -8,14 +8,16 @@ import (
 
 // StatusBar renders run context at the bottom of the terminal.
 type StatusBar struct {
-	runID   string
-	name    string
-	runtime string
-	grants  []string
-	warning string // persistent warning shown between grants and right side
-	width   int
-	height  int
-	message string // optional message overlay that replaces normal content
+	runID       string
+	name        string
+	runtime     string
+	grants      []string
+	warning     string // persistent warning shown between grants and right side
+	session     string // explicit session role for a joined session, e.g. "joined · 2"
+	joinedCount int    // number of joined agents (shown as "+N" on the primary)
+	width       int
+	height      int
+	message     string // optional message overlay that replaces normal content
 }
 
 // NewStatusBar creates a status bar with the given run metadata.
@@ -36,6 +38,30 @@ func (s *StatusBar) SetGrants(grants []string) {
 // SetWarning sets a persistent warning shown in the status bar (e.g. "proxy stale").
 func (s *StatusBar) SetWarning(warning string) {
 	s.warning = warning
+}
+
+// SetSession sets an explicit session-role label shown before the run-id
+// (e.g. "joined · 2"). Empty means a primary session.
+func (s *StatusBar) SetSession(label string) {
+	s.session = label
+}
+
+// SetJoinedCount sets the number of joined agents, rendered as "+N" before the
+// run-id on a primary session. Zero renders nothing.
+func (s *StatusBar) SetJoinedCount(n int) {
+	s.joinedCount = n
+}
+
+// sessionPlain returns the plain-text session segment (with a trailing space),
+// or "" when there is nothing to show.
+func (s *StatusBar) sessionPlain() string {
+	if s.session != "" {
+		return s.session + " "
+	}
+	if s.joinedCount > 0 {
+		return fmt.Sprintf("+%d ", s.joinedCount)
+	}
+	return ""
 }
 
 // SetDimensions sets terminal width and height.
@@ -66,6 +92,7 @@ func (s *StatusBar) Render() string {
 const (
 	bgDarkGray = "\x1b[48;5;236m"
 	fgCyan     = "\x1b[36m"
+	fgGreen    = "\x1b[32m"
 	fgMagenta  = "\x1b[35m"
 	fgYellow   = "\x1b[33m"
 	bold       = "\x1b[1m"
@@ -91,11 +118,11 @@ func (s *StatusBar) Content() string {
 	if s.message != "" {
 		return s.renderMessage()
 	}
-	return s.buildContent(true, true, true, true)
+	return s.buildContent(true, true, true, true, true)
 }
 
-// buildContent constructs the status bar with optional grants, name, and hint.
-func (s *StatusBar) buildContent(showGrants, showName, showHint, showWarning bool) string {
+// buildContent constructs the status bar with optional grants, name, hint, and session.
+func (s *StatusBar) buildContent(showGrants, showName, showHint, showWarning, showSession bool) string {
 	// Build left segments (plain text for measurement)
 	leftPlain := " moat "
 	runtimePlain := ""
@@ -111,35 +138,43 @@ func (s *StatusBar) buildContent(showGrants, showName, showHint, showWarning boo
 		warningPlain = " " + s.warning + " "
 	}
 
-	// Build right segment with optional hint
+	// Build right segment with optional session segment and hint
 	var rightPlain string
 	hintPlain := ""
 	if showHint {
 		hintPlain = " (ctrl+/)"
 	}
 
+	sessionSeg := ""
+	if showSession {
+		sessionSeg = s.sessionPlain()
+	}
+
 	if showName && s.name != "" {
-		rightPlain = fmt.Sprintf(" %s · %s%s ", s.runID, s.name, hintPlain)
+		rightPlain = fmt.Sprintf(" %s%s · %s%s ", sessionSeg, s.runID, s.name, hintPlain)
 	} else {
-		rightPlain = fmt.Sprintf(" %s%s ", s.runID, hintPlain)
+		rightPlain = fmt.Sprintf(" %s%s%s ", sessionSeg, s.runID, hintPlain)
 	}
 
 	totalPlain := runeLen(leftPlain) + runeLen(runtimePlain) + runeLen(grantsPlain) + runeLen(warningPlain) + runeLen(rightPlain)
 
 	if totalPlain > s.width {
-		// Truncation cascade: drop hint first, then grants, then name.
+		// Truncation cascade: drop hint first, then grants, then name, then session.
 		// Warning is kept as long as possible (dropped last) since it's diagnostic.
 		if showHint {
-			return s.buildContent(showGrants, showName, false, showWarning)
+			return s.buildContent(showGrants, showName, false, showWarning, showSession)
 		}
 		if showGrants && len(s.grants) > 0 {
-			return s.buildContent(false, showName, false, showWarning)
+			return s.buildContent(false, showName, false, showWarning, showSession)
 		}
 		if showName && s.name != "" {
-			return s.buildContent(false, false, false, showWarning)
+			return s.buildContent(false, false, false, showWarning, showSession)
+		}
+		if showSession && s.sessionPlain() != "" {
+			return s.buildContent(false, false, false, showWarning, false)
 		}
 		if showWarning && s.warning != "" {
-			return s.buildContent(false, false, false, false)
+			return s.buildContent(false, false, false, false, false)
 		}
 		if runeLen(leftPlain)+runeLen(rightPlain) > s.width {
 			// Just spaces
@@ -189,10 +224,20 @@ func (s *StatusBar) buildContent(showGrants, showName, showHint, showWarning boo
 	buf.WriteString(strings.Repeat(" ", middleLen))
 
 	// Build right segment with styling
+	buf.WriteString(" ")
+	if showSession {
+		if seg := s.sessionPlain(); seg != "" {
+			buf.WriteString(fgGreen)
+			buf.WriteString(strings.TrimRight(seg, " "))
+			buf.WriteString(reset)
+			buf.WriteString(bgDarkGray)
+			buf.WriteString(" ")
+		}
+	}
 	if showName && s.name != "" {
-		buf.WriteString(fmt.Sprintf(" %s · %s", s.runID, s.name))
+		buf.WriteString(fmt.Sprintf("%s · %s", s.runID, s.name))
 	} else {
-		buf.WriteString(fmt.Sprintf(" %s", s.runID))
+		buf.WriteString(s.runID)
 	}
 
 	// Add hint in dim style

--- a/internal/tui/statusbar.go
+++ b/internal/tui/statusbar.go
@@ -52,14 +52,28 @@ func (s *StatusBar) SetJoinedCount(n int) {
 	s.joinedCount = n
 }
 
-// sessionPlain returns the plain-text session segment (with a trailing space),
+// sessionBase returns the session segment text without any trailing separator,
 // or "" when there is nothing to show.
-func (s *StatusBar) sessionPlain() string {
+//
+// Rules:
+//   - s.session != "" → a joined session; returns s.session (e.g. "joined · 2"), green.
+//   - s.joinedCount > 0 → the primary with joins; returns "primary +N", red.
+//   - otherwise → solo primary; returns "" (no segment).
+func (s *StatusBar) sessionBase() string {
 	if s.session != "" {
-		return s.session + " "
+		return s.session
 	}
 	if s.joinedCount > 0 {
-		return fmt.Sprintf("+%d ", s.joinedCount)
+		return fmt.Sprintf("primary +%d", s.joinedCount)
+	}
+	return ""
+}
+
+// sessionPlain returns the plain-text session segment followed by " · " when
+// non-empty, or "" when there is nothing to show. Used for width measurement.
+func (s *StatusBar) sessionPlain() string {
+	if b := s.sessionBase(); b != "" {
+		return b + " · "
 	}
 	return ""
 }
@@ -94,6 +108,7 @@ const (
 	fgCyan     = "\x1b[36m"
 	fgGreen    = "\x1b[32m"
 	fgMagenta  = "\x1b[35m"
+	fgRed      = "\x1b[31m"
 	fgYellow   = "\x1b[33m"
 	bold       = "\x1b[1m"
 	dim        = "\x1b[2m"
@@ -226,12 +241,18 @@ func (s *StatusBar) buildContent(showGrants, showName, showHint, showWarning, sh
 	// Build right segment with styling
 	buf.WriteString(" ")
 	if showSession {
-		if seg := s.sessionPlain(); seg != "" {
-			buf.WriteString(fgGreen)
-			buf.WriteString(strings.TrimRight(seg, " "))
+		if base := s.sessionBase(); base != "" {
+			// Color: green for joined sessions, red for primary-with-joins.
+			color := fgGreen
+			if s.session == "" {
+				color = fgRed
+			}
+			buf.WriteString(color)
+			buf.WriteString(base)
 			buf.WriteString(reset)
 			buf.WriteString(bgDarkGray)
-			buf.WriteString(" ")
+			// Separator rendered in default footer style (not colored).
+			buf.WriteString(" · ")
 		}
 	}
 	if showName && s.name != "" {

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -309,6 +309,34 @@ func TestStatusBar_CtrlSlashHint(t *testing.T) {
 	t.Logf("Full width (80): %q", stripped)
 }
 
+func TestStatusBar_SessionSegment(t *testing.T) {
+	// Joined session shows "joined · N" before the run-id.
+	bar := NewStatusBar("run_123", "happy-otter", "apple")
+	bar.SetDimensions(120, 24)
+	bar.SetSession("joined · 2")
+	out := stripANSI(bar.Content())
+	if !strings.Contains(out, "joined · 2") {
+		t.Fatalf("joined session segment missing: %q", out)
+	}
+	if strings.Index(out, "joined · 2") > strings.Index(out, "run_123") {
+		t.Fatalf("session segment should appear before the run-id: %q", out)
+	}
+
+	// Primary with joins shows "+2"; primary solo shows neither.
+	primary := NewStatusBar("run_123", "happy-otter", "apple")
+	primary.SetDimensions(120, 24)
+	primary.SetJoinedCount(2)
+	if !strings.Contains(stripANSI(primary.Content()), "+2") {
+		t.Fatalf("primary +2 count missing")
+	}
+
+	solo := NewStatusBar("run_123", "happy-otter", "apple")
+	solo.SetDimensions(120, 24)
+	if strings.Contains(stripANSI(solo.Content()), "+0") {
+		t.Fatalf("solo primary should not show a +0 count")
+	}
+}
+
 func TestStatusBar_CtrlSlashHint_TruncationCascade(t *testing.T) {
 	bar := NewStatusBar("run_abc123", "my-agent", "docker")
 	bar.SetGrants([]string{"github", "aws"})

--- a/internal/tui/statusbar_test.go
+++ b/internal/tui/statusbar_test.go
@@ -310,30 +310,84 @@ func TestStatusBar_CtrlSlashHint(t *testing.T) {
 }
 
 func TestStatusBar_SessionSegment(t *testing.T) {
-	// Joined session shows "joined · N" before the run-id.
+	// Joined session: shows "joined · N · run-id" with green color.
 	bar := NewStatusBar("run_123", "happy-otter", "apple")
 	bar.SetDimensions(120, 24)
 	bar.SetSession("joined · 2")
-	out := stripANSI(bar.Content())
+	content := bar.Content()
+	out := stripANSI(content)
 	if !strings.Contains(out, "joined · 2") {
 		t.Fatalf("joined session segment missing: %q", out)
 	}
+	// Session label must precede the run-id.
 	if strings.Index(out, "joined · 2") > strings.Index(out, "run_123") {
 		t.Fatalf("session segment should appear before the run-id: %q", out)
 	}
+	// The separator between the session label and the run-id must be " · ".
+	// Expected pattern: "joined · 2 · run_123"
+	if !strings.Contains(out, "joined · 2 · run_123") {
+		t.Fatalf("joined session segment should be followed by ' · ' before run-id: %q", out)
+	}
+	// Joined sessions use green color.
+	if !strings.Contains(content, fgGreen) {
+		t.Fatalf("joined session should be green: %q", content)
+	}
 
-	// Primary with joins shows "+2"; primary solo shows neither.
+	// Primary with joins: shows "primary +2 · run-id" with red color.
 	primary := NewStatusBar("run_123", "happy-otter", "apple")
 	primary.SetDimensions(120, 24)
 	primary.SetJoinedCount(2)
-	if !strings.Contains(stripANSI(primary.Content()), "+2") {
-		t.Fatalf("primary +2 count missing")
+	primaryContent := primary.Content()
+	primaryOut := stripANSI(primaryContent)
+	if !strings.Contains(primaryOut, "primary +2") {
+		t.Fatalf("primary +2 label missing: %q", primaryOut)
+	}
+	// Label must precede run-id.
+	if strings.Index(primaryOut, "primary +2") > strings.Index(primaryOut, "run_123") {
+		t.Fatalf("primary label should appear before the run-id: %q", primaryOut)
+	}
+	// Must have " · " separator between label and run-id.
+	if !strings.Contains(primaryOut, "primary +2 · run_123") {
+		t.Fatalf("primary label should be followed by ' · ' before run-id: %q", primaryOut)
+	}
+	// Primary-with-joins uses red color.
+	if !strings.Contains(primaryContent, fgRed) {
+		t.Fatalf("primary-with-joins should be red: %q", primaryContent)
 	}
 
+	// Solo primary: no session segment at all.
 	solo := NewStatusBar("run_123", "happy-otter", "apple")
 	solo.SetDimensions(120, 24)
-	if strings.Contains(stripANSI(solo.Content()), "+0") {
-		t.Fatalf("solo primary should not show a +0 count")
+	soloOut := stripANSI(solo.Content())
+	if strings.Contains(soloOut, "+0") {
+		t.Fatalf("solo primary should not show a +0 count: %q", soloOut)
+	}
+	if strings.Contains(soloOut, "primary") {
+		t.Fatalf("solo primary should not show 'primary' label: %q", soloOut)
+	}
+	if strings.Contains(soloOut, "joined") {
+		t.Fatalf("solo primary should not show 'joined' label: %q", soloOut)
+	}
+
+	// Width alignment: plain measurement must match visible output width.
+	for _, tc := range []struct {
+		name  string
+		setup func(*StatusBar)
+	}{
+		{"solo", func(b *StatusBar) {}},
+		{"joined", func(b *StatusBar) { b.SetSession("joined · 2") }},
+		{"primary+joins", func(b *StatusBar) { b.SetJoinedCount(2) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewStatusBar("run_123", "happy-otter", "apple")
+			b.SetDimensions(120, 24)
+			tc.setup(b)
+			stripped := stripANSI(b.Content())
+			got := len([]rune(stripped))
+			if got != 120 {
+				t.Errorf("footer width = %d, want 120: %q", got, stripped)
+			}
+		})
 	}
 }
 

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -991,6 +991,17 @@ func (w *Writer) SetJoinedCount(n int) {
 	w.bar.SetJoinedCount(n)
 }
 
+// RefreshFooter repaints the footer to reflect updated status-bar state.
+// In compositor mode the render loop already repaints at renderInterval, so
+// this only needs to act in scroll mode.
+func (w *Writer) RefreshFooter() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if !w.altScreen {
+		w.redrawFooterLocked()
+	}
+}
+
 // SetupEscapeHints configures the escape proxy to show escape sequence hints
 // in the status bar when Ctrl-/ is pressed.
 func (w *Writer) SetupEscapeHints(proxy *term.EscapeProxy) {

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -82,6 +82,11 @@ type Writer struct {
 	altScreen bool
 	emulator  *vt.Emulator
 
+	// cleanedUp is set once Cleanup() has torn down the status bar. Guards
+	// late repaints (e.g. a footer-count poll firing RefreshFooter after exit)
+	// from painting a stray status line over the reset screen.
+	cleanedUp bool
+
 	// Escape sequence parser state for detecting alt screen sequences
 	// that may be split across Write() calls.
 	escBuf []byte
@@ -884,6 +889,8 @@ func (w *Writer) Cleanup() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
+	w.cleanedUp = true
+
 	// Stop footer timer if running
 	if w.footerTimer != nil {
 		w.footerTimer.Stop()
@@ -997,6 +1004,9 @@ func (w *Writer) SetJoinedCount(n int) {
 func (w *Writer) RefreshFooter() {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if w.cleanedUp {
+		return
+	}
 	if !w.altScreen {
 		w.redrawFooterLocked()
 	}

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -983,6 +983,14 @@ func (w *Writer) ClearMessage() {
 	w.bar.ClearMessage()
 }
 
+// SetJoinedCount updates the joined-agent count shown in the status footer.
+// Calling this on SIGWINCH keeps the primary's "+N" badge live.
+func (w *Writer) SetJoinedCount(n int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.bar.SetJoinedCount(n)
+}
+
 // SetupEscapeHints configures the escape proxy to show escape sequence hints
 // in the status bar when Ctrl-/ is pressed.
 func (w *Writer) SetupEscapeHints(proxy *term.EscapeProxy) {


### PR DESCRIPTION
## Summary

Adds `moat join <run> <agent>` — launch a second agent inside an already-running container, reusing its workspace, grants, and credentials without creating a new container or proxy registration.

```
moat join <run> <agent> [agent flags…]

moat join run_123 claude
moat join my-feature claude --continue
moat join run_123 claude -p "summarize the diff"
```

`join` is the run-first sibling of `exec` (`join : exec :: claude : run`): a configured-agent entry into an existing container, vs `exec`'s raw command.

## Design

- **PTY-backed interactive exec.** New `Runtime.ExecInteractive` (Docker + Apple) — the `docker exec -it` equivalent; the existing non-interactive `Exec` is unchanged.
- **Lifecycle.** Joins are exec children: the original agent keeps owning the container; stopping the run tears down joins with it. No new persistence, no daemon API changes (the join shares the run's existing proxy token — credential injection is automatic).
- **Same-provider v1 scope.** A clear error gates joining a different provider or a generic `moat run` container. Cross-provider join is deferred to create-time multi-agent provisioning (see the design doc).
- **Observability.** Console is split per agent (`logs.<index>.jsonl`); network/audit stay interleaved at the run level via the shared token.
- **Status footer.** Owner shows red `primary +N` when joins exist; each join shows `joined · N` (a stable, unique index via an `O_EXCL` registry); the primary count live-refreshes.

Design + plan: `docs/plans/2026-06-16-multi-agent-join-{design,plan}.md`.

## Testing

- Unit tests for the registry, provider `JoinCommand`/`IdentifiesAs`, `validateJoinAgent`, the `resizePump` channel lifecycle (under `-race`), footer rendering, split-console writer, and the manager runtime-resolve error path.
- **Integration:** `TestDockerExecInteractive` exercises the real PTY exec against Docker (TTY output + exit-code propagation).
- E2E scaffold (`internal/e2e/join_test.go`) wired to the harness for a container host.
- `make lint` clean; full unit suite green.

## Reviewed

Ran a multi-agent code review (correctness, security, adversarial, reliability, testing, maintainability, project-standards). No correctness or security defects. All P1/P2/P3 findings were fixed in this branch — notably a footer-poll use-after-cleanup guard, SIGTERM terminal-restore in the join loop, unified exit-code handling across both join paths, and closing the runtime-path test gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
