### PR TITLE
docs(release): cut v0.7.0 changelog and sync doc indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Moat runs AI coding agents in isolated containers with credential injection, net
 
 Moat is pre-1.0. The CLI interface and `moat.yaml` schema may change between minor versions. Breaking changes are listed under **Breaking** headings below.
 
-## Unreleased
+## v0.7.0 — 2026-08-01
 
-Adds HTTP request-body inspection to Keep policies. File- and pack-based `network.keep_policy` rules can now match on the parsed JSON request body, so policies can enforce content-based rules (e.g. block requests whose body carries a secret) instead of host/method/path alone. Also adds native volume backing for `volumes:` (`type: volume`) — a Docker named volume on the engine's native filesystem, for container-only working directories that should bypass the host↔VM filesystem-sharing layer a bind mount crosses. The routing proxy now serves a discovery index at its bare hosts so you can browse an agent's endpoints instead of memorizing hostnames.
+Adds two agents: `moat pi` runs the Pi coding agent against your existing `anthropic` or `openai` grant, and `moat copilot` runs GitHub Copilot CLI on the `github` grant. Keep policies gain HTTP request-body inspection — file- and pack-based `network.keep_policy` rules can match on the parsed JSON request body, so policies can enforce content-based rules (e.g. block requests whose body carries a secret) instead of host/method/path alone. Workspaces and volumes can now be backed by Docker named volumes (`workspace.mode: volume`, `type: volume`) to bypass the host↔VM filesystem-sharing layer a bind mount crosses, and the routing proxy serves a discovery index at its bare hosts so you can browse an agent's endpoints with `moat open` instead of memorizing hostnames.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,21 @@ moat copilot           # Interactive mode
 moat copilot -p "fix the failing tests"  # Non-interactive
 ```
 
-Agents run in isolated containers with credentials injected at the network layer. See the [Running Claude Code](docs/content/guides/01-claude-code.md), [Running Codex](docs/content/guides/02-codex.md), and [Running GitHub Copilot CLI](docs/content/guides/17-copilot.md) guides for details.
+### Gemini
+
+```bash
+moat grant gemini      # One-time: imports your Gemini credentials
+moat gemini            # Interactive mode
+```
+
+### Pi
+
+```bash
+moat grant anthropic   # Or: moat grant openai — Pi runs on whichever you grant
+moat pi                # Interactive mode
+```
+
+Agents run in isolated containers with credentials injected at the network layer. See the [Running Claude Code](docs/content/guides/01-claude-code.md), [Running Codex](docs/content/guides/02-codex.md), [Running Gemini](docs/content/guides/03-gemini.md), [Running Pi](docs/content/guides/16-pi.md), and [Running GitHub Copilot CLI](docs/content/guides/17-copilot.md) guides for details.
 
 ## Configuration
 
@@ -146,9 +160,11 @@ See the [moat.yaml reference](docs/content/reference/02-moat-yaml.md) for all op
 | `moat claude [workspace]` | Run Claude Code |
 | `moat copilot [workspace]` | Run GitHub Copilot CLI |
 | `moat codex [workspace]` | Run Codex |
+| `moat gemini [workspace]` | Run Gemini CLI |
+| `moat pi [workspace]` | Run the Pi coding agent |
 | `moat run [path] [-- cmd]` | Run an agent |
 | `moat join <run> <agent>` | Run another agent in a running container |
-| `moat attach <run-id>` | Attach to a running agent |
+| `moat open [agent] [endpoint]` | Open an agent's endpoint in your browser |
 | `moat grant <provider>` | Store credentials (github, anthropic, openai, aws, ssh) |
 | `moat grant list` | List stored credentials |
 | `moat revoke <provider>` | Remove credentials |

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,8 @@
 - [Running Claude Code](./content/guides/01-claude-code.md) — Use Claude Code in isolated containers
 - [Running Codex](./content/guides/02-codex.md) — Use OpenAI Codex CLI in isolated containers
 - [Running Gemini](./content/guides/03-gemini.md) — Use Google Gemini CLI in isolated containers
+- [Running Pi](./content/guides/16-pi.md) — Use the Pi coding agent with an existing Anthropic or OpenAI grant
+- [Running GitHub Copilot CLI](./content/guides/17-copilot.md) — Use Copilot CLI with the GitHub grant
 - [SSH Access](./content/guides/04-ssh.md) — Grant SSH access without exposing private keys
 - [Secrets Management](./content/guides/05-secrets.md) — Pull secrets from 1Password and AWS SSM
 - [Exposing Ports](./content/guides/06-ports.md) — Access services running inside agent containers
@@ -32,6 +34,11 @@
 - [MCP Servers](./content/guides/09-mcp.md) — Configure remote and local MCP servers
 - [Lifecycle Hooks](./content/guides/10-hooks.md) — Run commands during image build and container startup
 - [Observability](./content/guides/11-observability.md) — View logs, traces, and audit data
+- [Git Worktrees](./content/guides/12-worktrees.md) — Parallel work on multiple branches, each in its own container
+- [Workspace Sharing](./content/guides/13-workspace-sharing.md) — Isolate platform-specific dependency directories with mount excludes
+- [Volume-Mode Workspaces](./content/guides/15-volume-workspaces.md) — Run against an isolated copy of the workspace in an ephemeral Docker volume
+- [Multi-Agent Sessions](./content/guides/14-multi-agent.md) — Run a second agent inside a running container with `moat join`
+- [Recipes](./content/guides/13-recipes.md) — Complete `moat.yaml` examples for common project types
 
 ### Reference
 
@@ -41,6 +48,8 @@
 - [Grants Reference](./content/reference/04-grants.md) — All grant types, credential sources, and injection details
 - [Mount Syntax](./content/reference/05-mounts.md) — Mount format, path resolution, and access modes
 - [Dependencies Reference](./content/reference/06-dependencies.md) — Dependency types, version resolution, and base images
+- [Provider YAML Reference](./content/reference/07-provider-yaml.md) — Schema for YAML-defined credential providers
+- [Troubleshooting](./content/reference/08-troubleshooting.md) — Error-to-fix lookup for proxy, auth, credential, and runtime errors
 
 ---
 

--- a/docs/content/reference/04-grants.md
+++ b/docs/content/reference/04-grants.md
@@ -136,6 +136,8 @@ moat grant claude       # OAuth token (for moat claude / Claude Code)
 moat grant anthropic    # API key (for any agent or tool)
 ```
 
+`moat pi` runs on the `anthropic` grant when that is its resolved backend. Pi has no credential of its own — see [Running Pi](../guides/16-pi.md) for how the backend is chosen.
+
 No flags.
 
 ### `moat grant claude`
@@ -248,6 +250,8 @@ No flags.
 The proxy injects an `Authorization: Bearer <token>` header for requests to `api.openai.com`, `chatgpt.com`, and `*.openai.com`.
 
 The container receives `OPENAI_API_KEY` set to a format-valid placeholder so OpenAI SDKs work without prompting.
+
+`moat pi` runs on this grant when `openai` is its resolved backend. See [Running Pi](../guides/16-pi.md).
 
 ### Refresh behavior
 


### PR DESCRIPTION
Release prep for **v0.7.0**. Docs-only — no Go changes.

## CHANGELOG

`## Unreleased` → `## v0.7.0 — 2026-08-01`, and the summary paragraph rewritten. The old summary led with Keep body policies and volumes and never mentioned `moat pi` or `moat copilot` — the two headline additions of this release.

Audited every commit since `v0.6.1` (39 of them) against the entry list: all user-facing changes are already recorded. The rest are refactors (`#420`–`#429`), lint/format/CI (`#413`–`#419`, `#432`), and follow-up polish folded into an existing entry (`#411` into the port-in-use entry).

## Docs audit

Checked each unreleased feature for reference + guide coverage — `moat open`, the discovery index, `opentofu`/`terragrunt`, `type: volume`, `workspace.mode`, `params.body`, `MOAT_KEYRING_BACKEND`, `moat copilot`, `moat pi`, `pi.packages`, `reasoning_effort`. **All present.** The `docs/content` pages are in sync; the gaps were in the index/overview surfaces around them:

- **`docs/README.md`** was missing nine pages — the worktrees, workspace-sharing, volume-workspaces, multi-agent, recipes, Pi, and Copilot guides, plus the provider-yaml and troubleshooting references. Several predate this release.
- **`README.md`** listed `moat attach`, which no longer exists (verified against `moat --help`), and omitted `moat gemini`, `moat pi`, and `moat open`. Added Gemini and Pi quick-start sections alongside the existing three agents.
- **`docs/content/reference/04-grants.md`** documented which agent uses each credential for Claude, Codex, Gemini, and Copilot, but never mentioned Pi. Added a pointer from both the Anthropic and OpenAI sections to the Pi guide's backend-resolution rules.

No version pins exist in `docs/content`, and the goreleaser build takes its version from the tag, so nothing else needs bumping.

## Verification

- Every relative link added or touched resolves to a real file (checked).
- No `#NNN` placeholders remain in the CHANGELOG (CI gate).
- `moat grant gemini` and `moat grant providers` output verified against a live build before documenting them.

## Not included

Two things surfaced during the audit that are code, not docs, so they are not in this PR — see the review comment below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)