### PR TITLE
feat(mcp): adopt mcp:<name> grant naming (mcp-<name> still accepted)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between min
 - **PostHog OAuth shortcut** — `moat grant oauth posthog` now auto-discovers OAuth endpoints from PostHog's MCP server (`https://mcp.posthog.com/mcp`) without needing `--url` or a config file, matching the other well-known services (asana, cloudflare, hubspot, linear, notion, stripe). ([#382](https://github.com/majorcontext/moat/pull/382))
 - **Ministack service** — `ministack` is now available as a `service` dependency, running the LocalStack-compatible Ministack local cloud emulator as a sidecar container. Declare `ministack` under `dependencies` and configure it under `services.ministack` (e.g. `env`, `wait`). Readiness is probed against the container's `/_ministack/health` endpoint. ([#366](https://github.com/majorcontext/moat/pull/366))
 
+### Changed
+
+- MCP API-key grants now use the `mcp:<name>` (colon) naming convention, mirroring `oauth:<name>`. `moat grant mcp <name>` stores the credential as `mcp:<name>` and prints `grant: mcp:<name>` in its moat.yaml snippet, and the well-known `context7` catalog entry resolves to `mcp:context7`. The previous `mcp-<name>` (hyphen) form is still accepted everywhere — existing stored credentials and `moat.yaml` files keep working — but it is deprecated; prefer `mcp:<name>`. No migration is required. ([#386](https://github.com/majorcontext/moat/pull/386))
+
 ### Fixed
 
 - Fix the `moat.yaml` snippet printed by `moat grant oauth` being invalid — previously, the suggested `mcp:` block emitted `auth.grant` but omitted `auth.header`, so copying it verbatim into `moat.yaml` failed config validation with `'auth.header' is required when auth is specified`. The snippet now includes `header: Authorization`. ([#382](https://github.com/majorcontext/moat/pull/382))

--- a/cmd/moat/cli/grant_list.go
+++ b/cmd/moat/cli/grant_list.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"text/tabwriter"
 
 	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/mcpcatalog"
 	"github.com/majorcontext/moat/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -147,7 +147,8 @@ func credType(c credential.Credential) string {
 		}
 		return "registry"
 	default:
-		if strings.HasPrefix(string(c.Provider), "mcp-") {
+		// Accept both "mcp:<name>" (canonical) and "mcp-<name>" (deprecated).
+		if mcpcatalog.IsGrant(string(c.Provider)) {
 			return "mcp"
 		}
 		return "token"

--- a/cmd/moat/cli/grant_mcp.go
+++ b/cmd/moat/cli/grant_mcp.go
@@ -28,7 +28,7 @@ Examples:
     - name: context7
       url: https://mcp.context7.com/mcp
       auth:
-        grant: mcp-context7
+        grant: mcp:context7
         header: CONTEXT7_API_KEY
   YAML
 
@@ -51,7 +51,7 @@ func runGrantMCP(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Enter credential for MCP server '%s'\n", name)
-	fmt.Printf("This will be stored as grant 'mcp-%s'\n\n", name)
+	fmt.Printf("This will be stored as grant 'mcp:%s'\n\n", name)
 	fmt.Print("Credential: ")
 
 	credBytes, err := readPassword()
@@ -73,7 +73,7 @@ func runGrantMCP(cmd *cobra.Command, args []string) error {
 
 	// Store credential
 	cred := credential.Credential{
-		Provider:  credential.Provider(fmt.Sprintf("mcp-%s", name)),
+		Provider:  credential.Provider(fmt.Sprintf("mcp:%s", name)),
 		Token:     credentialStr,
 		CreatedAt: time.Now(),
 	}
@@ -83,13 +83,13 @@ func runGrantMCP(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("\nMCP credential 'mcp-%s' saved to %s\n", name, credPath)
+	fmt.Printf("\nMCP credential 'mcp:%s' saved to %s\n", name, credPath)
 	fmt.Printf("\nConfigure in moat.yaml:\n\n")
 	fmt.Printf(`mcp:
   - name: %s
     url: https://mcp.example.com/mcp
     auth:
-      grant: mcp-%s
+      grant: mcp:%s
       header: YOUR_HEADER_NAME
 
 `, name, name)

--- a/cmd/moat/cli/grant_test.go
+++ b/cmd/moat/cli/grant_test.go
@@ -47,14 +47,15 @@ func TestGrantMCP(t *testing.T) {
 	// Verify credential was saved
 	key, _ := credential.DefaultEncryptionKey()
 	store, _ := credential.NewFileStore(credential.DefaultStoreDir(), key)
-	cred, err := store.Get(credential.Provider("mcp-context7"))
+	// Canonical form is "mcp:<name>" (mirrors "oauth:<name>").
+	cred, err := store.Get(credential.Provider("mcp:context7"))
 
 	if err != nil {
 		t.Fatalf("failed to retrieve credential: %v", err)
 	}
 
-	if cred.Provider != "mcp-context7" {
-		t.Errorf("expected provider 'mcp-context7', got %q", cred.Provider)
+	if cred.Provider != "mcp:context7" {
+		t.Errorf("expected provider 'mcp:context7', got %q", cred.Provider)
 	}
 
 	if cred.Token != "test-api-key-123" {

--- a/cmd/moat/cli/revoke.go
+++ b/cmd/moat/cli/revoke.go
@@ -20,7 +20,7 @@ Supported providers:
   anthropic         Anthropic API key
   openai            OpenAI API key or OAuth credentials
   aws               AWS IAM role configuration
-  mcp-<name>        MCP server credential
+  mcp:<name>        MCP server credential (mcp-<name> also accepted)
 
 The credential file is permanently deleted.
 
@@ -37,7 +37,7 @@ Examples:
   moat revoke github
 
   # Revoke MCP server credential
-  moat revoke mcp-context7
+  moat revoke mcp:context7
 
   # Revoke a credential from a specific profile
   moat revoke github --profile myproject

--- a/docs/content/concepts/02-credentials.md
+++ b/docs/content/concepts/02-credentials.md
@@ -40,7 +40,7 @@ A **grant** is a credential made available to a run. Each grant type targets spe
 | `npm` | Per-registry (e.g., `registry.npmjs.org`) | `Authorization: Bearer` header |
 | `aws` | `*.amazonaws.com` | `credential_process` via AWS SDK |
 | `ssh:<host>` | The specified host only | SSH agent proxy |
-| `mcp-<name>` | Host from MCP server `url` field | Custom header injection |
+| `mcp:<name>` | Host from MCP server `url` field | Custom header injection |
 
 Grants are configured via the `--grant` CLI flag or the `grants:` field in `moat.yaml`. Credentials from CLI flags are merged with those in `moat.yaml`. See the [Grants reference](../reference/04-grants.md) for syntax details and per-provider setup instructions.
 

--- a/docs/content/guides/09-mcp.md
+++ b/docs/content/guides/09-mcp.md
@@ -37,10 +37,12 @@ Store credentials for the MCP server with `moat grant mcp`:
 ```bash
 $ moat grant mcp context7
 Enter credential for MCP server 'context7': ***************
-MCP credential 'mcp-context7' saved to ~/.moat/credentials/mcp-context7.enc
+MCP credential 'mcp:context7' saved to ~/.moat/credentials/mcp:context7.enc
 ```
 
-The credential is encrypted and stored locally. The grant name follows the pattern `mcp-<name>`.
+The credential is encrypted and stored locally. The grant name follows the pattern `mcp:<name>`, mirroring the `oauth:<name>` convention.
+
+> The older `mcp-<name>` (hyphen) form is still accepted for backward compatibility but is deprecated. Prefer `mcp:<name>`.
 
 For public MCP servers that do not require authentication, skip this step.
 
@@ -53,7 +55,7 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 ```
 
@@ -68,7 +70,7 @@ mcp:
 
 | Field | Description |
 |-------|-------------|
-| `auth.grant` | Grant name to use (format: `mcp-<name>`) |
+| `auth.grant` | Grant name to use (format: `mcp:<name>`; the deprecated `mcp-<name>` form is still accepted) |
 | `auth.header` | HTTP header name for credential injection |
 
 Omit the `auth` block for public MCP servers that do not require authentication:
@@ -96,13 +98,13 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 
   - name: notion
     url: https://notion-mcp.example.com
     auth:
-      grant: mcp-notion
+      grant: mcp:notion
       header: Notion-Token
 ```
 
@@ -134,7 +136,7 @@ mcp:
   - name: my-tools
     url: http://localhost:3000/mcp
     auth:
-      grant: mcp-my-tools
+      grant: mcp:my-tools
       header: Authorization
 ```
 
@@ -161,7 +163,7 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 
   - name: local-tools
@@ -187,7 +189,7 @@ mcp:
   - name: linear
     url: https://mcp.linear.app/mcp
     auth:
-      grant: mcp-linear
+      grant: mcp:linear
       header: Authorization
     policy: linear-readonly
 ```
@@ -489,7 +491,7 @@ Credential injection events are recorded in audit logs:
 ```bash
 $ moat audit
 
-[10:23:44.500] credential.injected grant=mcp-context7 host=mcp.context7.com header=CONTEXT7_API_KEY
+[10:23:44.500] credential.injected grant=mcp:context7 host=mcp.context7.com header=CONTEXT7_API_KEY
 ```
 
 Sandbox-local MCP server output appears in container logs:
@@ -503,13 +505,13 @@ moat logs
 ### MCP server not appearing in agent
 
 - Verify the MCP server is declared in `moat.yaml` (remote servers at the top level, sandbox-local servers under the agent section)
-- For remote servers, check that the grant exists: `moat grant list` should show `mcp-{name}`
+- For remote servers, check that the grant exists: `moat grant list` should show `mcp:{name}`
 - Check container logs for configuration errors: `moat logs`
 
 ### Authentication failures (401 or 403)
 
 - Verify the grant exists and the credential is correct
-- Revoke and re-grant: `moat revoke mcp-{name}` then `moat grant mcp {name}`
+- Revoke and re-grant: `moat revoke mcp:{name}` then `moat grant mcp {name}`
 - Verify the `url` in `moat.yaml` matches the actual MCP server endpoint
 - Verify the `header` name matches what the MCP server expects
 
@@ -519,7 +521,7 @@ If you see `moat-stub-{grant}` in error output, the proxy did not replace the st
 
 - The `url` in `moat.yaml` matches the host the agent is connecting to
 - The `header` name matches what the agent sends
-- The grant name in `auth.grant` matches the stored credential (`mcp-{name}`)
+- The grant name in `auth.grant` matches the stored credential (`mcp:{name}`)
 
 ### Connection refused
 

--- a/docs/content/reference/01-cli.md
+++ b/docs/content/reference/01-cli.md
@@ -587,13 +587,13 @@ Store a credential for an MCP server.
 moat grant mcp context7
 ```
 
-The credential is stored as `mcp-<name>` (e.g., `mcp-context7`) and can be referenced in moat.yaml.
+The credential is stored as `mcp:<name>` (e.g., `mcp:context7`), mirroring the `oauth:<name>` convention, and can be referenced in moat.yaml. The deprecated `mcp-<name>` (hyphen) form is still accepted for existing grants.
 
 **Interactive prompts:**
 - Credential (hidden input)
 
 **Storage:**
-- `~/.moat/credentials/mcp-<name>.enc`
+- `~/.moat/credentials/mcp:<name>.enc`
 
 ### moat grant oauth
 

--- a/docs/content/reference/02-moat-yaml.md
+++ b/docs/content/reference/02-moat-yaml.md
@@ -143,7 +143,7 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 
 # Snapshots
@@ -1274,7 +1274,7 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 ```
 
@@ -1286,7 +1286,7 @@ mcp:
 - `name` (required): Identifier for the MCP server (must be unique)
 - `url` (required): Endpoint for the MCP server. HTTPS is required for remote servers. HTTP is allowed for host-local servers (`localhost`, `127.0.0.1`, or `[::1]`)
 - `auth` (optional): Authentication configuration
-  - `grant` (required if auth present): Name of grant to use (format: `mcp-<name>`)
+  - `grant` (required if auth present): Name of grant to use (format: `mcp:<name>`; the deprecated `mcp-<name>` form is still accepted)
   - `header` (required if auth present): HTTP header name for credential injection
 
 **Credential injection:**
@@ -1300,7 +1300,7 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 
   - name: local-tools

--- a/docs/content/reference/04-grants.md
+++ b/docs/content/reference/04-grants.md
@@ -25,7 +25,7 @@ Store a credential with `moat grant <provider>`, then use it in runs with `--gra
 | `npm` | Per-registry (e.g., `registry.npmjs.org`, `npm.company.com`) | `Authorization: Bearer ...` | `.npmrc`, `NPM_TOKEN`, or manual |
 | `aws` | All AWS service endpoints | AWS `credential_process` (STS temporary credentials) | IAM role assumption via STS |
 | `ssh:<host>` | Specified host only | SSH agent forwarding (not HTTP) | Host SSH agent (`SSH_AUTH_SOCK`) |
-| `mcp-<name>` | Host from MCP server `url` field | Configured per-server header | Interactive prompt |
+| `mcp:<name>` | Host from MCP server `url` field | Configured per-server header | Interactive prompt |
 | `gitlab` | `gitlab.com`, `*.gitlab.com` | `PRIVATE-TOKEN: ...` | `GITLAB_TOKEN`, `GL_TOKEN`, or prompt |
 | `brave-search` | `api.search.brave.com` | `X-Subscription-Token: ...` | `BRAVE_API_KEY`, `BRAVE_SEARCH_API_KEY`, or prompt |
 | `elevenlabs` | `api.elevenlabs.io` | `xi-api-key: ...` | `ELEVENLABS_API_KEY` or prompt |
@@ -657,7 +657,7 @@ $ moat run --grant ssh:github.com -- git clone git@github.com:my-org/my-project.
 moat grant mcp <name>
 ```
 
-The `<name>` argument matches the MCP server name in `moat.yaml`. The credential is stored as `mcp-<name>`.
+The `<name>` argument matches the MCP server name in `moat.yaml`. The credential is stored as `mcp:<name>`, mirroring the `oauth:<name>` convention. The deprecated `mcp-<name>` (hyphen) form is still accepted for existing grants.
 
 ### Credential source
 
@@ -680,7 +680,7 @@ mcp:
   - name: context7
     url: https://mcp.context7.com/mcp
     auth:
-      grant: mcp-context7
+      grant: mcp:context7
       header: CONTEXT7_API_KEY
 ```
 
@@ -689,7 +689,7 @@ mcp:
 ```bash
 $ moat grant mcp context7
 Enter credential for MCP server 'context7': ••••••••
-MCP credential 'mcp-context7' saved
+MCP credential 'mcp:context7' saved
 
 $ moat claude ./my-project
 ```
@@ -759,7 +759,7 @@ moat revoke claude
 moat revoke anthropic
 moat revoke npm
 moat revoke ssh:github.com
-moat revoke mcp-context7
+moat revoke mcp:context7
 
 # Revoke from a specific profile
 moat revoke github --profile work

--- a/docs/content/reference/08-troubleshooting.md
+++ b/docs/content/reference/08-troubleshooting.md
@@ -207,7 +207,7 @@ invalid token (401 Unauthorized)
 ### `MCP server requires grant but it's not configured`
 
 ```
-MCP server 'my-server' requires grant 'mcp-my-server' but it's not configured
+MCP server 'my-server' requires grant 'mcp:my-server' but it's not configured
 
 To fix:
   moat grant mcp my-server

--- a/internal/daemon/refresh.go
+++ b/internal/daemon/refresh.go
@@ -8,13 +8,20 @@ import (
 
 	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/log"
+	"github.com/majorcontext/moat/internal/mcpcatalog"
 	"github.com/majorcontext/moat/internal/provider"
 )
 
 // resolveCredName maps a grant (e.g. "oauth:notion", "github") to the
-// credential store key. OAuth uses the full grant name; all others use
-// the resolved provider name.
+// credential store key. OAuth and MCP grants use the full grant name; all
+// others use the resolved provider name.
 func resolveCredName(grantName, grant string) credential.Provider {
+	// MCP grants ("mcp:<name>" or deprecated "mcp-<name>") store under the full
+	// grant name. This must precede provider.ResolveName because "mcp:context7"
+	// splits to grantName "mcp", which is not a registered provider.
+	if mcpcatalog.IsGrant(grant) {
+		return credential.Provider(grant)
+	}
 	canonical := provider.ResolveName(grantName)
 	if canonical == "oauth" {
 		return credential.Provider(grant)

--- a/internal/daemon/refresh_test.go
+++ b/internal/daemon/refresh_test.go
@@ -10,6 +10,30 @@ import (
 	"github.com/majorcontext/moat/internal/provider"
 )
 
+func TestResolveCredName(t *testing.T) {
+	tests := []struct {
+		grantName string
+		grant     string
+		want      credential.Provider
+	}{
+		{"github", "github", "github"},
+		{"oauth", "oauth:notion", "oauth:notion"},
+		// MCP grants resolve to the full grant name verbatim so that a
+		// credential granted as "mcp:context7" and one granted as the
+		// deprecated "mcp-context7" each resolve to their own store entry.
+		{"mcp", "mcp:context7", "mcp:context7"},
+		{"mcp-context7", "mcp-context7", "mcp-context7"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.grant, func(t *testing.T) {
+			got := resolveCredName(tt.grantName, tt.grant)
+			if got != tt.want {
+				t.Errorf("resolveCredName(%q, %q) = %q, want %q", tt.grantName, tt.grant, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRefreshTokensForRun_NoRefreshableProviders(t *testing.T) {
 	// With no providers registered (test environment), refreshTokensForRun
 	// should be a no-op and not panic.

--- a/internal/mcpcatalog/catalog.go
+++ b/internal/mcpcatalog/catalog.go
@@ -63,10 +63,10 @@ func init() {
 // Examples: "mcp:context7" → ("context7", true), "mcp-context7" →
 // ("context7", true), "oauth:notion" → ("", false), "github" → ("", false).
 func GrantName(grant string) (string, bool) {
-	if name, ok := strings.CutPrefix(grant, "mcp:"); ok {
+	if name, ok := strings.CutPrefix(grant, "mcp:"); ok && name != "" {
 		return name, true
 	}
-	if name, ok := strings.CutPrefix(grant, "mcp-"); ok {
+	if name, ok := strings.CutPrefix(grant, "mcp-"); ok && name != "" {
 		return name, true
 	}
 	return "", false

--- a/internal/mcpcatalog/catalog.go
+++ b/internal/mcpcatalog/catalog.go
@@ -22,7 +22,7 @@ type Entry struct {
 	Header string
 	// OAuth reports whether this server authenticates via OAuth (grant
 	// "oauth:<name>"), as opposed to an API-key grant (e.g. context7's
-	// "mcp-context7"). Only OAuth entries are valid targets for
+	// "mcp:context7"). Only OAuth entries are valid targets for
 	// `moat grant oauth` discovery.
 	OAuth bool
 }
@@ -53,6 +53,30 @@ func init() {
 		// Embedded data is compile-time constant — a parse failure is a bug.
 		panic("mcpcatalog: invalid registry.yaml: " + err.Error())
 	}
+}
+
+// GrantName reports whether grant is an MCP API-key grant and, if so, returns
+// the bare server name. It accepts both the canonical "mcp:<name>" form and the
+// deprecated (but still supported) "mcp-<name>" form, so the two behave
+// identically throughout grant validation, routing, and credential resolution.
+//
+// Examples: "mcp:context7" → ("context7", true), "mcp-context7" →
+// ("context7", true), "oauth:notion" → ("", false), "github" → ("", false).
+func GrantName(grant string) (string, bool) {
+	if name, ok := strings.CutPrefix(grant, "mcp:"); ok {
+		return name, true
+	}
+	if name, ok := strings.CutPrefix(grant, "mcp-"); ok {
+		return name, true
+	}
+	return "", false
+}
+
+// IsGrant reports whether grant is an MCP API-key grant in either the canonical
+// "mcp:<name>" or deprecated "mcp-<name>" form.
+func IsGrant(grant string) bool {
+	_, ok := GrantName(grant)
+	return ok
 }
 
 // Lookup returns the resolved entry for a name, ok=false if unknown. String

--- a/internal/mcpcatalog/catalog_test.go
+++ b/internal/mcpcatalog/catalog_test.go
@@ -18,7 +18,7 @@ func TestLookup(t *testing.T) {
 		{"betterstack", Entry{URL: "https://mcp.betterstack.com", Grant: "oauth:betterstack", Header: "Authorization", OAuth: true}, true},
 		{"sentry", Entry{URL: "https://mcp.sentry.dev/mcp", Grant: "oauth:sentry", Header: "Authorization", OAuth: true}, true},
 		// Object entry → explicit API-key auth preserved, no defaulting (OAuth=false).
-		{"context7", Entry{URL: "https://mcp.context7.com/mcp", Grant: "mcp-context7", Header: "CONTEXT7_API_KEY", OAuth: false}, true},
+		{"context7", Entry{URL: "https://mcp.context7.com/mcp", Grant: "mcp:context7", Header: "CONTEXT7_API_KEY", OAuth: false}, true},
 		// Unknown.
 		{"nonexistent", Entry{}, false},
 	}
@@ -32,6 +32,51 @@ func TestLookup(t *testing.T) {
 				t.Errorf("Lookup(%q) = %+v, want %+v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGrantName(t *testing.T) {
+	tests := []struct {
+		grant      string
+		wantServer string
+		wantOK     bool
+	}{
+		// Canonical and deprecated forms both strip to the same server name.
+		{"mcp:context7", "context7", true},
+		{"mcp-context7", "context7", true},
+		{"mcp:render", "render", true},
+		{"mcp-render", "render", true},
+		// Non-MCP grants are not matched.
+		{"oauth:notion", "", false},
+		{"github", "", false},
+		{"ssh:github.com", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.grant, func(t *testing.T) {
+			server, ok := GrantName(tt.grant)
+			if ok != tt.wantOK {
+				t.Fatalf("GrantName(%q) ok = %v, want %v", tt.grant, ok, tt.wantOK)
+			}
+			if server != tt.wantServer {
+				t.Errorf("GrantName(%q) server = %q, want %q", tt.grant, server, tt.wantServer)
+			}
+			if IsGrant(tt.grant) != tt.wantOK {
+				t.Errorf("IsGrant(%q) = %v, want %v", tt.grant, IsGrant(tt.grant), tt.wantOK)
+			}
+		})
+	}
+}
+
+// TestGrantNameMatchesOAuthExclusion confirms that mcp:context7 keeps
+// OAuth=false, so OAuth auto-discovery still excludes it.
+func TestGrantNameMatchesOAuthExclusion(t *testing.T) {
+	e, ok := Lookup("context7")
+	if !ok {
+		t.Fatal("Lookup(context7) not found")
+	}
+	if e.OAuth {
+		t.Errorf("context7 OAuth = true, want false (mcp: grant must not be OAuth)")
 	}
 }
 

--- a/internal/mcpcatalog/catalog_test.go
+++ b/internal/mcpcatalog/catalog_test.go
@@ -51,6 +51,9 @@ func TestGrantName(t *testing.T) {
 		{"github", "", false},
 		{"ssh:github.com", "", false},
 		{"", "", false},
+		// Empty server name after the prefix is rejected.
+		{"mcp:", "", false},
+		{"mcp-", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.grant, func(t *testing.T) {

--- a/internal/mcpcatalog/registry.yaml
+++ b/internal/mcpcatalog/registry.yaml
@@ -13,7 +13,7 @@ cloudflare: https://mcp.cloudflare.com/mcp
 context7:
   url: https://mcp.context7.com/mcp
   auth:
-    grant: mcp-context7
+    grant: mcp:context7
     header: CONTEXT7_API_KEY
 hubspot: https://mcp.hubspot.com
 linear: https://mcp.linear.app/mcp

--- a/internal/run/imageneeds.go
+++ b/internal/run/imageneeds.go
@@ -7,6 +7,7 @@ import (
 	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/deps"
 	"github.com/majorcontext/moat/internal/log"
+	"github.com/majorcontext/moat/internal/mcpcatalog"
 	"github.com/majorcontext/moat/internal/provider"
 )
 
@@ -116,7 +117,16 @@ func resolveImageNeedsWithStore(grants []string, depList []deps.Dependency, stor
 // "codex" (aliased from "openai"), but credentials are stored under "openai".
 // For namespaced grants like "oauth:notion", the full grant name is used as
 // the store key so that each OAuth integration has its own credential entry.
+// MCP grants ("mcp:<name>" or the deprecated "mcp-<name>") likewise use the
+// full grant name as the store key — the credential is stored verbatim under
+// whatever form was granted, so both forms resolve independently.
 func credentialStoreKey(baseName, fullGrant string) credential.Provider {
+	// MCP grants store under the full grant name. This must come before the
+	// provider.ResolveName path because "mcp:context7" splits to baseName "mcp",
+	// which is not a registered provider.
+	if mcpcatalog.IsGrant(fullGrant) {
+		return credential.Provider(fullGrant)
+	}
 	canonical := provider.ResolveName(baseName)
 	if canonical == providerCodex {
 		return credential.ProviderOpenAI

--- a/internal/run/imageneeds_test.go
+++ b/internal/run/imageneeds_test.go
@@ -221,6 +221,13 @@ func TestCredentialStoreKey(t *testing.T) {
 		{"oauth", "oauth:notion", "oauth:notion"},
 		{"oauth", "oauth:slack", "oauth:slack"},
 		{"claude", "claude:read", "claude"},
+		// MCP grants store under the full grant name verbatim. baseName is the
+		// portion before the first ":" as computed by callers, so "mcp:context7"
+		// arrives with baseName "mcp".
+		{"mcp", "mcp:context7", "mcp:context7"},          // canonical form
+		{"mcp-context7", "mcp-context7", "mcp-context7"}, // deprecated form
+		{"mcp", "mcp:render", "mcp:render"},              // canonical form
+		{"mcp-render", "mcp-render", "mcp-render"},       // deprecated form
 	}
 	for _, tt := range tests {
 		t.Run(tt.fullGrant, func(t *testing.T) {
@@ -240,6 +247,8 @@ func TestGrantToCommand(t *testing.T) {
 		{"github", "github"},
 		{"oauth:notion", "oauth notion"},
 		{"ssh:github.com", "ssh github.com"},
+		{"mcp:context7", "mcp context7"}, // canonical
+		{"mcp-context7", "mcp context7"}, // deprecated, normalizes the same
 	}
 	for _, tt := range tests {
 		t.Run(tt.grant, func(t *testing.T) {

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -863,7 +863,7 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 				}
 
 				// Use new provider registry (supports aliases like "anthropic" -> "claude")
-				// MCP grants (e.g., "mcp-test") have no registered provider — they are
+				// MCP grants (e.g., "mcp:test") have no registered provider — they are
 				// handled by the proxy MCP relay, not by provider.ConfigureProxy.
 				prov := provider.Get(grantName)
 				if prov == nil {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -14,6 +14,7 @@ import (
 	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/daemon"
 	"github.com/majorcontext/moat/internal/id"
+	"github.com/majorcontext/moat/internal/mcpcatalog"
 	"github.com/majorcontext/moat/internal/provider"
 	awsprov "github.com/majorcontext/moat/internal/providers/aws"
 	"github.com/majorcontext/moat/internal/snapshot"
@@ -259,7 +260,7 @@ func (r *Run) SetStateFailedAt(errMsg string, timestamp time.Time) {
 // Some grant types are validated by their own specialized code paths and are
 // skipped here:
 //   - "ssh" / "ssh:<host>" — validated by the SSH agent setup in Create()
-//   - "mcp-*" — validated by validateMCPGrants
+//   - "mcp:*" / "mcp-*" — validated by validateMCPGrants
 //
 // For all other grants, we check that (1) the provider is registered and
 // (2) the credential exists and can be decrypted from the store.
@@ -268,8 +269,9 @@ func validateGrants(grants []string, store *credential.FileStore) error {
 	for _, grant := range grants {
 		grantName := strings.Split(grant, ":")[0]
 
-		// Skip grants validated by dedicated code paths
-		if grantName == "ssh" || strings.HasPrefix(grantName, "mcp-") {
+		// Skip grants validated by dedicated code paths. MCP grants accept
+		// both "mcp:<name>" (canonical) and "mcp-<name>" (deprecated) forms.
+		if grantName == "ssh" || mcpcatalog.IsGrant(grant) {
 			continue
 		}
 
@@ -306,15 +308,16 @@ func validateGrants(grants []string, store *credential.FileStore) error {
 	return nil
 }
 
-// grantToCommand converts a grant name like "oauth:notion" or "mcp-context7"
+// grantToCommand converts a grant name like "oauth:notion" or "mcp:context7"
 // to a CLI-friendly form suitable for use in "moat grant <args>" instructions.
-// Examples: "oauth:notion" → "oauth notion", "mcp-context7" → "mcp context7".
+// Examples: "oauth:notion" → "oauth notion", "mcp:context7" → "mcp context7",
+// "mcp-context7" → "mcp context7" (deprecated form).
 func grantToCommand(grant string) string {
+	if server, ok := mcpcatalog.GrantName(grant); ok {
+		return "mcp " + server
+	}
 	if parts := strings.SplitN(grant, ":", 2); len(parts) == 2 {
 		return parts[0] + " " + parts[1]
-	}
-	if after, ok := strings.CutPrefix(grant, "mcp-"); ok {
-		return "mcp " + after
 	}
 	return grant
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -287,7 +287,12 @@ func TestValidateGrants(t *testing.T) {
 			errMsg:  "Configure the grants above",
 		},
 		{
-			name:    "mcp grant skipped by validateGrants",
+			name:    "mcp grant (canonical) skipped by validateGrants",
+			grants:  []string{"mcp:context7"},
+			wantErr: false,
+		},
+		{
+			name:    "mcp grant (deprecated) skipped by validateGrants",
 			grants:  []string{"mcp-test"},
 			wantErr: false,
 		},
@@ -394,10 +399,16 @@ func TestValidateMCPGrants(t *testing.T) {
 	rand.Read(key)
 	store, _ := credential.NewFileStore(credDir, key)
 
-	// Save one grant
+	// Save grants in both the canonical "mcp:<name>" form and the deprecated
+	// "mcp-<name>" form so we can prove both resolve identically.
 	store.Save(credential.Credential{
-		Provider:  "mcp-context7",
+		Provider:  "mcp:context7",
 		Token:     "test-token",
+		CreatedAt: time.Now(),
+	})
+	store.Save(credential.Credential{
+		Provider:  "mcp-legacy",
+		Token:     "legacy-token",
 		CreatedAt: time.Now(),
 	})
 
@@ -408,13 +419,27 @@ func TestValidateMCPGrants(t *testing.T) {
 		errMsg  string
 	}{
 		{
-			name: "valid grant exists",
+			name: "valid grant exists (canonical mcp: form)",
 			mcp: []config.MCPServerConfig{
 				{
 					Name: "context7",
 					URL:  "https://mcp.context7.com",
 					Auth: &config.MCPAuthConfig{
-						Grant:  "mcp-context7",
+						Grant:  "mcp:context7",
+						Header: "API_KEY",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid grant exists (deprecated mcp- form)",
+			mcp: []config.MCPServerConfig{
+				{
+					Name: "legacy",
+					URL:  "https://mcp.legacy.com",
+					Auth: &config.MCPAuthConfig{
+						Grant:  "mcp-legacy",
 						Header: "API_KEY",
 					},
 				},


### PR DESCRIPTION
## Summary

Aligns MCP API-key grant naming with the OAuth convention: `mcp:<name>` (colon) now mirrors `oauth:<name>`. `mcp:<name>` is the canonical, documented form. This is **backward compatible** — existing stored grants and `moat.yaml` files using `mcp-<name>` (hyphen) keep working (deprecated, still accepted). Not a hard rename.

## Why

OAuth grants are namespaced `oauth:notion`; MCP API-key grants were `mcp-context7`. Unifying on `<scheme>:<name>` (`mcp:context7`) is consistent and clearer.

## What changed

**Canonical form generated everywhere:**
- `moat grant mcp <name>` stores the credential as `mcp:<name>` and prints `grant: mcp:<name>` in its snippet.
- The `context7` catalog entry (`internal/mcpcatalog/registry.yaml`) becomes `grant: mcp:context7`.

**Backward-compat approach:**
- New leaf helper `mcpcatalog.GrantName(grant) (server, ok)` / `IsGrant(grant)` strips either the `mcp:` or `mcp-` prefix.
- All consumption sites route through it: grant validation (`run.validateGrants`), command hints (`run.grantToCommand`), credential store-key resolution (`run.credentialStoreKey`), daemon credential lookup (`daemon.resolveCredName`), and grant-type display (`cli/grant_list.go`).
- MCP grants resolve to the **full grant name verbatim** as the credential store key, so a credential granted as `mcp:context7` and one granted as `mcp-context7` each resolve independently. `mcp.Auth.Grant == grant` matching in the manager/daemon already works for both via string equality.
- `mcp:context7` keeps `OAuth:false` (not an `oauth:` prefix), so `oauth.LookupServerURL("context7")` still returns `""` (OAuth auto-discovery exclusion holds).

**Tests (TDD):**
- `mcpcatalog`: helper covers both prefixes → same server, non-mcp grant → `ok=false`; OAuth-exclusion confirmed for `context7`.
- `cli`: `moat grant mcp context7` now produces `mcp:context7`.
- `run`/`daemon`: `credentialStoreKey`, `grantToCommand`, `resolveCredName`, `validateGrants`, and `validateMCPGrants` all assert both `mcp:` and `mcp-` resolve.

**Docs + changelog:** Guide, references (cli, moat-yaml, grants, troubleshooting), and credentials concept updated to `mcp:<name>` with a "`mcp-` still accepted (deprecated)" note. `CHANGELOG.md` gets a `### Changed` entry under Unreleased (non-breaking).

## Verification
- `go build ./...` — clean
- `make lint` — 0 issues
- `make test-unit` — all packages pass except the pre-existing, network-blocked `internal/deps.TestRegistryGithubBinaryURLsExist` (environmental, unrelated)