### PR TITLE
refactor(run): extract provider mounts/init-files from Create

### DIFF
--- a/internal/run/manager_create.go
+++ b/internal/run/manager_create.go
@@ -1316,45 +1316,8 @@ region = %s
 	}
 
 	// Set up provider-specific container mounts and init files.
-	// Init files are written to disk by moat-init.sh at container startup,
-	// avoiding bind mounts for config dirs that tools need to write to.
-	initFiles := make(map[string]string)
-	if containerHome != "" {
-		if store, storeErr := openCredStore(); storeErr == nil {
-			for _, grant := range opts.Grants {
-				grantName := strings.Split(grant, ":")[0]
-				credName := credential.Provider(provider.ResolveName(grantName))
-				if cred, err := store.Get(credName); err == nil {
-					if prov := provider.Get(grantName); prov != nil {
-						provCred := provider.FromLegacy(cred)
-						providerMounts, cleanupPath, mountErr := prov.ContainerMounts(provCred, containerHome)
-						if mountErr != nil {
-							log.Debug("failed to set up provider mounts", "provider", credName, "error", mountErr)
-						} else {
-							mounts = append(mounts, providerMounts...)
-							if cleanupPath != "" {
-								if r.ProviderCleanupPaths == nil {
-									r.ProviderCleanupPaths = make(map[string]string)
-								}
-								r.ProviderCleanupPaths[string(credName)] = cleanupPath
-							}
-						}
-						// Collect init files from providers that implement InitFileProvider
-						if ifp, ok := prov.(provider.InitFileProvider); ok {
-							for p, content := range ifp.ContainerInitFiles(provCred, containerHome) {
-								cleaned := filepath.Clean(p)
-								if !filepath.IsAbs(cleaned) || !strings.HasPrefix(cleaned, containerHome+string(filepath.Separator)) {
-									log.Warn("init file path outside container home, skipping", "provider", credName, "path", p)
-									continue
-								}
-								initFiles[cleaned] = content
-							}
-						}
-					}
-				}
-			}
-		}
-	}
+	providerMounts, initFiles := m.setupProviderMounts(r, opts.Grants, containerHome, openCredStore)
+	mounts = append(mounts, providerMounts...)
 	if len(initFiles) > 0 {
 		var buf strings.Builder
 		for initPath, content := range initFiles {

--- a/internal/run/manager_provider.go
+++ b/internal/run/manager_provider.go
@@ -1,0 +1,66 @@
+package run
+
+// This file holds provider-specific container setup used by Create.
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/majorcontext/moat/internal/container"
+	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/log"
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+// setupProviderMounts collects provider-specific container mounts and init
+// files for the run's grants. Init files are written to disk by moat-init.sh at
+// container startup, avoiding bind mounts for config dirs that tools need to
+// write to. Provider cleanup paths are recorded on r. It returns empty results
+// (degrading, not failing) when there is no container home or the credential
+// store can't be opened — matching the original inline behavior.
+func (m *Manager) setupProviderMounts(r *Run, grants []string, containerHome string, openCredStore func() (*credential.FileStore, error)) (mounts []container.MountConfig, initFiles map[string]string) {
+	initFiles = make(map[string]string)
+	if containerHome == "" {
+		return nil, initFiles
+	}
+	store, storeErr := openCredStore()
+	if storeErr != nil {
+		return nil, initFiles
+	}
+	for _, grant := range grants {
+		grantName := strings.Split(grant, ":")[0]
+		credName := credential.Provider(provider.ResolveName(grantName))
+		if cred, err := store.Get(credName); err == nil {
+			if prov := provider.Get(grantName); prov != nil {
+				provCred := provider.FromLegacy(cred)
+				providerMounts, cleanupPath, mountErr := prov.ContainerMounts(provCred, containerHome)
+				if mountErr != nil {
+					log.Debug("failed to set up provider mounts", "provider", credName, "error", mountErr)
+				} else {
+					mounts = append(mounts, providerMounts...)
+					if cleanupPath != "" {
+						if r.ProviderCleanupPaths == nil {
+							r.ProviderCleanupPaths = make(map[string]string)
+						}
+						r.ProviderCleanupPaths[string(credName)] = cleanupPath
+					}
+				}
+				// Collect init files from providers that implement InitFileProvider.
+				// This runs independently of the mount step above: a ContainerMounts
+				// error skips only mounts and cleanup-path recording, not init files
+				// (preserved from the original inline code).
+				if ifp, ok := prov.(provider.InitFileProvider); ok {
+					for p, content := range ifp.ContainerInitFiles(provCred, containerHome) {
+						cleaned := filepath.Clean(p)
+						if !filepath.IsAbs(cleaned) || !strings.HasPrefix(cleaned, containerHome+string(filepath.Separator)) {
+							log.Warn("init file path outside container home, skipping", "provider", credName, "path", p)
+							continue
+						}
+						initFiles[cleaned] = content
+					}
+				}
+			}
+		}
+	}
+	return mounts, initFiles
+}

--- a/internal/run/manager_provider_test.go
+++ b/internal/run/manager_provider_test.go
@@ -1,0 +1,39 @@
+package run
+
+import (
+	"errors"
+	"testing"
+)
+
+// sshTestOpener and emptyTestStore are defined in manager_ssh_test.go (same
+// package) and reused here.
+
+func TestSetupProviderMounts_NoContainerHome(t *testing.T) {
+	m := &Manager{}
+	mounts, initFiles := m.setupProviderMounts(&Run{}, []string{"github"}, "", sshTestOpener(nil, nil))
+	if mounts != nil || len(initFiles) != 0 {
+		t.Fatalf("expected empty result with no container home, got mounts=%v initFiles=%v", mounts, initFiles)
+	}
+}
+
+func TestSetupProviderMounts_StoreError(t *testing.T) {
+	m := &Manager{}
+	mounts, initFiles := m.setupProviderMounts(&Run{}, []string{"github"}, "/home/moatuser", sshTestOpener(nil, errors.New("store open failed")))
+	if mounts != nil || len(initFiles) != 0 {
+		t.Fatalf("expected empty result on store error, got mounts=%v initFiles=%v", mounts, initFiles)
+	}
+}
+
+func TestSetupProviderMounts_CredMissSkipped(t *testing.T) {
+	// An empty store has no credential for the grant, so the grant is skipped
+	// (degrade, not fail) and nothing is mounted or recorded for cleanup.
+	m := &Manager{}
+	r := &Run{}
+	mounts, initFiles := m.setupProviderMounts(r, []string{"github"}, "/home/moatuser", sshTestOpener(emptyTestStore(t), nil))
+	if mounts != nil || len(initFiles) != 0 {
+		t.Fatalf("expected grant with missing credential to be skipped, got mounts=%v initFiles=%v", mounts, initFiles)
+	}
+	if r.ProviderCleanupPaths != nil {
+		t.Fatalf("expected no cleanup paths, got %v", r.ProviderCleanupPaths)
+	}
+}


### PR DESCRIPTION
## What

Low-risk phase extraction from `Create` (follows #421–#425). The provider-specific container mounts + init-files setup moves into `setupProviderMounts` in its own **`manager_provider.go`**.

`Create`: **~2,288 → ~2,251 lines.**

```go
func (m *Manager) setupProviderMounts(r *Run, grants []string, containerHome string,
    openCredStore func() (*credential.FileStore, error)) (mounts []container.MountConfig, initFiles map[string]string)
```

The caller appends the returned mounts and keeps the existing `MOAT_INIT_FILES` serialization. `r.ProviderCleanupPaths` is recorded inside the method (it takes `r`).

## Behavior-preserving

The per-grant logic (credential lookup, `provider.ContainerMounts`, cleanup-path recording, init-file path validation against the container home) is moved verbatim — verified line-by-line against `main`. The only changes: `opts.Grants` → the `grants` parameter, and the `containerHome != ""` / store-open conditions become early returns that **degrade to an empty result exactly as before** (the `openCredStore` closure preserves the open-once guarantee from #422).

## Tests

`manager_provider_test.go` covers the guard branches the extraction unlocked:
- no container home → empty
- store-open error → empty (degrade)
- grant with a missing credential → skipped, nothing mounted or recorded

The populated path needs a registered provider + a stored credential and stays e2e-covered.

## Verification

`go build ./...` ✓ · `go vet` ✓ · `golangci-lint run` → **0 issues** ✓ · `go test -race -count=1 ./internal/run/` ✓ (3 new tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)