### PR TITLE
chore(daemon): remove redundant daemon-hosted routing proxy

### DIFF
--- a/cmd/moat/cli/daemon.go
+++ b/cmd/moat/cli/daemon.go
@@ -197,29 +197,17 @@ func runDaemon(_ *cobra.Command, _ []string) error {
 		return startErr
 	}
 
-	// Set up routing proxy.
+	// Give the daemon API the shared route table so runs can register their
+	// hostname routes via POST /v1/routes/. Hostname traffic is served by the
+	// per-agent routing proxy (internal/routing.Lifecycle) that every `moat run`
+	// with exposed ports starts and shares via ~/.moat/proxy/proxy.lock — the
+	// daemon does not host its own routing proxy. (It used to start a second one
+	// here on a random, never-advertised port; nothing could reach it.)
 	routeTable, err := routing.NewRouteTable(daemonDir)
 	if err != nil {
 		log.Warn("failed to create route table", "error", err)
 	} else {
 		apiServer.SetRoutes(routeTable)
-
-		routingProxy := routing.NewProxyServer(routeTable)
-
-		// Enable TLS for routing proxy using same CA.
-		if err := routingProxy.EnableTLS(ca); err != nil {
-			log.Warn("failed to enable TLS for routing proxy", "error", err)
-		}
-
-		// Start routing proxy on a random available port.
-		if err := routingProxy.Start(0); err != nil {
-			log.Warn("failed to start routing proxy", "error", err)
-		} else {
-			log.Info("routing proxy started", "port", routingProxy.Port())
-			defer func() {
-				_ = routingProxy.Stop(context.Background())
-			}()
-		}
 	}
 
 	log.Info("daemon started", "pid", os.Getpid(), "proxy_port", actualPort, "sock", sockPath)

--- a/cmd/moat/cli/daemon.go
+++ b/cmd/moat/cli/daemon.go
@@ -198,11 +198,9 @@ func runDaemon(_ *cobra.Command, _ []string) error {
 	}
 
 	// Give the daemon API the shared route table so runs can register their
-	// hostname routes via POST /v1/routes/. Hostname traffic is served by the
-	// per-agent routing proxy (internal/routing.Lifecycle) that every `moat run`
-	// with exposed ports starts and shares via ~/.moat/proxy/proxy.lock — the
-	// daemon does not host its own routing proxy. (It used to start a second one
-	// here on a random, never-advertised port; nothing could reach it.)
+	// hostname routes via POST /v1/routes/. Hostname traffic itself is served by
+	// the per-agent routing proxy (internal/routing.Lifecycle, shared via
+	// ~/.moat/proxy/proxy.lock); the daemon does not host its own routing proxy.
 	routeTable, err := routing.NewRouteTable(daemonDir)
 	if err != nil {
 		log.Warn("failed to create route table", "error", err)


### PR DESCRIPTION
Closes #408.

## What

Removes the second routing proxy the daemon started (`routing.NewProxyServer` + `Start(0)`) in `cmd/moat/cli/daemon.go`.

## Why it's dead code

- The daemon bound it on a **random port that was only logged** — never persisted to the daemon state/lock, never returned by the daemon API, never read by any client. So nothing could ever route to it.
- It served the same `~/.moat/proxy/routes.json` as the **per-agent routing proxy** (`internal/routing.Lifecycle`, `proxy.lock`, port 8080) that `moat run` actually advertises and that `moat open` / the discovery index use.
- The documented architecture (`docs/plans/2025-01-12-hostname-routing-design.md`) describes only the single shared *lifecycle* proxy — there is no daemon-hosted routing proxy in the design. The daemon one was added with the shared-daemon refactor (#193, Feb 2026, after the lifecycle proxy) and never wired up.
- It also caused real confusion during the #407 work (a stray random-port proxy serving the same routes).

## What's kept

The daemon's route **table** and `apiServer.SetRoutes(...)` stay — the `POST/DELETE /v1/routes/` handlers are used by `moat run` (`RegisterRoutes`/`UnregisterRoutes`) to write the shared `routes.json` that the lifecycle proxy serves.

## Verification

- `go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test ./internal/daemon/ ./internal/routing/` — all green.
- End-to-end (Docker-in-Docker): with the daemon running it now listens on **only** the credential-proxy port (no random routing port, no "routing proxy started" log); hostname routing (`web.demo.localhost`) and the discovery index still work via the lifecycle proxy on 8080; route registration via the daemon API is unaffected.

No CHANGELOG entry — no user-visible behavior change (the removed proxy was never reachable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)