### PR TITLE
chore(ci): add review-prevention guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ jobs:
             exit 1
           fi
 
+      - name: Check CHANGELOG PR-link placeholders
+        run: |
+          # The changelog entry template uses #NNN as a placeholder for the PR
+          # number. Leaving it unfilled has slipped through review repeatedly
+          # (#383, #384), so fail fast if any placeholder remains.
+          if grep -nE '#NNN|pull/NNN' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has an unfilled PR-number placeholder. Replace NNN with the real PR number."
+            exit 1
+          fi
+
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,15 @@ golangci-lint run
 - Use `go vet` to catch common issues
 - **After completing a batch of changes, always run `make lint` and fix any issues before committing.** This catches formatting, vet, and lint errors early. If `golangci-lint` is not installed, fall back to `go vet ./...`.
 
+## Codebase Invariants
+
+Rules PR review has caught more than once, ordered by how often and how severely they bite. Check the relevant ones when touching that area:
+
+1. **Test the companion case — the most common review miss.** A test that asserts one direction or one property almost always needs its mirror: all-missing → also assert all-present; "explicit value wins" → also assert the catalog fallback still populates; the happy path → also cover the refresh/error path and symbolic inputs (`stable`/`latest`). One-sided tests pass while the regression they exist to catch ships anyway. (#357, #376, #383, #389)
+2. **Detector ↔ validator parity.** `run.DetectMissingGrants` (CLI pre-flight) must classify exactly what `validateGrants`/`validateMCPGrants` (the `Create` gate) reject — same empty-string handling, same error buckets. When you edit one, edit the other, and update the drift-guard test (`TestDetectMissingGrantsMatchesValidators`) to assert **both** directions. (#389)
+3. **Catalog lookups filter by auth type.** `oauth.LookupServerURL` returns `""` for non-OAuth catalog entries (`!e.OAuth`) so `moat grant oauth <api-key-server>` fails clearly instead of attempting OAuth discovery and failing confusingly. Preserve this property when adding catalog entries or lookup helpers. (#383, #386)
+4. **Match documented contracts exactly.** Env/flag checks use the documented value (`MOAT_NO_PROMPT == "1"`, not `!= ""`, which silently accepts `0`/`false`). Don't collapse distinct error causes (not-found vs permission-denied vs decrypt-failed) into one catch-all bucket — each implies different user guidance. (#389)
+
 ## Logging vs User-Visible Output
 
 Two separate systems — don't mix them up:
@@ -188,6 +197,15 @@ Documentation is part of the feature. A feature without docs is incomplete.
 - Store all design specs and implementation plans in `docs/plans/`
 - Naming convention: `YYYY-MM-DD-<topic>-design.md` for specs, `YYYY-MM-DD-<topic>-plan.md` for plans
 - Do not create `docs/superpowers/` or other directories for specs — `docs/plans/` is the single location
+
+## Before You Push
+
+The `claude-review` bot reviews every push — but it's the same model reviewing the same diff, so catching issues locally first saves a round-trip. Before pushing a branch:
+
+- **Self-review the diff** with `/code-review` (or the compound-engineering review agents). This catches the recurring classes the bot flags: edge cases, missing test coverage, error-classification mistakes.
+- **Re-read open PR review threads** before each new push. "Previous review flagged this — still not fixed" has recurred; address prior feedback before adding more.
+- **Check the high-frequency traps** from "Codebase Invariants" above — especially companion-case test coverage — plus empty/malformed inputs (empty strings, trailing-separator names like `mcp:`).
+- **Fill the CHANGELOG PR link** — replace the `#NNN` placeholder with the real PR number. CI now fails on an unfilled placeholder.
 
 ## Creating Pull Requests
 


### PR DESCRIPTION
## Why

Reflecting on the last ~10 PRs, the \`claude-review\` bot keeps catching the same classes of issue. They're cheap to pre-empt but currently only surface at PR time. This codifies them so they're caught locally first.

## What

- **CI changelog guard** (\`.github/workflows/ci.yml\`): the lint job now fails if an unfilled \`#NNN\` PR-link placeholder remains in \`CHANGELOG.md\`. This slipped through on #383 and #384.
- **CLAUDE.md → "Codebase Invariants"**: rules ranked by how often/severely they bite —
  1. Test the companion case (the most frequent miss: #357, #376, #383, #389)
  2. Detector ↔ validator parity (#389)
  3. Catalog lookups filter by auth type (#383, #386)
  4. Match documented contracts exactly (#389)
- **CLAUDE.md → "Before You Push"**: self-review the diff with \`/code-review\`, re-read open PR threads, check the high-frequency traps.

## Evidence

Findings reviewed across #338–#389; substantive ones concentrated in #357, #376, #383–#386, #389. The catalog auth-type rule was verified against current code (\`LookupServerURL\` returns \`""\` when \`!e.OAuth\`).

No behavior change to the binary — docs + one CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)