### PR TITLE
refactor(run): open the credential store once in Create

### DIFF
--- a/internal/run/manager_create.go
+++ b/internal/run/manager_create.go
@@ -112,16 +112,38 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 	// each mcp[].auth.grant in the top-level grants: list.
 	opts.Grants = appendMCPGrants(opts.Grants, opts.Config)
 
+	// openCredStore opens the run's credential store at most once and memoizes
+	// the result; deriving the key can touch the OS keychain, so re-opening at
+	// each site below was wasteful. credKeyFailed marks a key-derivation failure
+	// (fatal for some callers) versus a store-open failure (others degrade).
+	var (
+		credStoreCache *credential.FileStore
+		credStoreErr   error
+		credKeyFailed  bool
+		credStoreDone  bool
+	)
+	openCredStore := func() (*credential.FileStore, error) {
+		if !credStoreDone {
+			credStoreDone = true
+			key, keyErr := credential.DefaultEncryptionKey()
+			if keyErr != nil {
+				credKeyFailed = true
+				credStoreErr = fmt.Errorf("getting encryption key: %w", keyErr)
+			} else if s, storeErr := credential.NewFileStore(credential.DefaultStoreDir(), key); storeErr != nil {
+				credStoreErr = fmt.Errorf("opening credential store: %w", storeErr)
+			} else {
+				credStoreCache = s
+			}
+		}
+		return credStoreCache, credStoreErr
+	}
+
 	// Validate grants before allocating any resources (proxy, container, etc.)
 	needsGrantValidation := len(opts.Grants) > 0 || (opts.Config != nil && len(opts.Config.MCP) > 0)
 	if needsGrantValidation {
-		key, keyErr := credential.DefaultEncryptionKey()
-		if keyErr != nil {
-			return nil, fmt.Errorf("getting encryption key: %w", keyErr)
-		}
-		store, err := credential.NewFileStore(credential.DefaultStoreDir(), key)
+		store, err := openCredStore()
 		if err != nil {
-			return nil, fmt.Errorf("opening credential store: %w", err)
+			return nil, err
 		}
 		if err := validateGrants(opts.Grants, store); err != nil {
 			return nil, err
@@ -381,14 +403,10 @@ func (m *Manager) Create(ctx context.Context, opts Options) (*Run, error) {
 		runCtx := daemon.NewRunContext(r.ID)
 
 		// Load credentials for granted providers
-		key, keyErr := credential.DefaultEncryptionKey()
-		if keyErr != nil {
-			return nil, fmt.Errorf("getting encryption key: %w", keyErr)
+		store, err := openCredStore()
+		if err != nil && credKeyFailed {
+			return nil, err
 		}
-		store, err := credential.NewFileStore(
-			credential.DefaultStoreDir(),
-			key,
-		)
 
 		// Track Anthropic/Claude credential for base URL proxy setup
 		var anthropicCred *provider.Credential
@@ -821,15 +839,10 @@ region = %s
 		}
 
 		// Load SSH mappings for granted hosts
-		key, keyErr := credential.DefaultEncryptionKey()
-		if keyErr != nil {
-			cleanupDaemonRun()
-			return nil, fmt.Errorf("getting encryption key: %w", keyErr)
-		}
-		store, err := credential.NewFileStore(credential.DefaultStoreDir(), key)
+		store, err := openCredStore()
 		if err != nil {
 			cleanupDaemonRun()
-			return nil, fmt.Errorf("opening credential store: %w", err)
+			return nil, err
 		}
 
 		sshMappings, err := store.GetSSHMappingsForHosts(sshGrants)
@@ -1481,38 +1494,34 @@ region = %s
 	// avoiding bind mounts for config dirs that tools need to write to.
 	initFiles := make(map[string]string)
 	if containerHome != "" {
-		key, keyErr := credential.DefaultEncryptionKey()
-		if keyErr == nil {
-			store, storeErr := credential.NewFileStore(credential.DefaultStoreDir(), key)
-			if storeErr == nil {
-				for _, grant := range opts.Grants {
-					grantName := strings.Split(grant, ":")[0]
-					credName := credential.Provider(provider.ResolveName(grantName))
-					if cred, err := store.Get(credName); err == nil {
-						if prov := provider.Get(grantName); prov != nil {
-							provCred := provider.FromLegacy(cred)
-							providerMounts, cleanupPath, mountErr := prov.ContainerMounts(provCred, containerHome)
-							if mountErr != nil {
-								log.Debug("failed to set up provider mounts", "provider", credName, "error", mountErr)
-							} else {
-								mounts = append(mounts, providerMounts...)
-								if cleanupPath != "" {
-									if r.ProviderCleanupPaths == nil {
-										r.ProviderCleanupPaths = make(map[string]string)
-									}
-									r.ProviderCleanupPaths[string(credName)] = cleanupPath
+		if store, storeErr := openCredStore(); storeErr == nil {
+			for _, grant := range opts.Grants {
+				grantName := strings.Split(grant, ":")[0]
+				credName := credential.Provider(provider.ResolveName(grantName))
+				if cred, err := store.Get(credName); err == nil {
+					if prov := provider.Get(grantName); prov != nil {
+						provCred := provider.FromLegacy(cred)
+						providerMounts, cleanupPath, mountErr := prov.ContainerMounts(provCred, containerHome)
+						if mountErr != nil {
+							log.Debug("failed to set up provider mounts", "provider", credName, "error", mountErr)
+						} else {
+							mounts = append(mounts, providerMounts...)
+							if cleanupPath != "" {
+								if r.ProviderCleanupPaths == nil {
+									r.ProviderCleanupPaths = make(map[string]string)
 								}
+								r.ProviderCleanupPaths[string(credName)] = cleanupPath
 							}
-							// Collect init files from providers that implement InitFileProvider
-							if ifp, ok := prov.(provider.InitFileProvider); ok {
-								for p, content := range ifp.ContainerInitFiles(provCred, containerHome) {
-									cleaned := filepath.Clean(p)
-									if !filepath.IsAbs(cleaned) || !strings.HasPrefix(cleaned, containerHome+string(filepath.Separator)) {
-										log.Warn("init file path outside container home, skipping", "provider", credName, "path", p)
-										continue
-									}
-									initFiles[cleaned] = content
+						}
+						// Collect init files from providers that implement InitFileProvider
+						if ifp, ok := prov.(provider.InitFileProvider); ok {
+							for p, content := range ifp.ContainerInitFiles(provCred, containerHome) {
+								cleaned := filepath.Clean(p)
+								if !filepath.IsAbs(cleaned) || !strings.HasPrefix(cleaned, containerHome+string(filepath.Separator)) {
+									log.Warn("init file path outside container home, skipping", "provider", credName, "path", p)
+									continue
 								}
+								initFiles[cleaned] = content
 							}
 						}
 					}
@@ -1589,18 +1598,14 @@ region = %s
 			// Preference: claude > anthropic (for backward compatibility)
 			var claudeCred *provider.Credential
 			if needsClaudeInit {
-				key, keyErr := credential.DefaultEncryptionKey()
-				if keyErr == nil {
-					store, storeErr := credential.NewFileStore(credential.DefaultStoreDir(), key)
-					if storeErr == nil {
-						// Try claude first, fall back to anthropic
-						cred, err := store.Get(credential.ProviderClaude)
-						if err != nil {
-							cred, err = store.Get(credential.ProviderAnthropic)
-						}
-						if err == nil {
-							claudeCred = provider.FromLegacy(cred)
-						}
+				if store, storeErr := openCredStore(); storeErr == nil {
+					// Try claude first, fall back to anthropic
+					cred, err := store.Get(credential.ProviderClaude)
+					if err != nil {
+						cred, err = store.Get(credential.ProviderAnthropic)
+					}
+					if err == nil {
+						claudeCred = provider.FromLegacy(cred)
 					}
 				}
 			}
@@ -1692,13 +1697,9 @@ region = %s
 		// Get Codex credential for PrepareContainer
 		var codexCred *provider.Credential
 		if needsCodexInit {
-			key, keyErr := credential.DefaultEncryptionKey()
-			if keyErr == nil {
-				store, storeErr := credential.NewFileStore(credential.DefaultStoreDir(), key)
-				if storeErr == nil {
-					if cred, err := store.Get(credential.ProviderOpenAI); err == nil {
-						codexCred = provider.FromLegacy(cred)
-					}
+			if store, storeErr := openCredStore(); storeErr == nil {
+				if cred, err := store.Get(credential.ProviderOpenAI); err == nil {
+					codexCred = provider.FromLegacy(cred)
 				}
 			}
 		}
@@ -1780,13 +1781,9 @@ region = %s
 		// Get Gemini credential for PrepareContainer
 		var geminiCred *provider.Credential
 		if needsGeminiInit {
-			key, keyErr := credential.DefaultEncryptionKey()
-			if keyErr == nil {
-				store, storeErr := credential.NewFileStore(credential.DefaultStoreDir(), key)
-				if storeErr == nil {
-					if cred, err := store.Get(credential.ProviderGemini); err == nil {
-						geminiCred = provider.FromLegacy(cred)
-					}
+			if store, storeErr := openCredStore(); storeErr == nil {
+				if cred, err := store.Get(credential.ProviderGemini); err == nil {
+					geminiCred = provider.FromLegacy(cred)
 				}
 			}
 		}


### PR DESCRIPTION
## What

`Create` opened the credential store (`credential.NewFileStore`) at **seven** separate sites, each first deriving the encryption key (`credential.DefaultEncryptionKey()`, which can touch the OS keychain):

1. grant validation
2. the proxy credential loop
3. SSH mapping lookup
4. provider container mounts / init files
5. Claude init
6. Codex init
7. Gemini init

Every site opens the *same* store (same directory + key), so a single run re-opened it up to 7× — wasted work, and potentially repeated keychain access.

This PR introduces a memoized `openCredStore()` closure that opens the store **at most once** and caches the `(store, error)` result. All seven sites now share that one open.

## Why this is behavior-preserving

The seven sites have different error handling, which the memo preserves exactly:

| Sites | Original handling | After |
|-------|-------------------|-------|
| grant validation, SSH | hard-fail on key **or** store error (same wrapped messages) | `if err != nil { return err }` — memo returns the identical wrapped message |
| provider mounts, Claude/Codex/Gemini init | degrade (skip) on key **or** store error | `if store, storeErr := openCredStore(); storeErr == nil { … }` |
| proxy credential loop | **key** error fatal, **store** error degrades (skips loop) | `credKeyFailed` flag preserves the distinction |

- Error messages are unchanged (`getting encryption key: %w` / `opening credential store: %w` are produced inside the memo).
- The one site that distinguished a fatal key-derivation failure from a degradable store-open failure (the proxy loop, which runs for strict-network-policy runs even with zero grants) keeps that distinction via `credKeyFailed`.
- The credential lookups themselves and their order are untouched.

This is the "store opened 7×" item from the craftsmanship audit (follow-up to the `manager.go` file split, #421). The store opens in `grants.go` and `imageneeds.go` are on separate call paths (pre-`Create` grant prompting / image-needs computation) and are intentionally left untouched.

## Not a literal "phase extraction"

The plan called this "extract the credential-loading phase," but the credential reads are interleaved with proxy/SSH/mount/agent setup throughout `Create` rather than forming one contiguous block. The substantive win — open the store once — is delivered by the memoized opener; a cosmetic contiguous-phase extraction would have meant reordering unrelated setup, which isn't behavior-preserving. Framed honestly as the consolidation.

## Verification

`go build ./...` ✓ · `go vet` ✓ · `golangci-lint run` → **0 issues** ✓ · `go test -race ./internal/run/` ✓. Net diff is ~line-neutral (the memo helper replaces six redundant open blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)