### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Moat runs AI coding agents in isolated containers with credential injection, net
 
 Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between minor versions. Breaking changes are listed under **Breaking** headings below.
 
-## Unreleased
+## v0.6.0 — 2026-06-17
+
+Feature release centered on MCP ergonomics: well-known servers can be listed in `moat.yaml` by name alone, resolving URL, auth, and grant from a built-in catalog (with Langfuse regional and PostHog OAuth shortcuts), and MCP API-key grants adopt the `mcp:<name>` naming convention. Also adds `moat join` to launch a second agent in a running container, `moat proxy restart` for version-aware daemon replacement, and the `ministack` local-cloud service, plus fixes for GitHub HTTPS git auth, Apple async container teardown, and a remote-MCP relay 404 regression.
 
 ### Added
 


### PR DESCRIPTION
Cuts the **v0.6.0** release.

This finalizes the CHANGELOG `Unreleased` section into a versioned `v0.6.0 — 2026-06-17` entry. No code changes — the version is injected from the git tag via GoReleaser ldflags.

## Highlights since v0.5.4

**Added**
- Declarative MCP shorthand — list well-known servers by name in `moat.yaml` ([#383](https://github.com/majorcontext/moat/pull/383))
- Langfuse regional MCP shortcuts ([#384](https://github.com/majorcontext/moat/pull/384)) and PostHog OAuth shortcut ([#382](https://github.com/majorcontext/moat/pull/382))
- `moat join` — second agent in a running container ([#379](https://github.com/majorcontext/moat/pull/379))
- `moat proxy restart` with version-aware daemon adoption ([#385](https://github.com/majorcontext/moat/pull/385))
- `ministack` local-cloud service dependency ([#366](https://github.com/majorcontext/moat/pull/366))

**Changed**
- MCP API-key grants adopt `mcp:<name>` naming (hyphen form still accepted) ([#386](https://github.com/majorcontext/moat/pull/386))

**Fixed**
- Remote MCP relay 404 regression ([#387](https://github.com/majorcontext/moat/pull/387)), GitHub HTTPS git auth ([#376](https://github.com/majorcontext/moat/pull/376), [#380](https://github.com/majorcontext/moat/pull/380), [#381](https://github.com/majorcontext/moat/pull/381)), Apple async container teardown ([#367](https://github.com/majorcontext/moat/pull/367)), Claude agent python ([#369](https://github.com/majorcontext/moat/issues/369)), pre_run hook errors ([#377](https://github.com/majorcontext/moat/pull/377))

## Release steps after merge
1. Merge this PR to `main`
2. Tag the merge commit `v0.6.0` and push the tag — this triggers `.github/workflows/release.yml` (GoReleaser)