### PR TITLE
feat(mcp): add Langfuse regional MCP shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ### Added
 
-- **Langfuse MCP shortcuts** — `langfuse-eu`, `langfuse-us`, `langfuse-jp`, and `langfuse-hipaa` are now recognized shorthand names in `mcp:`. Each resolves to the regional Langfuse MCP endpoint (`/api/public/mcp`) with Basic auth via a shared `mcp-langfuse` grant. Grant once with `moat grant mcp langfuse` (credential: `Basic <base64(pk:sk)>`), then list the regional name in `moat.yaml`. Self-hosted instances still use the full `url` + `auth` form. ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
+- **Langfuse MCP shortcuts** — `langfuse-eu`, `langfuse-us`, `langfuse-jp`, and `langfuse-hipaa` are now recognized shorthand names in `mcp:`. Each resolves to the regional Langfuse MCP endpoint (`/api/public/mcp`) with Basic auth via a shared `mcp-langfuse` grant. Grant once with `moat grant mcp langfuse` (credential: `Basic <base64(pk:sk)>`), then list the regional name in `moat.yaml`. Self-hosted instances still use the full `url` + `auth` form. ([#384](https://github.com/majorcontext/moat/pull/384))
 - **Declarative MCP shorthand** — list a well-known MCP server in `moat.yaml` by name alone (a bare `- linear` under `mcp:`), and Moat resolves the URL, auth header, and required grant from its built-in catalog. The map form (`- name: linear`) still works for attaching a policy or overriding fields, and unknown servers still take an explicit `url` + `auth`. `moat grant oauth` now prints this shorthand. ([#383](https://github.com/majorcontext/moat/pull/383))
 - **`moat join`** — launch a second agent inside an already-running container,
   reusing its workspace, grants, and credentials without a new container. v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 
 ### Added
 
+- **Langfuse MCP shortcuts** — `langfuse-eu`, `langfuse-us`, `langfuse-jp`, and `langfuse-hipaa` are now recognized shorthand names in `mcp:`. Each resolves to the regional Langfuse MCP endpoint (`/api/public/mcp`) with Basic auth via a shared `mcp-langfuse` grant. Grant once with `moat grant mcp langfuse` (credential: `Basic <base64(pk:sk)>`), then list the regional name in `moat.yaml`. Self-hosted instances still use the full `url` + `auth` form. ([#NNN](https://github.com/majorcontext/moat/pull/NNN))
 - **Declarative MCP shorthand** — list a well-known MCP server in `moat.yaml` by name alone (a bare `- linear` under `mcp:`), and Moat resolves the URL, auth header, and required grant from its built-in catalog. The map form (`- name: linear`) still works for attaching a policy or overriding fields, and unknown servers still take an explicit `url` + `auth`. `moat grant oauth` now prints this shorthand. ([#383](https://github.com/majorcontext/moat/pull/383))
 - **`moat join`** — launch a second agent inside an already-running container,
   reusing its workspace, grants, and credentials without a new container. v1

--- a/cmd/moat/cli/grant_mcp.go
+++ b/cmd/moat/cli/grant_mcp.go
@@ -32,6 +32,12 @@ Examples:
         header: CONTEXT7_API_KEY
   YAML
 
+  # Grant Langfuse MCP access (Basic auth — paste the full header value)
+  moat grant mcp langfuse
+  # Credential: Basic <base64 of "pk-lf-...:sk-lf-..."> e.g.
+  #   echo -n "pk-lf-...:sk-lf-..." | base64
+  # then in moat.yaml:  mcp: [langfuse-us]
+
   # Use in a run
   moat claude ./workspace`,
 	Args: cobra.ExactArgs(1),

--- a/docs/content/guides/09-mcp.md
+++ b/docs/content/guides/09-mcp.md
@@ -470,6 +470,60 @@ Run `moat grant oauth <name>` once to authorize; the credential is stored and
 injected at run time. Servers not in the catalog still require the full
 `url` + `auth` form.
 
+### Langfuse
+
+Langfuse uses HTTP Basic auth rather than OAuth. Four regional shortcuts are
+available (`langfuse-eu`, `langfuse-us`, `langfuse-jp`, `langfuse-hipaa`); pick
+the one that matches your Langfuse project.
+
+**1. Build the credential**
+
+Langfuse's API key is a public/secret key pair. Encode it as a Basic auth header:
+
+```bash
+echo -n "pk-lf-your-public-key:sk-lf-your-secret-key" | base64
+```
+
+Prefix the output with `Basic ` (with a space). The full value looks like
+`Basic cGstbGYtLi4uOnNrLWxmLS4uLg==`.
+
+**2. Grant the credential**
+
+```bash
+moat grant mcp langfuse
+Credential: Basic <paste the value from step 1>
+```
+
+The grant name is `mcp-langfuse`. All four regional shortcuts share this grant,
+so you only need to run this once.
+
+**3. Configure in moat.yaml**
+
+```yaml
+mcp:
+  - langfuse-us   # or langfuse-eu / langfuse-jp / langfuse-hipaa
+```
+
+Available shorthand names and their hosts:
+
+| Name | Host |
+|------|------|
+| `langfuse-eu` | cloud.langfuse.com |
+| `langfuse-us` | us.cloud.langfuse.com |
+| `langfuse-jp` | jp.cloud.langfuse.com |
+| `langfuse-hipaa` | hipaa.cloud.langfuse.com |
+
+For a self-hosted Langfuse instance, use the full map form:
+
+```yaml
+mcp:
+  - name: langfuse
+    url: https://langfuse.internal.acme.com/api/public/mcp
+    auth:
+      grant: mcp-langfuse
+      header: Authorization
+```
+
 ### Token refresh
 
 OAuth tokens are auto-refreshed during runs. When a token expires, the proxy uses the stored refresh token to obtain a new access token without interrupting the agent.

--- a/docs/content/reference/02-moat-yaml.md
+++ b/docs/content/reference/02-moat-yaml.md
@@ -1321,9 +1321,32 @@ MCP servers running on the host machine (e.g., `http://localhost:3000`) are not 
 **See also:** [MCP servers guide](../guides/09-mcp.md#remote-mcp-servers)
 
 Each `mcp:` entry may be a bare service name (a string) when the server is in
-Moat's built-in catalog (e.g. `linear`, `notion`, `posthog`). The bare name
-resolves to its `url` and `auth` automatically; switch to the map form to add a
-`policy` or override a field. Unknown names require an explicit `url`.
+Moat's built-in catalog. The bare name resolves to its `url` and `auth`
+automatically; switch to the map form to add a `policy` or override a field.
+Unknown names require an explicit `url`.
+
+Recognized shorthand names:
+
+| Name | Auth type | Grant |
+|------|-----------|-------|
+| `asana` | OAuth | `oauth:asana` |
+| `betterstack` | OAuth | `oauth:betterstack` |
+| `cloudflare` | OAuth | `oauth:cloudflare` |
+| `context7` | API key | `mcp-context7` |
+| `hubspot` | OAuth | `oauth:hubspot` |
+| `langfuse-eu` | Basic auth | `mcp-langfuse` |
+| `langfuse-hipaa` | Basic auth | `mcp-langfuse` |
+| `langfuse-jp` | Basic auth | `mcp-langfuse` |
+| `langfuse-us` | Basic auth | `mcp-langfuse` |
+| `linear` | OAuth | `oauth:linear` |
+| `notion` | OAuth | `oauth:notion` |
+| `posthog` | OAuth | `oauth:posthog` |
+| `sentry` | OAuth | `oauth:sentry` |
+| `stripe` | OAuth | `oauth:stripe` |
+
+For Langfuse, pick the entry matching your project's region. All four share the
+`mcp-langfuse` grant. See the [MCP guide](../guides/09-mcp.md#langfuse) for the
+Basic auth credential format.
 
 ### mcp[].policy
 

--- a/examples/mcp-langfuse/README.md
+++ b/examples/mcp-langfuse/README.md
@@ -1,0 +1,64 @@
+# Langfuse MCP server
+
+Give Claude Code access to Langfuse's MCP server for LLM observability, tracing, and evaluation.
+
+## What this demonstrates
+
+- API-key credential granting with Basic auth (`moat grant mcp langfuse`)
+- Remote MCP server shorthand — `langfuse-us` resolves URL and auth from the built-in catalog
+- Per-region server selection
+
+## Regions
+
+Pick the entry that matches your Langfuse project:
+
+| Name | Host |
+|------|------|
+| `langfuse-eu` | cloud.langfuse.com |
+| `langfuse-us` | us.cloud.langfuse.com |
+| `langfuse-jp` | jp.cloud.langfuse.com |
+| `langfuse-hipaa` | hipaa.cloud.langfuse.com |
+
+Edit `moat.yaml` to replace `langfuse-us` with the correct region before running.
+
+## Setup
+
+### 1. Build the credential
+
+Langfuse uses HTTP Basic auth. The credential is `Basic <base64>` where the base64 encodes
+`public-key:secret-key`:
+
+```bash
+echo -n "pk-lf-your-public-key:sk-lf-your-secret-key" | base64
+```
+
+Prefix the result with `Basic ` (note the trailing space before the base64 string).
+
+### 2. Grant the credential
+
+```bash
+moat grant mcp langfuse
+Credential: Basic <paste the value from step 1>
+```
+
+The credential is stored encrypted under grant name `mcp-langfuse` and injected by the
+proxy for all `langfuse-*` servers (they share the same grant).
+
+## Run
+
+```bash
+moat claude examples/mcp-langfuse
+```
+
+## Self-hosted Langfuse
+
+For a self-hosted instance, use the full map form instead of the shorthand name:
+
+```yaml
+mcp:
+  - name: langfuse
+    url: https://langfuse.internal.acme.com/api/public/mcp
+    auth:
+      grant: mcp-langfuse
+      header: Authorization
+```

--- a/examples/mcp-langfuse/moat.yaml
+++ b/examples/mcp-langfuse/moat.yaml
@@ -1,0 +1,28 @@
+# Example: Langfuse MCP server with Basic auth
+#
+# Gives Claude Code access to Langfuse's MCP server for LLM observability,
+# tracing, and evaluation. Credentials are injected transparently by the
+# proxy — the agent never sees raw tokens.
+#
+# First, grant your Langfuse API credentials (one-time):
+#   moat grant mcp langfuse
+#   Credential: Basic <base64 of "pk-lf-...:sk-lf-...">
+#   e.g.: echo -n "pk-lf-...:sk-lf-..." | base64
+#   then prefix with "Basic "
+#
+# Then run:
+#   moat claude examples/mcp-langfuse
+
+name: mcp-langfuse
+
+dependencies:
+  - claude-code
+
+grants:
+  - claude
+
+command: ["claude"]
+interactive: true
+
+mcp:
+  - langfuse-us   # or langfuse-eu / langfuse-jp / langfuse-hipaa

--- a/internal/mcpcatalog/catalog_test.go
+++ b/internal/mcpcatalog/catalog_test.go
@@ -19,6 +19,13 @@ func TestLookup(t *testing.T) {
 		{"sentry", Entry{URL: "https://mcp.sentry.dev/mcp", Grant: "oauth:sentry", Header: "Authorization", OAuth: true}, true},
 		// Object entry → explicit API-key auth preserved, no defaulting (OAuth=false).
 		{"context7", Entry{URL: "https://mcp.context7.com/mcp", Grant: "mcp-context7", Header: "CONTEXT7_API_KEY", OAuth: false}, true},
+		// Langfuse regional entries — object form, shared grant, Authorization header.
+		{"langfuse-eu", Entry{URL: "https://cloud.langfuse.com/api/public/mcp", Grant: "mcp-langfuse", Header: "Authorization", OAuth: false}, true},
+		{"langfuse-us", Entry{URL: "https://us.cloud.langfuse.com/api/public/mcp", Grant: "mcp-langfuse", Header: "Authorization", OAuth: false}, true},
+		{"langfuse-jp", Entry{URL: "https://jp.cloud.langfuse.com/api/public/mcp", Grant: "mcp-langfuse", Header: "Authorization", OAuth: false}, true},
+		{"langfuse-hipaa", Entry{URL: "https://hipaa.cloud.langfuse.com/api/public/mcp", Grant: "mcp-langfuse", Header: "Authorization", OAuth: false}, true},
+		// No bare langfuse alias.
+		{"langfuse", Entry{}, false},
 		// Unknown.
 		{"nonexistent", Entry{}, false},
 	}
@@ -32,6 +39,30 @@ func TestLookup(t *testing.T) {
 				t.Errorf("Lookup(%q) = %+v, want %+v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLangfuseRegions(t *testing.T) {
+	regions := []string{"langfuse-eu", "langfuse-us", "langfuse-jp", "langfuse-hipaa"}
+	urls := make(map[string]bool)
+	for _, name := range regions {
+		e, ok := Lookup(name)
+		if !ok {
+			t.Fatalf("Lookup(%q) not found", name)
+		}
+		if e.Grant != "mcp-langfuse" {
+			t.Errorf("Lookup(%q).Grant = %q, want %q", name, e.Grant, "mcp-langfuse")
+		}
+		if e.Header != "Authorization" {
+			t.Errorf("Lookup(%q).Header = %q, want %q", name, e.Header, "Authorization")
+		}
+		if e.OAuth {
+			t.Errorf("Lookup(%q).OAuth = true, want false", name)
+		}
+		if urls[e.URL] {
+			t.Errorf("Lookup(%q).URL %q is a duplicate", name, e.URL)
+		}
+		urls[e.URL] = true
 	}
 }
 

--- a/internal/mcpcatalog/registry.yaml
+++ b/internal/mcpcatalog/registry.yaml
@@ -18,16 +18,24 @@ context7:
 hubspot: https://mcp.hubspot.com
 langfuse-eu:
   url: https://cloud.langfuse.com/api/public/mcp
-  auth: { grant: mcp-langfuse, header: Authorization }
+  auth:
+    grant: mcp-langfuse
+    header: Authorization
 langfuse-hipaa:
   url: https://hipaa.cloud.langfuse.com/api/public/mcp
-  auth: { grant: mcp-langfuse, header: Authorization }
+  auth:
+    grant: mcp-langfuse
+    header: Authorization
 langfuse-jp:
   url: https://jp.cloud.langfuse.com/api/public/mcp
-  auth: { grant: mcp-langfuse, header: Authorization }
+  auth:
+    grant: mcp-langfuse
+    header: Authorization
 langfuse-us:
   url: https://us.cloud.langfuse.com/api/public/mcp
-  auth: { grant: mcp-langfuse, header: Authorization }
+  auth:
+    grant: mcp-langfuse
+    header: Authorization
 linear: https://mcp.linear.app/mcp
 notion: https://mcp.notion.com/mcp
 posthog: https://mcp.posthog.com/mcp

--- a/internal/mcpcatalog/registry.yaml
+++ b/internal/mcpcatalog/registry.yaml
@@ -16,6 +16,18 @@ context7:
     grant: mcp-context7
     header: CONTEXT7_API_KEY
 hubspot: https://mcp.hubspot.com
+langfuse-eu:
+  url: https://cloud.langfuse.com/api/public/mcp
+  auth: { grant: mcp-langfuse, header: Authorization }
+langfuse-hipaa:
+  url: https://hipaa.cloud.langfuse.com/api/public/mcp
+  auth: { grant: mcp-langfuse, header: Authorization }
+langfuse-jp:
+  url: https://jp.cloud.langfuse.com/api/public/mcp
+  auth: { grant: mcp-langfuse, header: Authorization }
+langfuse-us:
+  url: https://us.cloud.langfuse.com/api/public/mcp
+  auth: { grant: mcp-langfuse, header: Authorization }
 linear: https://mcp.linear.app/mcp
 notion: https://mcp.notion.com/mcp
 posthog: https://mcp.posthog.com/mcp


### PR DESCRIPTION
## Summary

- Adds four object-form catalog entries to `internal/mcpcatalog/registry.yaml`: `langfuse-eu`, `langfuse-us`, `langfuse-jp`, `langfuse-hipaa`, each pointing at `https://<host>/api/public/mcp` with `grant: mcp-langfuse` and `header: Authorization`
- No bare `langfuse` alias — forces explicit region selection (the existing unknown-name error already lists valid names)
- Adds `moat grant mcp langfuse` help example documenting the `Basic <base64(pk:sk)>` credential format
- Adds `examples/mcp-langfuse/` with `moat.yaml` and a `README.md` covering the base64 step, region choice, and self-hosted override
- Updates `docs/content/guides/09-mcp.md` with a Langfuse section and `docs/content/reference/02-moat-yaml.md` with a catalog name table

## Test plan

- [ ] `go test ./internal/mcpcatalog/` — `TestLookup` covers all four regions + absent bare alias; `TestLangfuseRegions` asserts same grant/header + distinct URLs
- [ ] `go test ./internal/config/` — existing shorthand resolution tests cover the object-form path
- [ ] `go build ./...` passes
- [ ] `make lint` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)