### PR TITLE
docs(mcp): frame host-local MCP credential isolation; add example

### DIFF
--- a/docs/content/guides/09-mcp.md
+++ b/docs/content/guides/09-mcp.md
@@ -12,7 +12,7 @@ MCP (Model Context Protocol) servers extend AI agents with additional tools and 
 Moat supports three types of MCP servers:
 
 - **Remote MCP servers** -- External HTTPS services accessed through Moat's credential-injecting proxy
-- **Host-local MCP servers** -- Services running on the host machine, bridged to the container through the proxy relay
+- **Host-local MCP servers** -- Services running on the host machine, bridged to the container through the proxy relay -- useful when the server needs credentials that exist only on the host
 - **Sandbox-local MCP servers** -- Child processes running inside the container
 
 This guide covers configuring all three types, granting credentials, and troubleshooting common issues.
@@ -119,6 +119,8 @@ moat grant mcp notion
 
 Host-local MCP servers run on your host machine (outside the container). Containers cannot reach `localhost` on the host directly, so Moat's proxy relay bridges the connection.
 
+Running the server on the host is the right choice when it authenticates with credentials that only exist on the host -- a corp credential process, the OS keychain, or a VPN-gated CLI. Those credentials stay on the host: they are never injected into the container and never written to container config. The agent invokes the server's tools through the relay and only sees the results. This is the opposite trade-off from a [sandbox-local server](#sandbox-local-mcp-servers), where the server -- and its secrets -- run inside the container. See [`examples/mcp-hostlocal`](https://github.com/majorcontext/moat/tree/main/examples/mcp-hostlocal) for a runnable demonstration.
+
 ### Configure in moat.yaml
 
 Declare host-local servers in the `mcp:` section with an `http://localhost` or `http://127.0.0.1` URL:
@@ -129,7 +131,7 @@ mcp:
     url: http://localhost:3000/mcp
 ```
 
-Authentication is optional. If the host-local server requires credentials:
+With no `auth:` block, Moat relays the request untouched and injects nothing -- the host server authenticates itself (this is the credential-isolation case above). Add an `auth:` block only when you want Moat to inject a credential from the grant store instead:
 
 ```yaml
 mcp:

--- a/docs/content/guides/09-mcp.md
+++ b/docs/content/guides/09-mcp.md
@@ -119,7 +119,11 @@ moat grant mcp notion
 
 Host-local MCP servers run on your host machine (outside the container). Containers cannot reach `localhost` on the host directly, so Moat's proxy relay bridges the connection.
 
-Running the server on the host is the right choice when it authenticates with credentials that only exist on the host -- a corp credential process, the OS keychain, or a VPN-gated CLI. Those credentials stay on the host: they are never injected into the container and never written to container config. The agent invokes the server's tools through the relay and only sees the results. This is the opposite trade-off from a [sandbox-local server](#sandbox-local-mcp-servers), where the server -- and its secrets -- run inside the container. See [`examples/mcp-hostlocal`](https://github.com/majorcontext/moat/tree/main/examples/mcp-hostlocal) for a runnable demonstration.
+Running the server on the host is the right choice when it authenticates with credentials that only exist on the host -- a corp credential process, the OS keychain, or a VPN-gated CLI. Those credentials stay on the host: they are never injected into the container and never written to container config. The agent invokes the server's tools through the relay and only sees the results.
+
+> **Note:** A [sandbox-local server](#sandbox-local-mcp-servers) runs the server -- and its secrets -- inside the container instead. Use host-local when the credential cannot or should not enter the sandbox.
+
+See [`examples/mcp-hostlocal`](https://github.com/majorcontext/moat/tree/main/examples/mcp-hostlocal) for a runnable demonstration.
 
 ### Configure in moat.yaml
 

--- a/examples/mcp-hostlocal/README.md
+++ b/examples/mcp-hostlocal/README.md
@@ -1,0 +1,43 @@
+# Host-local MCP server with host-only credentials
+
+Run an MCP server on the **host** so it can use credentials that exist only
+there — a corp credential process, the OS keychain, a VPN-gated CLI — and let
+the sandboxed agent use its tools without those credentials ever entering the
+container.
+
+## What this demonstrates
+
+- A top-level `mcp:` server with an `http://localhost` URL and **no `auth:`
+  block**. The host server authenticates itself; Moat relays the agent's
+  requests untouched and injects nothing.
+- The proxy relay bridges the container to `localhost` on the host, so the
+  agent reaches the server even though the container cannot see host `localhost`
+  directly.
+- The host credential stays on the host. It is never injected into the
+  container, never written to container config, and (if the server is written
+  carefully) never returned in a tool result.
+
+This is the opposite trade-off from [`mcp-local`](../mcp-local), where the MCP
+server — and its secrets — run *inside* the sandbox.
+
+## Run
+
+Start the host server first, then run the agent:
+
+```bash
+node examples/mcp-hostlocal/server.js &
+moat claude examples/mcp-hostlocal
+```
+
+Ask Claude to call the `whoami` tool. It reports the corp identity without ever
+seeing the underlying credential.
+
+## How it works
+
+The agent connects to a relay endpoint on the proxy
+(`http://moat-proxy:PORT/mcp/<token>/corp-hostlocal`). The relay, running on the
+host, forwards the request to `http://localhost:9123`. The host server uses its
+host-only credential to do the work and returns only derived results. The
+credential never crosses into the sandbox.
+
+See the [MCP guide](../../docs/content/guides/09-mcp.md) for the full picture.

--- a/examples/mcp-hostlocal/README.md
+++ b/examples/mcp-hostlocal/README.md
@@ -36,7 +36,7 @@ seeing the underlying credential.
 
 The agent connects to a relay endpoint on the proxy
 (`http://moat-proxy:PORT/mcp/<token>/corp-hostlocal`). The relay, running on the
-host, forwards the request to `http://localhost:9123`. The host server uses its
+host, forwards the request to `http://localhost:9123/mcp`. The host server uses its
 host-only credential to do the work and returns only derived results. The
 credential never crosses into the sandbox.
 

--- a/examples/mcp-hostlocal/moat.yaml
+++ b/examples/mcp-hostlocal/moat.yaml
@@ -1,0 +1,32 @@
+# Example: host-local MCP server with host-only credentials
+#
+# Runs an MCP server on the HOST (not in the sandbox) so it can use
+# credentials that only exist on the host — a corp credential process,
+# the OS keychain, a VPN-gated CLI. The agent reaches the server's tools
+# through Moat's proxy relay, but the credential never enters the
+# container: nothing is injected, nothing is written to container config.
+#
+# Note there is no `auth:` block. The host server authenticates itself;
+# Moat relays the request untouched and injects no credential.
+#
+# Start the host server first, then run the agent:
+#   node examples/mcp-hostlocal/server.js &
+#   moat claude examples/mcp-hostlocal
+#
+# Verify config generation (relay URL, no injected auth):
+#   moat run --no-sandbox examples/mcp-hostlocal -- cat /moat/claude-init/.claude.json
+
+name: mcp-hostlocal
+
+dependencies:
+  - claude-code
+
+grants:
+  - claude
+
+command: ["claude"]
+interactive: true
+
+mcp:
+  - name: corp-hostlocal
+    url: http://localhost:9123

--- a/examples/mcp-hostlocal/moat.yaml
+++ b/examples/mcp-hostlocal/moat.yaml
@@ -29,4 +29,4 @@ interactive: true
 
 mcp:
   - name: corp-hostlocal
-    url: http://localhost:9123
+    url: http://localhost:9123/mcp

--- a/examples/mcp-hostlocal/server.js
+++ b/examples/mcp-hostlocal/server.js
@@ -54,20 +54,35 @@ function handle(msg) {
           ],
         };
       }
+      // Plain-object throw (not an Error): caught below, which checks e.code.
       throw { code: -32602, message: `unknown tool: ${msg.params && msg.params.name}` };
     default:
       throw { code: -32601, message: `method not found: ${msg.method}` };
   }
 }
 
+const MAX_BODY = 1 * 1024 * 1024; // 1 MiB — MCP messages are small
+
 const server = http.createServer((req, res) => {
+  // Accepts POST on any path; the relay forwards the configured URL's path
+  // (e.g. /mcp) through unchanged, and this demo ignores it.
   if (req.method !== "POST") {
     res.writeHead(405).end();
     return;
   }
   let body = "";
-  req.on("data", (c) => (body += c));
+  let tooLarge = false;
+  req.on("data", (c) => {
+    if (tooLarge) return;
+    body += c;
+    if (body.length > MAX_BODY) {
+      tooLarge = true;
+      res.writeHead(413).end();
+      req.destroy();
+    }
+  });
   req.on("end", () => {
+    if (tooLarge) return;
     let msg;
     try {
       msg = JSON.parse(body);

--- a/examples/mcp-hostlocal/server.js
+++ b/examples/mcp-hostlocal/server.js
@@ -77,8 +77,7 @@ const server = http.createServer((req, res) => {
     body += c;
     if (body.length > MAX_BODY) {
       tooLarge = true;
-      res.writeHead(413).end();
-      req.destroy();
+      res.writeHead(413).end(() => req.destroy());
     }
   });
   req.on("end", () => {

--- a/examples/mcp-hostlocal/server.js
+++ b/examples/mcp-hostlocal/server.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Minimal host-local MCP server (zero dependencies).
+//
+// Simulates corp tooling that authenticates with a credential only available
+// on the host — here, a "token" read from the host environment. The agent in
+// the sandbox can call this server's tools through Moat's proxy relay, but the
+// credential never leaves the host: it is not injected into the container, not
+// written to any container config, and never returned in a tool result.
+//
+// Speaks the MCP streamable-HTTP transport well enough for a basic client:
+// POST JSON-RPC, single JSON response. Listens on 127.0.0.1 only.
+
+const http = require("http");
+
+const PORT = parseInt(process.env.PORT || "9123", 10);
+
+// A host-only secret. In real corp tooling this would come from a credential
+// process, the OS keychain, or a VPN-gated CLI — none reachable from inside
+// the sandbox. We only ever expose facts *derived* from it, never the value.
+const CORP_TOKEN = process.env.CORP_TOKEN || "s3cr3t-corp-token-do-not-leak";
+const CORP_USER = process.env.CORP_USER || "alice@corp.example";
+
+const TOOLS = [
+  {
+    name: "whoami",
+    description:
+      "Report the corp identity this host server authenticates as. " +
+      "Uses the host-only credential without revealing it.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+];
+
+function handle(msg) {
+  switch (msg.method) {
+    case "initialize":
+      return {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: { name: "corp-hostlocal", version: "0.1.0" },
+      };
+    case "tools/list":
+      return { tools: TOOLS };
+    case "tools/call":
+      if (msg.params && msg.params.name === "whoami") {
+        // Derived fact only — the token value is never returned.
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `Authenticated to corp as ${CORP_USER} ` +
+                `(credential present on host, length ${CORP_TOKEN.length}).`,
+            },
+          ],
+        };
+      }
+      throw { code: -32602, message: `unknown tool: ${msg.params && msg.params.name}` };
+    default:
+      throw { code: -32601, message: `method not found: ${msg.method}` };
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method !== "POST") {
+    res.writeHead(405).end();
+    return;
+  }
+  let body = "";
+  req.on("data", (c) => (body += c));
+  req.on("end", () => {
+    let msg;
+    try {
+      msg = JSON.parse(body);
+    } catch {
+      res.writeHead(400).end();
+      return;
+    }
+    console.error(`[host-mcp] ${msg.method} (id=${msg.id ?? "-"})`);
+
+    // Notifications (no id) get an empty 202 — no response body.
+    if (msg.id === undefined || msg.id === null) {
+      res.writeHead(202).end();
+      return;
+    }
+
+    let result, error;
+    try {
+      result = handle(msg);
+    } catch (e) {
+      error = e.code ? e : { code: -32603, message: String(e) };
+    }
+    const payload = { jsonrpc: "2.0", id: msg.id };
+    if (error) payload.error = error;
+    else payload.result = result;
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(payload));
+  });
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.error(`[host-mcp] listening on http://127.0.0.1:${PORT} (corp token hidden from sandbox)`);
+});


### PR DESCRIPTION
## Why

A teammate idea — *"run local MCP servers on the host so they can use credential processes only available on a corp-managed host"* — turned out to be **already supported and documented**, but the docs framed host-local MCP purely as *connectivity* ("containers can't reach host `localhost`, the relay bridges it"). They never stated the actual motivation: keeping host-only credentials out of the sandbox.

This PR adds the missing framing and a runnable proof. No new config, no new abstractions — the existing `mcp: url: http://localhost:PORT` (no `auth:`) path already does this.

## What

- **`examples/mcp-hostlocal/`** — a runnable demo: a zero-dependency host MCP server that holds a host-only secret, exposes a `whoami` tool, and never returns the secret. `moat.yaml` declares it with `http://localhost` and no `auth:` block.
- **`docs/content/guides/09-mcp.md`** — reframes the host-local section around credential isolation: a "why run it on the host" paragraph, a corrected "no `auth:` means the host server self-authenticates" explanation, the trade-off vs sandbox-local MCP, and a link to the example.

## Verification

Built moat and ran a grant-free probe container through the real relay (Docker-in-Docker):

- `initialize` and `tools/call whoami` both returned `200` from the host server **via the relay**
- The 29-char host secret was used host-side; only a derived fact crossed into the container — confirmed it never leaked
- The relay enforces the per-run token (wrong token → `407`)

The probe exercises moat's relay bridge (the moat-specific path); it does not drive Claude's own MCP client, since no `claude` grant is configured in the test sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
