### PR TITLE
refactor(run): extract Claude container staging from Create

### DIFF
--- a/internal/run/manager_agentinit.go
+++ b/internal/run/manager_agentinit.go
@@ -133,6 +133,32 @@ func (m *Manager) setupGeminiStaging(ctx context.Context, geminiProvider provide
 	return geminiConfig, nil
 }
 
+// buildClaudeMCPRelayServers builds the .claude.json MCP server map, pointing
+// each entry at a proxy-relay URL instead of its direct URL.
+//
+// Proxy relay URLs work around Claude Code's MCP client not respecting
+// HTTP_PROXY, and bridge host-local MCP servers (localhost/127.0.0.1) the
+// container cannot reach directly. The relay host is the synthetic proxy host
+// (in NO_PROXY) so the client connects directly and the proxy strips the
+// per-run token via handleDirectMCPRelay; GetHostAddress is not in NO_PROXY, so
+// it would route through the CONNECT tunnel to the wrong handler -> 404.
+func buildClaudeMCPRelayServers(mcps []config.MCPServerConfig, proxyPort int, authToken string) map[string]provider.MCPServerConfig {
+	servers := make(map[string]provider.MCPServerConfig)
+	proxyAddr := fmt.Sprintf("%s:%d", syntheticProxyHost, proxyPort)
+	for _, mcp := range mcps {
+		mcpCfg := provider.MCPServerConfig{
+			URL: fmt.Sprintf("http://%s/mcp/%s/%s", proxyAddr, authToken, mcp.Name),
+		}
+		if mcp.Auth != nil {
+			mcpCfg.Headers = map[string]string{
+				mcp.Auth.Header: "moat-stub-" + mcp.Auth.Grant,
+			}
+		}
+		servers[mcp.Name] = mcpCfg
+	}
+	return servers
+}
+
 // setupClaudeStaging builds the Claude container config via the provider
 // interface: it assembles the proxy-relay MCP server config, resolves the
 // Claude (or, for back-compat, Anthropic) credential, prepares the container,
@@ -141,31 +167,12 @@ func (m *Manager) setupGeminiStaging(ctx context.Context, geminiProvider provide
 // grants, so its local-MCP build is a plain conversion. openCredStore must be
 // non-nil when needsClaudeInit is true; claudeSettings may be nil.
 func (m *Manager) setupClaudeStaging(ctx context.Context, claudeProvider provider.AgentProvider, opts Options, r *Run, needsClaudeInit, hasPlugins, hasClaudeCode bool, claudeSettings *claude.Settings, containerHome, renderedContext string, openCredStore func() (*credential.FileStore, error)) (*provider.ContainerConfig, error) {
-	// Build MCP server configuration for .claude.json
-	// Use proxy relay URLs instead of direct MCP server URLs to work around
-	// Claude Code's MCP client not respecting HTTP_PROXY environment variables.
-	// This also bridges host-local MCP servers (localhost/127.0.0.1) which
-	// the container cannot reach directly.
-	mcpServers := make(map[string]provider.MCPServerConfig)
-	if opts.Config != nil && len(opts.Config.MCP) > 0 {
-		// Use the synthetic proxy host (in NO_PROXY) so the MCP client
-		// connects directly and the proxy strips the per-run token via
-		// handleDirectMCPRelay. GetHostAddress is not in NO_PROXY, so it would
-		// route through the CONNECT tunnel to the wrong handler → 404.
-		proxyAddr := fmt.Sprintf("%s:%d", syntheticProxyHost, r.ProxyPort)
-		for _, mcp := range opts.Config.MCP {
-			relayURL := fmt.Sprintf("http://%s/mcp/%s/%s", proxyAddr, r.ProxyAuthToken, mcp.Name)
-			mcpCfg := provider.MCPServerConfig{
-				URL: relayURL,
-			}
-			if mcp.Auth != nil {
-				mcpCfg.Headers = map[string]string{
-					mcp.Auth.Header: "moat-stub-" + mcp.Auth.Grant,
-				}
-			}
-			mcpServers[mcp.Name] = mcpCfg
-		}
+	// Build the proxy-relay MCP server config for .claude.json.
+	var claudeMCPs []config.MCPServerConfig
+	if opts.Config != nil {
+		claudeMCPs = opts.Config.MCP
 	}
+	mcpServers := buildClaudeMCPRelayServers(claudeMCPs, r.ProxyPort, r.ProxyAuthToken)
 
 	// Get Claude credential for PrepareContainer
 	// Preference: claude > anthropic (for backward compatibility)

--- a/internal/run/manager_agentinit.go
+++ b/internal/run/manager_agentinit.go
@@ -8,11 +8,17 @@ package run
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/majorcontext/moat/internal/config"
 	"github.com/majorcontext/moat/internal/credential"
+	"github.com/majorcontext/moat/internal/log"
 	"github.com/majorcontext/moat/internal/provider"
+	"github.com/majorcontext/moat/internal/providers/claude"
+	"github.com/majorcontext/moat/internal/ui"
 )
 
 // buildLocalMCPConfig converts an agent's local MCP server specs into the
@@ -125,4 +131,121 @@ func (m *Manager) setupGeminiStaging(ctx context.Context, geminiProvider provide
 		return nil, fmt.Errorf("preparing Gemini container config: %w", prepErr)
 	}
 	return geminiConfig, nil
+}
+
+// setupClaudeStaging builds the Claude container config via the provider
+// interface: it assembles the proxy-relay MCP server config, resolves the
+// Claude (or, for back-compat, Anthropic) credential, prepares the container,
+// and writes settings.json into the staging dir (pinning the renderer and, for
+// bypass runs, persisting bypass-permissions mode). claude.mcp does not support
+// grants, so its local-MCP build is a plain conversion. openCredStore must be
+// non-nil when needsClaudeInit is true; claudeSettings may be nil.
+func (m *Manager) setupClaudeStaging(ctx context.Context, claudeProvider provider.AgentProvider, opts Options, r *Run, needsClaudeInit, hasPlugins, hasClaudeCode bool, claudeSettings *claude.Settings, containerHome, renderedContext string, openCredStore func() (*credential.FileStore, error)) (*provider.ContainerConfig, error) {
+	// Build MCP server configuration for .claude.json
+	// Use proxy relay URLs instead of direct MCP server URLs to work around
+	// Claude Code's MCP client not respecting HTTP_PROXY environment variables.
+	// This also bridges host-local MCP servers (localhost/127.0.0.1) which
+	// the container cannot reach directly.
+	mcpServers := make(map[string]provider.MCPServerConfig)
+	if opts.Config != nil && len(opts.Config.MCP) > 0 {
+		// Use the synthetic proxy host (in NO_PROXY) so the MCP client
+		// connects directly and the proxy strips the per-run token via
+		// handleDirectMCPRelay. GetHostAddress is not in NO_PROXY, so it would
+		// route through the CONNECT tunnel to the wrong handler → 404.
+		proxyAddr := fmt.Sprintf("%s:%d", syntheticProxyHost, r.ProxyPort)
+		for _, mcp := range opts.Config.MCP {
+			relayURL := fmt.Sprintf("http://%s/mcp/%s/%s", proxyAddr, r.ProxyAuthToken, mcp.Name)
+			mcpCfg := provider.MCPServerConfig{
+				URL: relayURL,
+			}
+			if mcp.Auth != nil {
+				mcpCfg.Headers = map[string]string{
+					mcp.Auth.Header: "moat-stub-" + mcp.Auth.Grant,
+				}
+			}
+			mcpServers[mcp.Name] = mcpCfg
+		}
+	}
+
+	// Get Claude credential for PrepareContainer
+	// Preference: claude > anthropic (for backward compatibility)
+	var claudeCred *provider.Credential
+	if needsClaudeInit {
+		if store, storeErr := openCredStore(); storeErr == nil {
+			// Try claude first, fall back to anthropic
+			cred, err := store.Get(credential.ProviderClaude)
+			if err != nil {
+				cred, err = store.Get(credential.ProviderAnthropic)
+			}
+			if err == nil {
+				claudeCred = provider.FromLegacy(cred)
+			}
+		}
+	}
+
+	// Build local MCP server config from claude.mcp entries (claude.mcp does
+	// not support grants, so there is no grant->env resolution here).
+	var claudeLocalMCP map[string]provider.LocalMCPServerConfig
+	if opts.Config != nil && len(opts.Config.Claude.MCP) > 0 {
+		claudeLocalMCP = make(map[string]provider.LocalMCPServerConfig)
+		for name, spec := range opts.Config.Claude.MCP {
+			claudeLocalMCP[name] = provider.LocalMCPServerConfig{
+				Command: spec.Command,
+				Args:    spec.Args,
+				Env:     spec.Env,
+				Cwd:     spec.Cwd,
+			}
+		}
+	}
+
+	// Call provider to prepare container config
+	var claudeSubType, claudeRateTier string
+	if opts.Config != nil {
+		claudeSubType = opts.Config.Claude.SubscriptionType
+		claudeRateTier = opts.Config.Claude.RateLimitTier
+	}
+	claudeConfig, prepErr := claudeProvider.PrepareContainer(ctx, provider.PrepareOpts{
+		Credential:       claudeCred,
+		ContainerHome:    containerHome,
+		MCPServers:       mcpServers,
+		RuntimeContext:   renderedContext,
+		LocalMCPServers:  claudeLocalMCP,
+		SubscriptionType: claudeSubType,
+		RateLimitTier:    claudeRateTier,
+		// HostConfig is read automatically by the provider if nil
+	})
+	if prepErr != nil {
+		return nil, fmt.Errorf("preparing Claude container config: %w", prepErr)
+	}
+
+	// Write settings.json to suppress startup prompts, pin the renderer,
+	// persist bypass-permissions mode, and configure plugins.
+	// moat-init.sh copies $MOAT_CLAUDE_INIT/settings.json to ~/.claude/settings.json.
+	skipPrompt := opts.Config != nil && opts.Config.Claude.SkipPermissionsPrompt
+	if hasPlugins || skipPrompt || hasClaudeCode {
+		if claudeSettings == nil {
+			claudeSettings = &claude.Settings{}
+		}
+		// Pin the renderer and (for bypass runs) persist bypass mode so
+		// Claude Code's fullscreen-renderer re-exec can't silently drop the
+		// --dangerously-skip-permissions flag. See Settings.ApplyRunPolicy.
+		if policyErr := claudeSettings.ApplyRunPolicy(hasClaudeCode, skipPrompt); policyErr != nil {
+			ui.Warnf("Failed to persist bypass-permissions mode in settings.json (check the 'permissions' value in ~/.moat/claude/settings.json): %v", policyErr)
+		}
+		settingsPath := filepath.Join(claudeConfig.StagingDir, "settings.json")
+		settingsJSON, jsonErr := json.MarshalIndent(claudeSettings, "", "  ")
+		if jsonErr != nil {
+			// MarshalIndent cannot fail for Settings (no channels, funcs, or cycles);
+			// log.Warn for defense-in-depth only.
+			log.Warn("failed to marshal settings.json", "error", jsonErr)
+		} else if writeErr := os.WriteFile(settingsPath, settingsJSON, 0o644); writeErr != nil {
+			ui.Warnf("Failed to write Claude settings to container: %v", writeErr)
+		} else {
+			log.Debug("wrote settings.json to staging dir",
+				"plugins", len(claudeSettings.EnabledPlugins),
+				"marketplaces", len(claudeSettings.ExtraKnownMarketplaces))
+		}
+	}
+
+	return claudeConfig, nil
 }

--- a/internal/run/manager_agentinit_test.go
+++ b/internal/run/manager_agentinit_test.go
@@ -69,6 +69,37 @@ func TestBuildLocalMCPConfig_GrantInjectsEnvWithoutMutatingSpec(t *testing.T) {
 	}
 }
 
+func TestBuildClaudeMCPRelayServers_Empty(t *testing.T) {
+	if got := buildClaudeMCPRelayServers(nil, 8080, "tok"); len(got) != 0 {
+		t.Fatalf("expected empty map for no MCP servers, got %v", got)
+	}
+}
+
+func TestBuildClaudeMCPRelayServers_RelayURLNoAuth(t *testing.T) {
+	mcps := []config.MCPServerConfig{{Name: "srv"}}
+	got := buildClaudeMCPRelayServers(mcps, 8080, "tok123")
+	cfg, ok := got["srv"]
+	if !ok {
+		t.Fatalf("missing server entry: %v", got)
+	}
+	// The relay must target the synthetic proxy host + per-run token, in this
+	// exact shape (a past 404 bug came from using the wrong host here).
+	if want := "http://moat-proxy:8080/mcp/tok123/srv"; cfg.URL != want {
+		t.Fatalf("relay URL = %q, want %q", cfg.URL, want)
+	}
+	if cfg.Headers != nil {
+		t.Fatalf("expected no headers without auth, got %v", cfg.Headers)
+	}
+}
+
+func TestBuildClaudeMCPRelayServers_AuthHeaderStub(t *testing.T) {
+	mcps := []config.MCPServerConfig{{Name: "srv", Auth: &config.MCPAuthConfig{Header: "X-Api-Key", Grant: "notion"}}}
+	got := buildClaudeMCPRelayServers(mcps, 9000, "tok")
+	if h := got["srv"].Headers["X-Api-Key"]; h != "moat-stub-notion" {
+		t.Fatalf("auth header = %q, want %q", h, "moat-stub-notion")
+	}
+}
+
 func TestSetupGeminiStaging_UnknownGrant(t *testing.T) {
 	m := &Manager{}
 	cfg := &config.Config{}

--- a/internal/run/manager_create.go
+++ b/internal/run/manager_create.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -1357,117 +1356,15 @@ region = %s
 				return nil, fmt.Errorf("claude provider not registered")
 			}
 
-			// Build MCP server configuration for .claude.json
-			// Use proxy relay URLs instead of direct MCP server URLs to work around
-			// Claude Code's MCP client not respecting HTTP_PROXY environment variables.
-			// This also bridges host-local MCP servers (localhost/127.0.0.1) which
-			// the container cannot reach directly.
-			mcpServers := make(map[string]provider.MCPServerConfig)
-			if opts.Config != nil && len(opts.Config.MCP) > 0 {
-				// Use the synthetic proxy host (in NO_PROXY) so the MCP client
-				// connects directly and the proxy strips the per-run token via
-				// handleDirectMCPRelay. GetHostAddress is not in NO_PROXY, so it would
-				// route through the CONNECT tunnel to the wrong handler → 404.
-				proxyAddr := fmt.Sprintf("%s:%d", syntheticProxyHost, r.ProxyPort)
-				for _, mcp := range opts.Config.MCP {
-					relayURL := fmt.Sprintf("http://%s/mcp/%s/%s", proxyAddr, r.ProxyAuthToken, mcp.Name)
-					mcpCfg := provider.MCPServerConfig{
-						URL: relayURL,
-					}
-					if mcp.Auth != nil {
-						mcpCfg.Headers = map[string]string{
-							mcp.Auth.Header: "moat-stub-" + mcp.Auth.Grant,
-						}
-					}
-					mcpServers[mcp.Name] = mcpCfg
-				}
-			}
-
-			// Get Claude credential for PrepareContainer
-			// Preference: claude > anthropic (for backward compatibility)
-			var claudeCred *provider.Credential
-			if needsClaudeInit {
-				if store, storeErr := openCredStore(); storeErr == nil {
-					// Try claude first, fall back to anthropic
-					cred, err := store.Get(credential.ProviderClaude)
-					if err != nil {
-						cred, err = store.Get(credential.ProviderAnthropic)
-					}
-					if err == nil {
-						claudeCred = provider.FromLegacy(cred)
-					}
-				}
-			}
-
-			// Build local MCP server config from claude.mcp entries
-			var claudeLocalMCP map[string]provider.LocalMCPServerConfig
-			if opts.Config != nil && len(opts.Config.Claude.MCP) > 0 {
-				claudeLocalMCP = make(map[string]provider.LocalMCPServerConfig)
-				for name, spec := range opts.Config.Claude.MCP {
-					claudeLocalMCP[name] = provider.LocalMCPServerConfig{
-						Command: spec.Command,
-						Args:    spec.Args,
-						Env:     spec.Env,
-						Cwd:     spec.Cwd,
-					}
-				}
-			}
-
-			// Call provider to prepare container config
-			var prepErr error
-			var claudeSubType, claudeRateTier string
-			if opts.Config != nil {
-				claudeSubType = opts.Config.Claude.SubscriptionType
-				claudeRateTier = opts.Config.Claude.RateLimitTier
-			}
-			claudeConfig, prepErr = claudeProvider.PrepareContainer(ctx, provider.PrepareOpts{
-				Credential:       claudeCred,
-				ContainerHome:    containerHome,
-				MCPServers:       mcpServers,
-				RuntimeContext:   renderedContext,
-				LocalMCPServers:  claudeLocalMCP,
-				SubscriptionType: claudeSubType,
-				RateLimitTier:    claudeRateTier,
-				// HostConfig is read automatically by the provider if nil
-			})
-			if prepErr != nil {
+			cfg, stageErr := m.setupClaudeStaging(ctx, claudeProvider, opts, r, needsClaudeInit, hasPlugins, hasClaudeCode, claudeSettings, containerHome, renderedContext, openCredStore)
+			if stageErr != nil {
 				cleanupDaemonRun()
 				cleanupSSH(sshServer)
-				return nil, fmt.Errorf("preparing Claude container config: %w", prepErr)
+				return nil, stageErr
 			}
-
-			// Add mounts and env vars from provider
+			claudeConfig = cfg
 			mounts = append(mounts, claudeConfig.Mounts...)
 			proxyEnv = append(proxyEnv, claudeConfig.Env...)
-
-			// Write settings.json to suppress startup prompts, pin the renderer,
-			// persist bypass-permissions mode, and configure plugins.
-			// moat-init.sh copies $MOAT_CLAUDE_INIT/settings.json to ~/.claude/settings.json.
-			skipPrompt := opts.Config != nil && opts.Config.Claude.SkipPermissionsPrompt
-			if hasPlugins || skipPrompt || hasClaudeCode {
-				if claudeSettings == nil {
-					claudeSettings = &claude.Settings{}
-				}
-				// Pin the renderer and (for bypass runs) persist bypass mode so
-				// Claude Code's fullscreen-renderer re-exec can't silently drop the
-				// --dangerously-skip-permissions flag. See Settings.ApplyRunPolicy.
-				if policyErr := claudeSettings.ApplyRunPolicy(hasClaudeCode, skipPrompt); policyErr != nil {
-					ui.Warnf("Failed to persist bypass-permissions mode in settings.json (check the 'permissions' value in ~/.moat/claude/settings.json): %v", policyErr)
-				}
-				settingsPath := filepath.Join(claudeConfig.StagingDir, "settings.json")
-				settingsJSON, jsonErr := json.MarshalIndent(claudeSettings, "", "  ")
-				if jsonErr != nil {
-					// MarshalIndent cannot fail for Settings (no channels, funcs, or cycles);
-					// log.Warn for defense-in-depth only.
-					log.Warn("failed to marshal settings.json", "error", jsonErr)
-				} else if writeErr := os.WriteFile(settingsPath, settingsJSON, 0o644); writeErr != nil {
-					ui.Warnf("Failed to write Claude settings to container: %v", writeErr)
-				} else {
-					log.Debug("wrote settings.json to staging dir",
-						"plugins", len(claudeSettings.EnabledPlugins),
-						"marketplaces", len(claudeSettings.ExtraKnownMarketplaces))
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
## What

Completes the agent-init staging extraction (follows Codex #427, Gemini #428). Moves the Claude staging body out of `Create` into `setupClaudeStaging` in `manager_agentinit.go`: proxy-relay MCP server config, the claude→anthropic credential lookup, local-MCP conversion, `PrepareContainer`, and the `settings.json` write (`ApplyRunPolicy` / renderer pinning / bypass-permissions persistence).

`Create`: **~2,132 → ~2,030 lines.**

## Behavior-preserving — verified

Same pattern as Codex/Gemini, with Claude's specifics:
- The `provider.GetAgent("claude") == nil` check **stays inline** in `Create` — its rollback is `cleanupDaemonRun()` only (no `cleanupSSH`; Claude is staged first, so no prior agent configs).
- The body's single returning error (`PrepareContainer` failure) carried `{cleanupDaemonRun, cleanupSSH}` → reproduced exactly by the one caller handler. `settings.json` errors are logged, not returned (unchanged).
- `claudeConfig` stays a `Create`-scoped var (assigned `claudeConfig = cfg`, **not** `:=`) feeding all 25 later `cleanupAgentConfig` sites + `r.ClaudeConfigTempDir`.
- `claude.mcp` has no grant support, so its local-MCP build is a plain conversion (deliberately not routed through `buildLocalMCPConfig`).
- `claudeSettings` isn't read after this block, so the method's local nil-init is safe.

Reviewed by an 8-persona pass (correctness/adversarial/security/standards/agent-native all zero findings) — verified line-for-line against `main`.

## Second commit (`fix(review)`)

Per that review, extracted the MCP proxy-relay URL building into a pure `buildClaudeMCPRelayServers` helper + unit tests (empty / relay-URL / auth-header-stub). This is a historically buggy spot (a past 404 came from using `GetHostAddress` instead of the synthetic proxy host); the pure helper locks the URL shape with no provider fake needed. Behavior-identical.

## Tests

No unit test for `setupClaudeStaging` itself — it's fully provider-delegated (`PrepareContainer`, needs a heavy `AgentProvider` fake) with no cheap grant-validation branches like Codex/Gemini, so it stays e2e-covered (consistent with #427). The new `buildClaudeMCPRelayServers` + existing `buildLocalMCPConfig` helpers carry the unit coverage.

## Verification

`go build ./...` ✓ · `go vet` ✓ · `golangci-lint run` → **0 issues** ✓ · `go test -race -count=1 ./internal/run/` ✓. Manual smoke test passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)