### PR TITLE
chore(lint): enable exhaustive and testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,15 @@ linters:
     - unused        # Unused code detection
     - bodyclose     # HTTP response body must be closed
     - prealloc      # Slice preallocation for performance
+    - exhaustive    # Enum switches must handle every case (or have a default)
+    - testifylint   # Idiomatic testify assertions (require for errors, Len/Empty, etc.)
 
   settings:
+    exhaustive:
+      # A switch with a default is treated as exhaustive; we only flag enum
+      # switches that silently skip unhandled cases with no default at all.
+      default-signifies-exhaustive: true
+
     errcheck:
       check-type-assertions: true
       check-blank: false

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -541,6 +541,9 @@ func RunInteractiveAttached(ctx context.Context, manager *run.Manager, r *run.Ru
 			go dumpTUI(r, ringRecorder, statusWriter, &flashMu, &flashTimer)
 		case term.EscapeResetTUI:
 			go resetTUI(ctx, manager, r, statusWriter, injectable, &flashMu, &flashTimer)
+		case term.EscapeNone, term.EscapeStop:
+			// No inline UI action: EscapeNone means no escape was matched, and
+			// EscapeStop is handled by the run lifecycle, not this hook.
 		}
 	})
 

--- a/internal/container/apple_inspect_test.go
+++ b/internal/container/apple_inspect_test.go
@@ -82,7 +82,7 @@ func TestParseAppleInspectEmptyAndNull(t *testing.T) {
 	info, err = parseAppleInspect([]byte(`[{"id":"run_abc","status":null}]`))
 	require.NoError(t, err)
 	require.Len(t, info, 1)
-	assert.Equal(t, "", info[0].state())
+	assert.Empty(t, info[0].state())
 }
 
 func TestParseAppleInspectMalformed(t *testing.T) {

--- a/internal/container/apple_service_test.go
+++ b/internal/container/apple_service_test.go
@@ -55,7 +55,7 @@ func TestAppleBuildRunArgsWithCmd(t *testing.T) {
 			break
 		}
 	}
-	assert.Greater(t, imageIdx, 0, "image should be in args")
+	assert.Positive(t, imageIdx, "image should be in args")
 	// Extra cmd args come after image, with placeholders resolved
 	assert.Contains(t, args[imageIdx+1:], "--requirepass")
 	assert.Contains(t, args[imageIdx+1:], "redispass")
@@ -109,7 +109,7 @@ func TestParseRunContainerID(t *testing.T) {
 	assert.Equal(t, "abc123", parseRunContainerID("abc123\n\n"))
 
 	// Empty output yields empty id.
-	assert.Equal(t, "", parseRunContainerID("  \n"))
+	assert.Empty(t, parseRunContainerID("  \n"))
 }
 
 func TestParseContainerIPv4(t *testing.T) {

--- a/internal/deps/dockerfile.go
+++ b/internal/deps/dockerfile.go
@@ -105,6 +105,7 @@ func categorizeDeps(deps []Dependency) categorizedDeps {
 	var c categorizedDeps
 	for _, dep := range deps {
 		if dep.IsDynamic() {
+			//nolint:exhaustive // gated by dep.IsDynamic(); only TypeDynamic* values reach here
 			switch dep.Type {
 			case TypeDynamicNpm:
 				c.dynamicNpm = append(c.dynamicNpm, dep)
@@ -144,6 +145,9 @@ func categorizeDeps(deps []Dependency) categorizedDeps {
 			c.dockerMode = dep.DockerMode
 		case TypeMeta:
 			// Meta dependencies are expanded during parsing/validation
+		default:
+			// Other types (services, dynamic — handled above) need no
+			// Dockerfile categorization here.
 		}
 	}
 	return c

--- a/internal/deps/script.go
+++ b/internal/deps/script.go
@@ -51,6 +51,9 @@ func GenerateInstallScript(deps []Dependency) (string, error) {
 			customDeps = append(customDeps, dep)
 		case TypeMeta:
 			// Meta dependencies are expanded during parsing/validation
+		default:
+			// Other types (uv-tool, docker, services, dynamic) are not
+			// installed via the shell-script path.
 		}
 	}
 

--- a/internal/keep/policy_test.go
+++ b/internal/keep/policy_test.go
@@ -89,7 +89,7 @@ func TestToKeepYAML_MultipleDeny(t *testing.T) {
 	assert.Contains(t, yamlStr, "operation: Edit")
 	assert.Contains(t, yamlStr, "operation: Write")
 	assert.Contains(t, yamlStr, "operation: Bash")
-	assert.Equal(t, 3, len(pc.Deny))
+	assert.Len(t, pc.Deny, 3)
 }
 
 func TestToKeepYAML_AuditMode(t *testing.T) {

--- a/internal/run/services_test.go
+++ b/internal/run/services_test.go
@@ -140,7 +140,7 @@ func TestBuildServiceConfigUnknown(t *testing.T) {
 	dep := deps.Dependency{Name: "unknown", Version: "1", Type: deps.TypeService}
 
 	_, err := buildServiceConfig(dep, "run-000", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown service")
 }
 

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -465,8 +465,12 @@ func matchControlSeq(data []byte) controlSeqResult {
 // Caller passes raw bytes of the matched sequence so RIS/DECSTR can be
 // forwarded verbatim.
 func (w *Writer) handleControlSeqLocked(res controlSeqResult, raw []byte) error {
-	//nolint:exhaustive // ctrlNone is gated out by the caller (only called when res.kind != ctrlNone)
 	switch res.kind {
+	case ctrlNone:
+		// Unreachable in practice: callers only invoke this for a matched
+		// control sequence (res.kind != ctrlNone). Handle it explicitly so a
+		// new controlSeqKind can't silently slip through.
+		return nil
 	case ctrlDECSTBM:
 		return w.outputLocked(w.scrollRegionBytes())
 	case ctrlDECSTR:
@@ -500,7 +504,6 @@ func (w *Writer) handleControlSeqLocked(res controlSeqResult, raw []byte) error 
 		buf.WriteString("\x1b[H")
 		return w.outputLocked(buf.Bytes())
 	}
-	// Unreachable: callers gate this on res.kind != ctrlNone.
 	return nil
 }
 

--- a/internal/tui/writer.go
+++ b/internal/tui/writer.go
@@ -465,6 +465,7 @@ func matchControlSeq(data []byte) controlSeqResult {
 // Caller passes raw bytes of the matched sequence so RIS/DECSTR can be
 // forwarded verbatim.
 func (w *Writer) handleControlSeqLocked(res controlSeqResult, raw []byte) error {
+	//nolint:exhaustive // ctrlNone is gated out by the caller (only called when res.kind != ctrlNone)
 	switch res.kind {
 	case ctrlDECSTBM:
 		return w.outputLocked(w.scrollRegionBytes())


### PR DESCRIPTION
From the craftsmanship audit's tooling-floor move — raise the lint floor with two checks that catch real issue classes, and fix what they flag. **+23/-5 lines.**

## `exhaustive` (with `default-signifies-exhaustive: true`)
Enum switches must handle every case or have a default. Configured so a `default:` counts as exhaustive — flagging only switches that silently skip cases with **no default** (the real silent-gap risk).

Of the 19 raw findings, 14 already have a default. The 5 without one are made explicit (all behavior-preserving — the unhandled cases already did nothing):

| Switch | Fix |
|--------|-----|
| `exec.go` `term.EscapeAction` | explicit `case EscapeNone, EscapeStop:` no-op (small enum → future-proof) |
| `dockerfile.go` `spec.Type` categorization | documented `default:` |
| `script.go` `spec.Type` categorization | documented `default:` |
| `dockerfile.go` dynamic branch | `//nolint:exhaustive` — gated by `dep.IsDynamic()`, only `TypeDynamic*` reach it |
| `writer.go` `controlSeqKind` | `//nolint:exhaustive` — `ctrlNone` is gated out by the caller |

## `testifylint`
Idiomatic testify assertions. Auto-fixed `assert.Empty`/`Len`/`Positive` uses; switched one `assert.Error` → `require.Error` so the following `err.Error()` can't nil-panic if no error occurred (the exact bug the check exists for).

## Deferred
`noctx` (~66 findings — threading context through that many call sites is its own large effort) and `gofumpt` (repo-wide reformat — better as its own focused PR).

## Testing
`go build ./...`, `golangci-lint run ./...` (**0 issues** with both linters now enabled), and the affected package tests pass. No behavior change → no CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)