### PR TITLE
refactor(run): drop the empty StartOptions struct

### DIFF
--- a/cmd/moat/cli/doctor_claude.go
+++ b/cmd/moat/cli/doctor_claude.go
@@ -945,7 +945,7 @@ func testContainerAuth(ctx context.Context, diag *claudeDiagnostic) error {
 	diag.ContainerTest = result
 
 	// Start container (don't stream logs to avoid cluttering output)
-	if startErr := mgr.Start(ctx, r.ID, run.StartOptions{}); startErr != nil {
+	if startErr := mgr.Start(ctx, r.ID); startErr != nil {
 		return fmt.Errorf("starting container: %w", startErr)
 	}
 

--- a/cmd/moat/cli/exec.go
+++ b/cmd/moat/cli/exec.go
@@ -340,7 +340,7 @@ func ExecuteRun(ctx context.Context, opts intcli.ExecOptions) (*run.Run, error) 
 	}
 
 	// Non-interactive: start the container, stream its output, and wait for exit.
-	if err := manager.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := manager.Start(ctx, r.ID); err != nil {
 		log.Error("failed to start run", "id", r.ID, "error", err)
 		return r, fmt.Errorf("starting run: %w", err)
 	}

--- a/internal/e2e/daemon_test.go
+++ b/internal/e2e/daemon_test.go
@@ -209,7 +209,7 @@ func TestDaemonNetworkLogging(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -292,7 +292,7 @@ func TestDaemonCredentialInjection(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -362,7 +362,7 @@ func TestDaemonProxyEnvInContainer(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -455,10 +455,10 @@ func TestDaemonNetworkLoggingIsolation(t *testing.T) {
 		defer mgr.Destroy(context.Background(), r2.ID)
 
 		// Start both runs
-		if err := mgr.Start(ctx, r1.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r1.ID); err != nil {
 			t.Fatalf("Start r1: %v", err)
 		}
-		if err := mgr.Start(ctx, r2.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r2.ID); err != nil {
 			t.Fatalf("Start r2: %v", err)
 		}
 

--- a/internal/e2e/docker_test.go
+++ b/internal/e2e/docker_test.go
@@ -73,7 +73,7 @@ func TestDockerDependency(t *testing.T) {
 	}
 	defer mgr.Destroy(context.Background(), r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -258,7 +258,7 @@ func TestDockerDindDependency(t *testing.T) {
 	}
 	defer mgr.Destroy(context.Background(), r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -388,7 +388,7 @@ func TestDockerDindIsolation(t *testing.T) {
 	}
 	defer mgr.Destroy(context.Background(), r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -501,7 +501,7 @@ CMD ["echo", "Hello from BuildKit"]
 	}
 	defer mgr.Destroy(context.Background(), r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -263,7 +263,7 @@ func TestProxyBindsToLocalhostOnly(t *testing.T) {
 		defer mgr.Destroy(context.Background(), r.ID)
 
 		// Start the run
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		defer mgr.Stop(context.Background(), r.ID)
@@ -330,7 +330,7 @@ func TestProxyNotAccessibleFromNetwork(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		defer mgr.Stop(context.Background(), r.ID)
@@ -419,7 +419,7 @@ func TestNetworkRequestsAreCaptured(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -513,7 +513,7 @@ func TestContainerCanReachProxyViaHostDockerInternal(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -592,7 +592,7 @@ func TestLogsAreCaptured(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -662,7 +662,7 @@ func TestWorkspaceIsMounted(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -730,7 +730,7 @@ func TestConfigEnvironmentVariables(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -904,7 +904,7 @@ func TestAppleContainerBasicRun(t *testing.T) {
 	}
 	defer mgr.Destroy(context.Background(), r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -989,7 +989,7 @@ func TestAppleContainerWithProxy(t *testing.T) {
 		t.Fatalf("ProxyPort is 0 after Create, expected daemon proxy with grants=%v", r.Grants)
 	}
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	defer mgr.Stop(context.Background(), r.ID)
@@ -1217,7 +1217,7 @@ func TestSSHAuthSockEnvSetInContainer(t *testing.T) {
 			t.Error("SSHAgentServer should be set when SSH grants are configured")
 		}
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1347,7 +1347,7 @@ func TestDependencyNodeRuntime(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1409,7 +1409,7 @@ func TestDependencyPythonRuntime(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1471,7 +1471,7 @@ func TestDependencyGoRuntime(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1535,7 +1535,7 @@ func TestDependencyMultipleRuntimes(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1604,7 +1604,7 @@ func TestDependencyNpmPackage(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1666,7 +1666,7 @@ func TestDependencyGitHubBinary(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1730,7 +1730,7 @@ func TestDependencyMetaBundle(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -1986,7 +1986,7 @@ func TestClaudeLogSyncMountTarget(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 

--- a/internal/e2e/endpoints_test.go
+++ b/internal/e2e/endpoints_test.go
@@ -295,7 +295,7 @@ func TestProxyTokenValidInContainer(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -396,7 +396,7 @@ func startEndpointRun(t *testing.T, name string, ports map[string]int, cmd []str
 		t.Fatalf("Create: %v", err)
 	}
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		mgr.Destroy(context.Background(), r.ID)
 		mgr.Close()
 		cancel()

--- a/internal/e2e/host_traffic_test.go
+++ b/internal/e2e/host_traffic_test.go
@@ -122,7 +122,7 @@ func TestHostTrafficBlockedByDefault(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -208,7 +208,7 @@ func TestHostTrafficAllowedWithNetworkHost(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -270,7 +270,7 @@ func TestHostTrafficWrongPortBlocked(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -348,7 +348,7 @@ func TestHostTrafficStrictPolicyWithRules(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -415,7 +415,7 @@ func TestHostTrafficMultiplePorts(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -482,7 +482,7 @@ func TestHostTrafficProxyBypass(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {

--- a/internal/e2e/join_test.go
+++ b/internal/e2e/join_test.go
@@ -73,7 +73,7 @@ func TestJoinHeadless(t *testing.T) {
 		defer mgr.Destroy(context.Background(), primaryRun.ID)
 		defer mgr.Stop(context.Background(), primaryRun.ID)
 
-		if err := mgr.Start(ctx, primaryRun.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, primaryRun.ID); err != nil {
 			t.Fatalf("Start primary run: %v", err)
 		}
 

--- a/internal/e2e/logs_capture_test.go
+++ b/internal/e2e/logs_capture_test.go
@@ -42,7 +42,7 @@ func TestLogsCapturedInAttachedMode(t *testing.T) {
 		defer mgr.Destroy(context.Background(), r.ID)
 
 		// Start and wait for completion (simulating attached mode)
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -115,7 +115,7 @@ func TestLogsCapturedInDetachedMode(t *testing.T) {
 		defer mgr.Destroy(context.Background(), r.ID)
 
 		// Start without waiting (detached mode)
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -250,7 +250,7 @@ func TestLogsCapturedAfterStop(t *testing.T) {
 		defer mgr.Destroy(context.Background(), r.ID)
 
 		// Start the run
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 
@@ -325,7 +325,7 @@ func TestLogsAlwaysExistForAudit(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 

--- a/internal/e2e/services_test.go
+++ b/internal/e2e/services_test.go
@@ -90,7 +90,7 @@ func TestServicePostgres(t *testing.T) {
 	}
 	cleanupRun(t, mgr, r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -163,7 +163,7 @@ func TestServiceRedis(t *testing.T) {
 	}
 	cleanupRun(t, mgr, r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -229,7 +229,7 @@ func TestServiceMultiple(t *testing.T) {
 	}
 	cleanupRun(t, mgr, r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -307,7 +307,7 @@ func TestServiceCustomConfig(t *testing.T) {
 	}
 	cleanupRun(t, mgr, r.ID)
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 
@@ -382,7 +382,7 @@ func TestServiceCleanup(t *testing.T) {
 
 	runID := r.ID
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 

--- a/internal/e2e/volume_workspace_test.go
+++ b/internal/e2e/volume_workspace_test.go
@@ -231,7 +231,7 @@ func TestVolumeWorkspaceLifecycle(t *testing.T) {
 		_ = exec.Command("docker", "volume", "rm", run.WorkspaceVolumeName(r.ID)).Run()
 	})
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -374,7 +374,7 @@ func TestVolumeWorkspaceDestroyGuard(t *testing.T) {
 		_ = exec.Command("docker", "volume", "rm", volName).Run()
 	})
 
-	if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r.ID); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	if err := mgr.Wait(ctx, r.ID); err != nil {

--- a/internal/e2e/volumes_test.go
+++ b/internal/e2e/volumes_test.go
@@ -67,7 +67,7 @@ func TestVolumePersistenceAcrossRuns(t *testing.T) {
 			t.Fatalf("Create run 1: %v", err)
 		}
 
-		if err := mgr.Start(ctx, r1.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r1.ID); err != nil {
 			t.Fatalf("Start run 1: %v", err)
 		}
 		if err := mgr.Wait(ctx, r1.ID); err != nil {
@@ -135,7 +135,7 @@ func TestVolumePersistenceAcrossRuns(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r2.ID)
 
-		if err := mgr.Start(ctx, r2.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r2.ID); err != nil {
 			t.Fatalf("Start run 2: %v", err)
 		}
 		if err := mgr.Wait(ctx, r2.ID); err != nil {
@@ -208,7 +208,7 @@ func TestVolumeReadOnly(t *testing.T) {
 		}
 		defer mgr.Destroy(context.Background(), r.ID)
 
-		if err := mgr.Start(ctx, r.ID, run.StartOptions{}); err != nil {
+		if err := mgr.Start(ctx, r.ID); err != nil {
 			t.Fatalf("Start: %v", err)
 		}
 		if err := mgr.Wait(ctx, r.ID); err != nil {
@@ -292,7 +292,7 @@ func TestVolumeIsolation(t *testing.T) {
 		t.Fatalf("Create agent1: %v", err)
 	}
 
-	if err := mgr.Start(ctx, r1.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r1.ID); err != nil {
 		t.Fatalf("Start agent1: %v", err)
 	}
 	if err := mgr.Wait(ctx, r1.ID); err != nil {
@@ -349,7 +349,7 @@ func TestVolumeIsolation(t *testing.T) {
 	}
 	defer mgr.Destroy(context.Background(), r2.ID)
 
-	if err := mgr.Start(ctx, r2.ID, run.StartOptions{}); err != nil {
+	if err := mgr.Start(ctx, r2.ID); err != nil {
 		t.Fatalf("Start agent2: %v", err)
 	}
 	if err := mgr.Wait(ctx, r2.ID); err != nil {

--- a/internal/run/edge_cases_test.go
+++ b/internal/run/edge_cases_test.go
@@ -217,7 +217,7 @@ func TestStartFirewallFailureStopsContainer(t *testing.T) {
 	m.runs[r.ID] = r
 	m.mu.Unlock()
 
-	err := m.Start(context.Background(), r.ID, StartOptions{})
+	err := m.Start(context.Background(), r.ID)
 	if err == nil {
 		t.Fatal("Start should fail when firewall setup fails")
 	}
@@ -266,7 +266,7 @@ func TestStartFirewallFailureStopContainerAlsoFails(t *testing.T) {
 	m.runs[r.ID] = r
 	m.mu.Unlock()
 
-	err := m.Start(context.Background(), r.ID, StartOptions{})
+	err := m.Start(context.Background(), r.ID)
 	if err == nil {
 		t.Fatal("Start should fail when firewall setup fails")
 	}
@@ -334,7 +334,7 @@ func TestStartNoFirewallWhenNotEnabled(t *testing.T) {
 	m.runs[r.ID] = r
 	m.mu.Unlock()
 
-	err = m.Start(context.Background(), r.ID, StartOptions{})
+	err = m.Start(context.Background(), r.ID)
 	if err != nil {
 		t.Fatalf("Start should succeed: %v", err)
 	}

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -3038,9 +3038,6 @@ region = %s
 	return r, nil
 }
 
-// StartOptions configures how a run is started.
-type StartOptions struct{}
-
 // replaceHostInEnv replaces all occurrences of oldHost with newHost in the
 // value portion of env vars (after the first '='). This is used to rewrite
 // proxy URLs when a container is placed on a custom network whose gateway
@@ -3136,7 +3133,7 @@ func (m *Manager) setupFirewall(ctx context.Context, r *Run) error {
 }
 
 // Start begins execution of a run.
-func (m *Manager) Start(ctx context.Context, runID string, opts StartOptions) error {
+func (m *Manager) Start(ctx context.Context, runID string) error {
 	m.mu.Lock()
 	r, ok := m.runs[runID]
 	if !ok {


### PR DESCRIPTION
From the craftsmanship audit. `Manager.Start` took a zero-field `StartOptions{}` at every call site — pure ceremony. Remove the type and simplify the signature.

## Change
```go
-func (m *Manager) Start(ctx context.Context, runID string, opts StartOptions) error
+func (m *Manager) Start(ctx context.Context, runID string) error
```
- Deleted `type StartOptions struct{}`.
- Updated all **57** call sites (`Start(ctx, id, run.StartOptions{})` → `Start(ctx, id)`), mostly e2e tests.
- The unrelated Docker SDK `container.StartOptions{}` (4 uses in `docker.go`) is untouched.

When a real start option is needed, it can be reintroduced with a concrete field driving it (the audit's "no empty options structs" guidance).

## Testing
`go build ./...`, `go vet -tags=e2e ./internal/e2e/ ./internal/run/ ./cmd/moat/cli/` (compile-checks the e2e call sites), `golangci-lint run ./...` (0 issues), and unit tests all pass. No behavior change → no CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)