### PR TITLE
refactor(run): extract Codex container staging from Create

### DIFF
--- a/internal/run/manager_agentinit.go
+++ b/internal/run/manager_agentinit.go
@@ -1,0 +1,76 @@
+package run
+
+// This file holds per-agent container staging (Claude/Codex/Gemini) used by
+// Create. Each helper builds an agent's *provider.ContainerConfig via the
+// provider interface. The caller resolves the provider (so its "not registered"
+// error keeps its original rollback) and owns rolling back resources allocated
+// before the call; these helpers create nothing that outlives a failed call.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/provider"
+)
+
+// setupCodexStaging builds the Codex container config (OpenAI auth + local MCP
+// servers) via the provider interface. openCredStore must be non-nil when
+// needsCodexInit is true (Create always passes a real closure).
+func (m *Manager) setupCodexStaging(ctx context.Context, codexProvider provider.AgentProvider, opts Options, needsCodexInit bool, containerHome, renderedContext string, openCredStore func() (*credential.FileStore, error)) (*provider.ContainerConfig, error) {
+	// Get Codex credential for PrepareContainer
+	var codexCred *provider.Credential
+	if needsCodexInit {
+		if store, storeErr := openCredStore(); storeErr == nil {
+			if cred, err := store.Get(credential.ProviderOpenAI); err == nil {
+				codexCred = provider.FromLegacy(cred)
+			}
+		}
+	}
+
+	// Build local MCP server config from codex.mcp entries
+	var codexLocalMCP map[string]provider.LocalMCPServerConfig
+	if opts.Config != nil && len(opts.Config.Codex.MCP) > 0 {
+		codexLocalMCP = make(map[string]provider.LocalMCPServerConfig)
+		for name, spec := range opts.Config.Codex.MCP {
+			env := spec.Env
+			if spec.Grant != "" {
+				v, ok := grantToEnvVar(spec.Grant)
+				if !ok {
+					return nil, fmt.Errorf("codex.mcp.%s: unknown grant %q (supported: github, openai, anthropic, gemini)", name, spec.Grant)
+				}
+				if !hasGrant(opts.Config.Grants, spec.Grant) {
+					return nil, fmt.Errorf("codex.mcp.%s: grant %q not declared in top-level grants list — add 'grants: [%s]' to agent.yaml", name, spec.Grant, spec.Grant)
+				}
+				if env == nil {
+					env = make(map[string]string)
+				} else {
+					// Copy to avoid mutating the original config
+					envCopy := make(map[string]string, len(env)+1)
+					for k, v := range env {
+						envCopy[k] = v
+					}
+					env = envCopy
+				}
+				env[v] = grantToPlaceholder(spec.Grant)
+			}
+			codexLocalMCP[name] = provider.LocalMCPServerConfig{
+				Command: spec.Command,
+				Args:    spec.Args,
+				Env:     env,
+				Cwd:     spec.Cwd,
+			}
+		}
+	}
+
+	codexConfig, prepErr := codexProvider.PrepareContainer(ctx, provider.PrepareOpts{
+		Credential:      codexCred,
+		ContainerHome:   containerHome,
+		RuntimeContext:  renderedContext,
+		LocalMCPServers: codexLocalMCP,
+	})
+	if prepErr != nil {
+		return nil, fmt.Errorf("preparing Codex container config: %w", prepErr)
+	}
+	return codexConfig, nil
+}

--- a/internal/run/manager_agentinit_test.go
+++ b/internal/run/manager_agentinit_test.go
@@ -1,0 +1,32 @@
+package run
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/majorcontext/moat/internal/config"
+)
+
+func TestSetupCodexStaging_UnknownGrant(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{}
+	cfg.Codex.MCP = map[string]config.MCPServerSpec{"srv": {Grant: "bogus"}}
+	// The provider is nil here: grant validation errors return before
+	// PrepareContainer is ever called.
+	_, err := m.setupCodexStaging(context.Background(), nil, Options{Config: cfg}, false, "", "", nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown grant") {
+		t.Fatalf("expected unknown-grant error, got %v", err)
+	}
+}
+
+func TestSetupCodexStaging_GrantNotDeclared(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{}
+	// "github" is a known grant but is not in the top-level grants list.
+	cfg.Codex.MCP = map[string]config.MCPServerSpec{"srv": {Grant: "github"}}
+	_, err := m.setupCodexStaging(context.Background(), nil, Options{Config: cfg}, false, "", "", nil)
+	if err == nil || !strings.Contains(err.Error(), "not declared") {
+		t.Fatalf("expected grant-not-declared error, got %v", err)
+	}
+}

--- a/internal/run/manager_create.go
+++ b/internal/run/manager_create.go
@@ -1483,73 +1483,14 @@ region = %s
 			return nil, fmt.Errorf("codex provider not registered")
 		}
 
-		// Get Codex credential for PrepareContainer
-		var codexCred *provider.Credential
-		if needsCodexInit {
-			if store, storeErr := openCredStore(); storeErr == nil {
-				if cred, err := store.Get(credential.ProviderOpenAI); err == nil {
-					codexCred = provider.FromLegacy(cred)
-				}
-			}
-		}
-
-		// Build local MCP server config from codex.mcp entries
-		var codexLocalMCP map[string]provider.LocalMCPServerConfig
-		if opts.Config != nil && len(opts.Config.Codex.MCP) > 0 {
-			codexLocalMCP = make(map[string]provider.LocalMCPServerConfig)
-			for name, spec := range opts.Config.Codex.MCP {
-				env := spec.Env
-				if spec.Grant != "" {
-					v, ok := grantToEnvVar(spec.Grant)
-					if !ok {
-						cleanupDaemonRun()
-						cleanupSSH(sshServer)
-						cleanupAgentConfig(claudeConfig)
-						return nil, fmt.Errorf("codex.mcp.%s: unknown grant %q (supported: github, openai, anthropic, gemini)", name, spec.Grant)
-					}
-					if !hasGrant(opts.Config.Grants, spec.Grant) {
-						cleanupDaemonRun()
-						cleanupSSH(sshServer)
-						cleanupAgentConfig(claudeConfig)
-						return nil, fmt.Errorf("codex.mcp.%s: grant %q not declared in top-level grants list — add 'grants: [%s]' to agent.yaml", name, spec.Grant, spec.Grant)
-					}
-					if env == nil {
-						env = make(map[string]string)
-					} else {
-						// Copy to avoid mutating the original config
-						envCopy := make(map[string]string, len(env)+1)
-						for k, v := range env {
-							envCopy[k] = v
-						}
-						env = envCopy
-					}
-					env[v] = grantToPlaceholder(spec.Grant)
-				}
-				codexLocalMCP[name] = provider.LocalMCPServerConfig{
-					Command: spec.Command,
-					Args:    spec.Args,
-					Env:     env,
-					Cwd:     spec.Cwd,
-				}
-			}
-		}
-
-		// Call provider to prepare container config
-		var prepErr error
-		codexConfig, prepErr = codexProvider.PrepareContainer(ctx, provider.PrepareOpts{
-			Credential:      codexCred,
-			ContainerHome:   containerHome,
-			RuntimeContext:  renderedContext,
-			LocalMCPServers: codexLocalMCP,
-		})
-		if prepErr != nil {
+		cfg, stageErr := m.setupCodexStaging(ctx, codexProvider, opts, needsCodexInit, containerHome, renderedContext, openCredStore)
+		if stageErr != nil {
 			cleanupDaemonRun()
 			cleanupSSH(sshServer)
 			cleanupAgentConfig(claudeConfig)
-			return nil, fmt.Errorf("preparing Codex container config: %w", prepErr)
+			return nil, stageErr
 		}
-
-		// Add mounts and env vars from provider
+		codexConfig = cfg
 		mounts = append(mounts, codexConfig.Mounts...)
 		proxyEnv = append(proxyEnv, codexConfig.Env...)
 	}


### PR DESCRIPTION
## What

Phase extraction from `Create` (follows #421–#426). The Codex staging body — OpenAI credential lookup, local-MCP config build with grant validation, and the `PrepareContainer` call — moves into `setupCodexStaging` in the new **`manager_agentinit.go`** (which will also host the Gemini and Claude staging helpers).

`Create`: **~2,251 → ~2,192 lines.**

## Behavior-preserving (note the cleanup asymmetry)

The error-path rollback sets in this block were *inconsistent*, which shaped the extraction:

| Error path | Original rollback | Now |
|---|---|---|
| `provider.GetAgent("codex") == nil` | `cleanupDaemonRun` + `cleanupAgentConfig(claudeConfig)` — **no `cleanupSSH`** | **kept inline** in `Create` (exact set preserved) |
| unknown grant / undeclared grant / `PrepareContainer` failure | `cleanupDaemonRun` + `cleanupSSH` + `cleanupAgentConfig(claudeConfig)` | moved into the method; the single caller error handler reproduces this exact set |

So the provider-nil path keeps its (ssh-less) rollback inline, and the three moved error paths all shared one rollback set — reproduced verbatim by the caller. No cleanup normalization. Verified line-by-line against `main`.

`codexConfig` stays a `Create`-scoped var (used at ~40 later `cleanupAgentConfig` sites + `r.CodexConfigTempDir`), assigned from the method's return.

## Tests

`manager_agentinit_test.go` covers the two grant-validation errors (unknown grant, grant not declared) — they return before `PrepareContainer`, so they need no provider. The `PrepareContainer` success path is provider-delegated and stays e2e-covered.

## Verification

`go build ./...` ✓ · `go vet` ✓ · `golangci-lint run` → **0 issues** ✓ · `go test -race -count=1 ./internal/run/` ✓. Manual smoke test passed locally. (Unrelated pre-existing Mac e2e failures — Apple-runtime/TTY tests masked by `.envrc`'s `MOAT_RUNTIME=docker` — are not touched by this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)