### PR TITLE
refactor(run): extract Gemini container staging from Create

### DIFF
--- a/internal/run/manager_agentinit.go
+++ b/internal/run/manager_agentinit.go
@@ -10,9 +10,51 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/credential"
 	"github.com/majorcontext/moat/internal/provider"
 )
+
+// buildLocalMCPConfig converts an agent's local MCP server specs into the
+// provider's LocalMCPServerConfig map, resolving each spec's optional grant
+// into an injected env placeholder. agentName prefixes validation errors
+// (e.g. "codex", "gemini"). Returns nil when there are no specs.
+func buildLocalMCPConfig(agentName string, specs map[string]config.MCPServerSpec, grants []string) (map[string]provider.LocalMCPServerConfig, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]provider.LocalMCPServerConfig)
+	for name, spec := range specs {
+		env := spec.Env
+		if spec.Grant != "" {
+			v, ok := grantToEnvVar(spec.Grant)
+			if !ok {
+				return nil, fmt.Errorf("%s.mcp.%s: unknown grant %q (supported: github, openai, anthropic, gemini)", agentName, name, spec.Grant)
+			}
+			if !hasGrant(grants, spec.Grant) {
+				return nil, fmt.Errorf("%s.mcp.%s: grant %q not declared in top-level grants list — add 'grants: [%s]' to agent.yaml", agentName, name, spec.Grant, spec.Grant)
+			}
+			if env == nil {
+				env = make(map[string]string)
+			} else {
+				// Copy to avoid mutating the original config
+				envCopy := make(map[string]string, len(env)+1)
+				for k, v := range env {
+					envCopy[k] = v
+				}
+				env = envCopy
+			}
+			env[v] = grantToPlaceholder(spec.Grant)
+		}
+		out[name] = provider.LocalMCPServerConfig{
+			Command: spec.Command,
+			Args:    spec.Args,
+			Env:     env,
+			Cwd:     spec.Cwd,
+		}
+	}
+	return out, nil
+}
 
 // setupCodexStaging builds the Codex container config (OpenAI auth + local MCP
 // servers) via the provider interface. openCredStore must be non-nil when
@@ -28,38 +70,13 @@ func (m *Manager) setupCodexStaging(ctx context.Context, codexProvider provider.
 		}
 	}
 
-	// Build local MCP server config from codex.mcp entries
+	// Build local MCP server config from codex.mcp entries.
 	var codexLocalMCP map[string]provider.LocalMCPServerConfig
-	if opts.Config != nil && len(opts.Config.Codex.MCP) > 0 {
-		codexLocalMCP = make(map[string]provider.LocalMCPServerConfig)
-		for name, spec := range opts.Config.Codex.MCP {
-			env := spec.Env
-			if spec.Grant != "" {
-				v, ok := grantToEnvVar(spec.Grant)
-				if !ok {
-					return nil, fmt.Errorf("codex.mcp.%s: unknown grant %q (supported: github, openai, anthropic, gemini)", name, spec.Grant)
-				}
-				if !hasGrant(opts.Config.Grants, spec.Grant) {
-					return nil, fmt.Errorf("codex.mcp.%s: grant %q not declared in top-level grants list — add 'grants: [%s]' to agent.yaml", name, spec.Grant, spec.Grant)
-				}
-				if env == nil {
-					env = make(map[string]string)
-				} else {
-					// Copy to avoid mutating the original config
-					envCopy := make(map[string]string, len(env)+1)
-					for k, v := range env {
-						envCopy[k] = v
-					}
-					env = envCopy
-				}
-				env[v] = grantToPlaceholder(spec.Grant)
-			}
-			codexLocalMCP[name] = provider.LocalMCPServerConfig{
-				Command: spec.Command,
-				Args:    spec.Args,
-				Env:     env,
-				Cwd:     spec.Cwd,
-			}
+	if opts.Config != nil {
+		var err error
+		codexLocalMCP, err = buildLocalMCPConfig("codex", opts.Config.Codex.MCP, opts.Config.Grants)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -73,4 +90,39 @@ func (m *Manager) setupCodexStaging(ctx context.Context, codexProvider provider.
 		return nil, fmt.Errorf("preparing Codex container config: %w", prepErr)
 	}
 	return codexConfig, nil
+}
+
+// setupGeminiStaging builds the Gemini container config (Gemini auth + local MCP
+// servers) via the provider interface.
+func (m *Manager) setupGeminiStaging(ctx context.Context, geminiProvider provider.AgentProvider, opts Options, needsGeminiInit bool, containerHome, renderedContext string, openCredStore func() (*credential.FileStore, error)) (*provider.ContainerConfig, error) {
+	// Get Gemini credential for PrepareContainer
+	var geminiCred *provider.Credential
+	if needsGeminiInit {
+		if store, storeErr := openCredStore(); storeErr == nil {
+			if cred, err := store.Get(credential.ProviderGemini); err == nil {
+				geminiCred = provider.FromLegacy(cred)
+			}
+		}
+	}
+
+	// Build local MCP server config from gemini.mcp entries.
+	var geminiLocalMCP map[string]provider.LocalMCPServerConfig
+	if opts.Config != nil {
+		var err error
+		geminiLocalMCP, err = buildLocalMCPConfig("gemini", opts.Config.Gemini.MCP, opts.Config.Grants)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	geminiConfig, prepErr := geminiProvider.PrepareContainer(ctx, provider.PrepareOpts{
+		Credential:      geminiCred,
+		ContainerHome:   containerHome,
+		RuntimeContext:  renderedContext,
+		LocalMCPServers: geminiLocalMCP,
+	})
+	if prepErr != nil {
+		return nil, fmt.Errorf("preparing Gemini container config: %w", prepErr)
+	}
+	return geminiConfig, nil
 }

--- a/internal/run/manager_agentinit_test.go
+++ b/internal/run/manager_agentinit_test.go
@@ -30,3 +30,62 @@ func TestSetupCodexStaging_GrantNotDeclared(t *testing.T) {
 		t.Fatalf("expected grant-not-declared error, got %v", err)
 	}
 }
+
+func TestBuildLocalMCPConfig_NoSpecs(t *testing.T) {
+	out, err := buildLocalMCPConfig("codex", nil, nil)
+	if err != nil || out != nil {
+		t.Fatalf("expected (nil, nil) for no specs, got (%v, %v)", out, err)
+	}
+}
+
+func TestBuildLocalMCPConfig_NoGrant(t *testing.T) {
+	specs := map[string]config.MCPServerSpec{"srv": {Command: "run", Args: []string{"-x"}, Cwd: "/w"}}
+	out, err := buildLocalMCPConfig("codex", specs, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, ok := out["srv"]
+	if !ok || got.Command != "run" || len(got.Args) != 1 || got.Cwd != "/w" {
+		t.Fatalf("spec not converted faithfully: %+v", out)
+	}
+	if got.Env != nil {
+		t.Fatalf("no grant means no env injection, got %v", got.Env)
+	}
+}
+
+func TestBuildLocalMCPConfig_GrantInjectsEnvWithoutMutatingSpec(t *testing.T) {
+	orig := map[string]string{"EXISTING": "1"}
+	specs := map[string]config.MCPServerSpec{"srv": {Grant: "github", Env: orig}}
+	out, err := buildLocalMCPConfig("codex", specs, []string{"github"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	env := out["srv"].Env
+	if env["EXISTING"] != "1" || len(env) != 2 {
+		t.Fatalf("expected the existing env plus one injected placeholder, got %v", env)
+	}
+	if len(orig) != 1 {
+		t.Fatalf("the original spec env must not be mutated, got %v", orig)
+	}
+}
+
+func TestSetupGeminiStaging_UnknownGrant(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{}
+	cfg.Gemini.MCP = map[string]config.MCPServerSpec{"srv": {Grant: "bogus"}}
+	_, err := m.setupGeminiStaging(context.Background(), nil, Options{Config: cfg}, false, "", "", nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown grant") {
+		t.Fatalf("expected unknown-grant error, got %v", err)
+	}
+}
+
+func TestSetupGeminiStaging_GrantNotDeclared(t *testing.T) {
+	m := &Manager{}
+	cfg := &config.Config{}
+	// "github" is a known grant but is not in the top-level grants list.
+	cfg.Gemini.MCP = map[string]config.MCPServerSpec{"srv": {Grant: "github"}}
+	_, err := m.setupGeminiStaging(context.Background(), nil, Options{Config: cfg}, false, "", "", nil)
+	if err == nil || !strings.Contains(err.Error(), "not declared") {
+		t.Fatalf("expected grant-not-declared error, got %v", err)
+	}
+}

--- a/internal/run/manager_create.go
+++ b/internal/run/manager_create.go
@@ -1508,75 +1508,15 @@ region = %s
 			return nil, fmt.Errorf("gemini provider not registered")
 		}
 
-		// Get Gemini credential for PrepareContainer
-		var geminiCred *provider.Credential
-		if needsGeminiInit {
-			if store, storeErr := openCredStore(); storeErr == nil {
-				if cred, err := store.Get(credential.ProviderGemini); err == nil {
-					geminiCred = provider.FromLegacy(cred)
-				}
-			}
-		}
-
-		// Build local MCP server config from gemini.mcp entries
-		var geminiLocalMCP map[string]provider.LocalMCPServerConfig
-		if opts.Config != nil && len(opts.Config.Gemini.MCP) > 0 {
-			geminiLocalMCP = make(map[string]provider.LocalMCPServerConfig)
-			for name, spec := range opts.Config.Gemini.MCP {
-				env := spec.Env
-				if spec.Grant != "" {
-					v, ok := grantToEnvVar(spec.Grant)
-					if !ok {
-						cleanupDaemonRun()
-						cleanupSSH(sshServer)
-						cleanupAgentConfig(claudeConfig)
-						cleanupAgentConfig(codexConfig)
-						return nil, fmt.Errorf("gemini.mcp.%s: unknown grant %q (supported: github, openai, anthropic, gemini)", name, spec.Grant)
-					}
-					if !hasGrant(opts.Config.Grants, spec.Grant) {
-						cleanupDaemonRun()
-						cleanupSSH(sshServer)
-						cleanupAgentConfig(claudeConfig)
-						cleanupAgentConfig(codexConfig)
-						return nil, fmt.Errorf("gemini.mcp.%s: grant %q not declared in top-level grants list — add 'grants: [%s]' to agent.yaml", name, spec.Grant, spec.Grant)
-					}
-					if env == nil {
-						env = make(map[string]string)
-					} else {
-						envCopy := make(map[string]string, len(env)+1)
-						for k, v := range env {
-							envCopy[k] = v
-						}
-						env = envCopy
-					}
-					env[v] = grantToPlaceholder(spec.Grant)
-				}
-				geminiLocalMCP[name] = provider.LocalMCPServerConfig{
-					Command: spec.Command,
-					Args:    spec.Args,
-					Env:     env,
-					Cwd:     spec.Cwd,
-				}
-			}
-		}
-
-		// Call provider to prepare container config
-		var prepErr error
-		geminiConfig, prepErr = geminiProvider.PrepareContainer(ctx, provider.PrepareOpts{
-			Credential:      geminiCred,
-			ContainerHome:   containerHome,
-			RuntimeContext:  renderedContext,
-			LocalMCPServers: geminiLocalMCP,
-		})
-		if prepErr != nil {
+		cfg, stageErr := m.setupGeminiStaging(ctx, geminiProvider, opts, needsGeminiInit, containerHome, renderedContext, openCredStore)
+		if stageErr != nil {
 			cleanupDaemonRun()
 			cleanupSSH(sshServer)
 			cleanupAgentConfig(claudeConfig)
 			cleanupAgentConfig(codexConfig)
-			return nil, fmt.Errorf("preparing Gemini container config: %w", prepErr)
+			return nil, stageErr
 		}
-
-		// Add mounts and env vars from provider
+		geminiConfig = cfg
 		mounts = append(mounts, geminiConfig.Mounts...)
 		proxyEnv = append(proxyEnv, geminiConfig.Env...)
 	}


### PR DESCRIPTION
## What

Extracts the Gemini staging body from `Create` into `setupGeminiStaging` in `manager_agentinit.go`, mirroring `setupCodexStaging` (#427). `Create`: **~2,192 → ~2,132 lines.**

**Stacked on #427** (Codex) — both add to `manager_agentinit.go` and edit `manager_create.go`, so stacking avoids conflicts. GitHub will retarget this to `main` once #427 merges (I'll rebase to drop the Codex commit from the diff).

## Behavior-preserving

Same approach as #427: the `provider.GetAgent("gemini") == nil` check stays inline (its rollback omits `cleanupSSH`); the three extracted error paths all shared one rollback set — `cleanupDaemonRun` + `cleanupSSH` + `cleanupAgentConfig(claudeConfig)` + `cleanupAgentConfig(codexConfig)` — reproduced exactly by the single caller handler. Verified line-by-line against `main`.

## Tests

The two grant-validation errors (unknown grant, grant not declared), which return before `PrepareContainer`.

## Verification

`go build ./...` ✓ · `go vet` ✓ · `golangci-lint run` → **0 issues** ✓ · `go test -race -count=1 ./internal/run/` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)