### PR TITLE
refactor(run): extract network-mode resolution from Create

### DIFF
--- a/internal/run/manager_create.go
+++ b/internal/run/manager_create.go
@@ -837,47 +837,9 @@ region = %s
 	proxyEnv = append(proxyEnv, sshSetup.env...)
 	mounts = append(mounts, sshSetup.mounts...)
 
-	// Configure network mode and extra hosts based on runtime capabilities
-	// We use bridge mode when:
-	// 1. We have ports to publish (host mode doesn't support port publishing)
-	// 2. We're on macOS/Windows (host mode not supported)
-	// 3. We're using Apple container runtime
-	// We only use host mode when we need proxy access AND don't have ports to publish on Linux.
-	var networkMode string
-	var extraHosts []string
-	needsPorts := len(ports) > 0
+	// Configure network mode and extra hosts based on runtime capabilities.
 	needsProxy := r.ProxyAuthToken != ""
-
-	if needsProxy || needsPorts {
-		if m.defaultRuntime().SupportsHostNetwork() && !needsPorts {
-			// Docker on Linux without ports: use host network so container can reach 127.0.0.1
-			networkMode = "host"
-		} else {
-			// Use bridge mode when we need port publishing, or on macOS/Windows/Apple
-			networkMode = "bridge"
-			// On Linux, Docker doesn't provide host.docker.internal by default,
-			// so add it via host-gateway mapping. On macOS/Windows, Docker
-			// Desktop and Rancher Desktop resolve it via built-in DNS — adding
-			// host-gateway would override the correct IP with the bridge
-			// gateway (which is unreachable on Rancher Desktop).
-			if m.defaultRuntime().Type() == container.RuntimeDocker && goruntime.GOOS == "linux" {
-				extraHosts = []string{"host.docker.internal:host-gateway"}
-			}
-		}
-		// Add synthetic hostnames to --add-host on runtimes where Docker's
-		// "host-gateway" substitution produces a reachable IP (Docker on
-		// Linux). Apple has no --add-host equivalent, and Docker Desktop on
-		// macOS/Windows must not use this path — "host-gateway" resolves to
-		// the docker0 bridge gateway, which is unreachable from containers on
-		// custom networks (those created by `services:`). Those runtimes
-		// instead rely on MOAT_EXTRA_HOSTS written by moat-init.sh (see above).
-		//
-		// "moat-proxy" is used for proxy traffic (in NO_PROXY).
-		// "moat-host" is used for host service traffic (NOT in NO_PROXY,
-		// so it flows through the proxy for network policy enforcement).
-		synthHosts, _ := synthHostStrategy(m.defaultRuntime().Type(), goruntime.GOOS, hostAddr)
-		extraHosts = append(extraHosts, synthHosts...)
-	}
+	networkMode, extraHosts := m.resolveNetworkConfig(len(ports) > 0, needsProxy, hostAddr)
 
 	// Add config env vars, filtering out proxy-related variables that would
 	// override moat's proxy settings and re-open the host traffic bypass.

--- a/internal/run/manager_network.go
+++ b/internal/run/manager_network.go
@@ -1,0 +1,61 @@
+package run
+
+// This file holds container network-mode resolution used by Create.
+
+import (
+	goruntime "runtime"
+
+	"github.com/majorcontext/moat/internal/container"
+)
+
+// resolveNetworkConfig picks the container network mode and any extra host
+// mappings from runtime capabilities and whether the run needs published ports
+// or proxy access. It returns ("", nil) when neither is needed.
+//
+// We use bridge mode when:
+//  1. We have ports to publish (host mode doesn't support port publishing)
+//  2. We're on macOS/Windows (host mode not supported)
+//  3. We're using the Apple container runtime
+//
+// We only use host mode when we need proxy access AND don't have ports to
+// publish on Linux.
+func (m *Manager) resolveNetworkConfig(needsPorts, needsProxy bool, hostAddr string) (networkMode string, extraHosts []string) {
+	if !needsProxy && !needsPorts {
+		return "", nil
+	}
+
+	if m.defaultRuntime().SupportsHostNetwork() && !needsPorts {
+		// Docker on Linux without ports: use host network so container can reach 127.0.0.1
+		networkMode = "host"
+	} else {
+		// Use bridge mode when we need port publishing, or on macOS/Windows/Apple.
+		networkMode = "bridge"
+		// On Linux, Docker doesn't provide host.docker.internal by default, so
+		// add it via host-gateway mapping. On macOS/Windows, Docker Desktop and
+		// Rancher Desktop resolve it via built-in DNS — adding host-gateway
+		// would override the correct IP with the bridge gateway (which is
+		// unreachable on Rancher Desktop).
+		if m.defaultRuntime().Type() == container.RuntimeDocker && goruntime.GOOS == "linux" {
+			extraHosts = []string{"host.docker.internal:host-gateway"}
+		}
+	}
+
+	// Add synthetic hostnames to --add-host on runtimes where Docker's
+	// "host-gateway" substitution produces a reachable IP (Docker on Linux).
+	// Apple has no --add-host equivalent, and Docker Desktop on macOS/Windows
+	// must not use this path — "host-gateway" resolves to the docker0 bridge
+	// gateway, which is unreachable from containers on custom networks (those
+	// created by `services:`). Those runtimes instead rely on MOAT_EXTRA_HOSTS
+	// written by moat-init.sh.
+	//
+	// "moat-proxy" is used for proxy traffic (in NO_PROXY).
+	// "moat-host" is used for host service traffic (NOT in NO_PROXY, so it flows
+	// through the proxy for network policy enforcement).
+	//
+	// We take only the --add-host entries here; the companion MOAT_EXTRA_HOSTS
+	// env value (the discarded second return) is set separately by Create's own
+	// synthHostStrategy call for runtimes that rely on it.
+	synthHosts, _ := synthHostStrategy(m.defaultRuntime().Type(), goruntime.GOOS, hostAddr)
+	extraHosts = append(extraHosts, synthHosts...)
+	return networkMode, extraHosts
+}

--- a/internal/run/manager_network_test.go
+++ b/internal/run/manager_network_test.go
@@ -1,0 +1,74 @@
+package run
+
+import (
+	goruntime "runtime"
+	"slices"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/container"
+)
+
+func mgrWithRuntime(rt container.Runtime) *Manager {
+	return &Manager{runtimePool: container.NewRuntimePoolWithDefault(rt)}
+}
+
+// noHostNetRuntime is a stubRuntime that reports no host-network support, to
+// exercise the bridge-mode fallback path.
+type noHostNetRuntime struct{ *stubRuntime }
+
+func (noHostNetRuntime) SupportsHostNetwork() bool { return false }
+
+func TestResolveNetworkConfig_NoneNeeded(t *testing.T) {
+	m := &Manager{} // defaultRuntime is never reached on this path
+	mode, hosts := m.resolveNetworkConfig(false, false, "127.0.0.1")
+	if mode != "" || hosts != nil {
+		t.Fatalf("expected empty config, got mode=%q hosts=%v", mode, hosts)
+	}
+}
+
+func TestResolveNetworkConfig_HostMode(t *testing.T) {
+	// stubRuntime supports host network; with proxy needed and no ports, host
+	// mode lets the container reach 127.0.0.1.
+	m := mgrWithRuntime(&stubRuntime{})
+	mode, hosts := m.resolveNetworkConfig(false, true, "127.0.0.1")
+	if mode != "host" {
+		t.Fatalf("expected host mode, got %q", mode)
+	}
+	// Even in host mode the synthetic hosts are appended (no host.docker.internal,
+	// which is bridge-only).
+	wantSynth, _ := synthHostStrategy(container.RuntimeDocker, goruntime.GOOS, "127.0.0.1")
+	if !slices.Equal(hosts, wantSynth) {
+		t.Fatalf("host mode extraHosts = %v, want synth hosts %v", hosts, wantSynth)
+	}
+}
+
+func TestResolveNetworkConfig_BridgeWithPortsAndProxy(t *testing.T) {
+	// Proxy and ports needed simultaneously: ports force bridge mode.
+	m := mgrWithRuntime(&stubRuntime{})
+	mode, _ := m.resolveNetworkConfig(true, true, "127.0.0.1")
+	if mode != "bridge" {
+		t.Fatalf("expected bridge mode for proxy+ports, got %q", mode)
+	}
+}
+
+func TestResolveNetworkConfig_BridgeWithPorts(t *testing.T) {
+	// Published ports force bridge mode even when host network is supported.
+	m := mgrWithRuntime(&stubRuntime{})
+	mode, hosts := m.resolveNetworkConfig(true, false, "127.0.0.1")
+	if mode != "bridge" {
+		t.Fatalf("expected bridge mode, got %q", mode)
+	}
+	// host.docker.internal is mapped only for Docker on Linux.
+	if goruntime.GOOS == "linux" && !slices.Contains(hosts, "host.docker.internal:host-gateway") {
+		t.Fatalf("expected host.docker.internal mapping on linux, got %v", hosts)
+	}
+}
+
+func TestResolveNetworkConfig_BridgeWhenNoHostNetwork(t *testing.T) {
+	// A runtime without host-network support uses bridge mode even with no ports.
+	m := mgrWithRuntime(noHostNetRuntime{&stubRuntime{}})
+	mode, _ := m.resolveNetworkConfig(false, true, "127.0.0.1")
+	if mode != "bridge" {
+		t.Fatalf("expected bridge mode when host network unsupported, got %q", mode)
+	}
+}


### PR DESCRIPTION
## What

Next phase extraction from `Create` (follows #421 split, #422 credential consolidation, #423 SSH setup). The network-mode/extra-hosts computation moves into a pure `resolveNetworkConfig` method in its own **`manager_network.go`** (continuing the file-per-phase pattern).

`Create`: **~2,353 → ~2,315 lines.**

```go
func (m *Manager) resolveNetworkConfig(needsPorts, needsProxy bool, hostAddr string) (networkMode string, extraHosts []string)
```

Call site:
```go
needsProxy := r.ProxyAuthToken != ""
networkMode, extraHosts := m.resolveNetworkConfig(len(ports) > 0, needsProxy, hostAddr)
```

`needsProxy` stays in `Create` (used later for proxy-env filtering); `networkMode`/`extraHosts` stay `Create`-scoped vars (reassigned/mutated later for custom networks) — declared from the return values.

## Behavior-preserving

Identical host-vs-bridge selection, the same Docker-on-Linux `host.docker.internal:host-gateway` mapping, and the same synthetic-host append. The only structural change is an inverted guard — an early `return "", nil` when neither ports nor proxy are needed, equivalent to the original `if needsProxy || needsPorts { … }`. Verified the substantive logic line-by-line against `main`.

## Tests

`manager_network_test.go` covers the paths the extraction unlocked:
- none needed → `("", nil)`
- proxy + no ports + host-network-capable runtime → `host`
- published ports → `bridge` (+ `host.docker.internal` on Linux)
- no-host-network runtime → `bridge` even without ports (via a small `stubRuntime` override)

## Verification

`go build ./...` ✓ · `go vet` ✓ · `golangci-lint run` → **0 issues** ✓ · `go test -race -count=1 ./internal/run/` ✓ (4 new tests pass).

Part of the `manager.go` decomposition; agent-init staging, service orchestration, and the cleanup-rollback-stack remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)