### PR TITLE
chore(security): pin Go 1.25.11 toolchain to clear stdlib vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Adds HTTP request-body inspection to Keep policies. File- and pack-based `networ
 ### Security
 
 - Upgrade dependencies to clear 15 vulnerabilities that `govulncheck` reports moat actually calls — `containerd/v2` (→2.2.5), `golang.org/x/crypto` (→0.53.0), `in-toto-golang` (→0.11.0), `go-git/v5` (→5.17.1), `moby/buildkit` (→0.28.1), and `ulikunitz/xz` (→0.5.15). No user action required. Remaining `govulncheck` findings are in `docker/docker` (no upstream fix available yet) and the Go standard library (cleared by building with a newer Go toolchain). ([#416](https://github.com/majorcontext/moat/pull/416))
+- Build with the Go 1.25.11 toolchain to clear ~16 Go standard-library vulnerabilities `govulncheck` reports moat calls (`crypto/x509`, `crypto/tls`, `html/template`, `net/*`, `archive/tar`, …), pinned via a `toolchain` directive. No user action required. With this and the dependency upgrades above, `govulncheck`'s reachable count drops from 36 to 5 — the rest being `docker/docker`, which has no upstream fix yet. ([#417](https://github.com/majorcontext/moat/pull/417))
 
 ## v0.6.1 — 2026-06-19
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/majorcontext/moat
 
 go 1.25.5
 
+toolchain go1.25.11
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.6
 	github.com/aws/aws-sdk-go-v2/config v1.32.7


### PR DESCRIPTION
Follow-up to the dependency bumps (#416). After those, the remaining `govulncheck` reachable findings were **~16 Go standard-library vulnerabilities** (`crypto/x509`, `crypto/tls`, `html/template`, `net/textproto`, `net/http`, `archive/tar`, …), all fixed in Go 1.25.7–1.25.11.

## Change
A single line in `go.mod`:
```
toolchain go1.25.11
```
This pins the **build toolchain** to go1.25.11 so the standard library is patched, **without** raising the language-version floor (the `go 1.25.5` directive is unchanged). Contributors on an older local toolchain auto-fetch 1.25.11 via `GOTOOLCHAIN=auto`; CI's `setup-go` (`go-version-file: go.mod`) honors the `toolchain` directive.

## Impact
`govulncheck` reachable count: **21 → 5**. Combined with #416, the project went from **36 → 5** called vulnerabilities. The remaining 5 are all `docker/docker` — "Fixed in: N/A" upstream, nothing to bump to yet.

## Verified under go1.25.11
`go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run ./...` (0 issues), and the full non-network test suite all pass. The `go mod tidy` gate from #416 stays green (the toolchain line is the only change; tidy is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)