### PR TITLE
ci(review): let the review bot run go build/vet/test to verify findings

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Set up Go so the reviewer can actually run go build/vet/test/gofmt to
+      # verify findings, instead of falling back to static-only analysis.
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Collapse previous Claude reviews
         env:
           GH_TOKEN: ${{ github.token }}
@@ -39,6 +47,12 @@ jobs:
             Use the /code-review skill to review this pull request.
 
             Use the repository's CLAUDE.md for guidance on style, conventions, and architecture.
+
+            Go is set up in this job — you can and should run `go build ./...`,
+            `go vet ./...`, targeted `go test ./path/...`, and `gofmt -l` to
+            verify findings and confirm compilation/tests rather than reasoning
+            statically. Prefer targeted package tests over the full suite (CI
+            already runs `make test-unit`). Don't claim you couldn't run these.
 
             Review as a second pair of eyes — catch things the author or a coding agent
             would miss. Think about:
@@ -62,4 +76,4 @@ jobs:
             Use inline comments for specific code issues. Use a top-level PR comment for
             the overall summary.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(gofmt:*),Bash(make:*),Bash(golangci-lint:*)"


### PR DESCRIPTION
## Problem

Every `claude-review` pass closes with some variant of:

> I could not run `go build`/`go vet`/`go test`/`gofmt` in this sandbox — all non-trivial Bash commands required interactive approval unavailable in this run. Everything above is from static reading of the diff.

So the bot recommends "confirm `make lint`/`make test-unit` pass" but never runs them itself. Two causes in `.github/workflows/claude-code-review.yml`:

1. The action's `--allowedTools` only permitted `mcp__github_inline_comment__…` and three `gh pr …` commands. Any `go`/`make`/`gofmt` command fell outside the allowlist, prompted for approval, and was denied in headless CI.
2. The job had no Go toolchain set up at all.

## Fix

- Add an `actions/setup-go@v6` step (`go-version-file: go.mod`, cache) mirroring the CI `lint`/`test` jobs.
- Extend `--allowedTools` with `Bash(go build:*)`, `Bash(go vet:*)`, `Bash(go test:*)`, `Bash(gofmt:*)`, `Bash(make:*)`, `Bash(golangci-lint:*)`.
- Tell the reviewer in the prompt that Go is available and it should run targeted builds/tests to verify findings (preferring targeted package tests over the full suite, which CI already runs).

## Safety

The job is already gated to same-repo PRs (`if: github.event.pull_request.head.repo.full_name == github.repository`), so executing a PR branch's test code is the same trust boundary as the existing `Test` CI job — no new exposure to fork PRs.

Because `pull_request` runs the workflow from the PR's own head for same-repo PRs, this PR's own review run will exercise the new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)