### PR TITLE
fix(routing): drop raw bind-error noise from port-in-use message

### DIFF
--- a/internal/routing/lifecycle.go
+++ b/internal/routing/lifecycle.go
@@ -105,7 +105,9 @@ func (lc *Lifecycle) EnsureRunning() error {
 		// is taken, point the user at how to change it rather than surfacing a
 		// raw bind error.
 		if errors.Is(err, syscall.EADDRINUSE) {
-			return fmt.Errorf("routing proxy port %d is already in use — choose another with MOAT_PROXY_PORT=<port> or set proxy.port in ~/.moat/config.yaml: %w", lc.port, err)
+			// Don't wrap the raw "bind: address already in use" — the whole
+			// point is to replace that noise with an actionable message.
+			return fmt.Errorf("routing proxy port %d is already in use — choose another with MOAT_PROXY_PORT=<port> or set proxy.port in ~/.moat/config.yaml", lc.port)
 		}
 		return fmt.Errorf("starting proxy: %w", err)
 	}

--- a/internal/routing/lifecycle_test.go
+++ b/internal/routing/lifecycle_test.go
@@ -28,9 +28,16 @@ func TestEnsureRunningPortInUse(t *testing.T) {
 	if err == nil {
 		t.Fatal("EnsureRunning: expected error when port is in use, got nil")
 	}
-	// The message must be actionable: point at how to pick a different port.
-	if !strings.Contains(err.Error(), "MOAT_PROXY_PORT") || !strings.Contains(err.Error(), fmt.Sprint(port)) {
-		t.Errorf("error not actionable: %v", err)
+	// The message must be actionable: name the busy port and both ways to
+	// change it (env var and config key).
+	for _, want := range []string{"MOAT_PROXY_PORT", "proxy.port", fmt.Sprint(port)} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error missing %q: %v", want, err)
+		}
+	}
+	// And it must not re-introduce the raw bind-error noise it replaces.
+	if strings.Contains(err.Error(), "address already in use") {
+		t.Errorf("error should not embed the raw bind error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #409 — addresses the two points from that PR's **first** review pass (which weren't caught before merge).

## 1. Error-noise regression (the main one)

#409's message wrapped the raw error with `%w`, so the user-visible string *still* ended with the raw bind error it was meant to replace:

```
Error: creating run: starting routing proxy: routing proxy port 8080 is already in use — choose another with MOAT_PROXY_PORT=<port> or set proxy.port in ~/.moat/config.yaml: listen tcp 127.0.0.1:8080: bind: address already in use
```

Nothing inspects the wrapped errno — `manager.go` just wraps it again with `"starting routing proxy: %w"` and it's printed — so dropping the wrap loses nothing and gives the clean message the PR promised:

```
Error: creating run: starting routing proxy: routing proxy port 8080 is already in use — choose another with MOAT_PROXY_PORT=<port> or set proxy.port in ~/.moat/config.yaml
```

(The `errors.Is(err, syscall.EADDRINUSE)` *detection* is unchanged — it tests the listener error, not the returned one.)

## 2. Test gap

`TestEnsureRunningPortInUse` asserted `MOAT_PROXY_PORT` but not `proxy.port`, the other remedy the message names. Tightened to assert both remedies + the port number, and to assert the raw `address already in use` text is **not** embedded (locks in fix #1).

## Notes

No new CHANGELOG entry — #409's existing Unreleased entry already promises "reports which port is taken and how to change it"; this just makes that string actually clean.

## Testing

`go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test ./internal/routing/` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)