### PR TITLE
refactor(provider): declare agent-only providers via an interface

### DIFF
--- a/cmd/moat/cli/grant_providers.go
+++ b/cmd/moat/cli/grant_providers.go
@@ -53,13 +53,15 @@ var goProviderCLINames = map[string]string{
 	"codex": "openai",
 }
 
-// agentOnlyProviders are registered as CredentialProviders to carry agent
-// runtime behavior, but have no credential of their own — their Grant()
-// always errors and points at the real grant. Listing them under
-// 'moat grant providers' invites users to run a command that cannot work.
-var agentOnlyProviders = map[string]bool{
-	"copilot": true, // runs on the github grant
-	"pi":      true, // runs on the anthropic or openai grant
+// isAgentOnly reports whether a provider has no credential of its own — it
+// runs on another provider's grant and its Grant() always errors. Listing one
+// under 'moat grant providers' invites users to run a command that cannot
+// work. Providers declare this themselves via provider.AgentOnlyProvider, so a
+// new agent runtime that borrows a grant is excluded by implementing the
+// interface rather than by being added to a list here.
+func isAgentOnly(p provider.CredentialProvider) bool {
+	_, ok := p.(provider.AgentOnlyProvider)
+	return ok
 }
 
 type providerInfo struct {
@@ -77,7 +79,7 @@ func grantProviderInfos() []providerInfo {
 	for _, p := range all {
 		// Agent-only providers cannot be granted directly — skip them so the
 		// listing only shows names that work as 'moat grant <name>'.
-		if agentOnlyProviders[p.Name()] {
+		if isAgentOnly(p) {
 			continue
 		}
 		// Show the CLI-facing name where it differs from the canonical one.

--- a/cmd/moat/cli/grant_providers.go
+++ b/cmd/moat/cli/grant_providers.go
@@ -28,8 +28,8 @@ func init() {
 }
 
 // goProviderDescriptions provides descriptions for Go-implemented providers
-// that don't implement DescribableProvider. Every provider that survives
-// agentOnlyProviders needs an entry here or its own Description() — a blank
+// that don't implement DescribableProvider. Every provider that survives the
+// isAgentOnly filter needs an entry here or its own Description() — a blank
 // description column is a bug, and TestGrantProviderInfosAllDescribed guards it.
 var goProviderDescriptions = map[string]string{
 	"github":    "GitHub token",

--- a/cmd/moat/cli/grant_providers_test.go
+++ b/cmd/moat/cli/grant_providers_test.go
@@ -15,18 +15,67 @@ import (
 // Agent-only providers register as CredentialProviders but their Grant()
 // always errors, so listing them tells users to run a command that cannot work.
 func TestGrantProviderInfosExcludesAgentOnly(t *testing.T) {
-	for name := range agentOnlyProviders {
-		if provider.Get(name) == nil {
+	// Checked by literal name so that dropping the marker from a provider
+	// fails here rather than silently narrowing the test to whatever still
+	// implements the interface.
+	for _, name := range []string{"pi", "copilot"} {
+		p := provider.Get(name)
+		if p == nil {
 			t.Fatalf("provider %q is not registered — this test would pass vacuously", name)
+		}
+		if _, ok := p.(provider.AgentOnlyProvider); !ok {
+			t.Errorf("provider %q has no credential of its own and must implement provider.AgentOnlyProvider", name)
 		}
 	}
 
-	// Checked by literal name, not via agentOnlyProviders, so that deleting an
-	// entry from that map fails here instead of silently narrowing the test.
 	excluded := map[string]bool{"pi": true, "copilot": true}
 	for _, info := range grantProviderInfos() {
-		if excluded[info.Name] || agentOnlyProviders[info.Name] {
+		if excluded[info.Name] {
 			t.Errorf("agent-only provider %q must not be listed under 'moat grant providers'", info.Name)
+		}
+	}
+}
+
+// The structural half of the guard: whatever declares itself agent-only stays
+// out of the listing, including providers added after this test was written.
+func TestGrantProviderInfosExcludesEveryAgentOnlyMarker(t *testing.T) {
+	markers := make(map[string]bool)
+	for _, p := range provider.All() {
+		if _, ok := p.(provider.AgentOnlyProvider); ok {
+			markers[p.Name()] = true
+		}
+	}
+	if len(markers) == 0 {
+		t.Fatal("no registered provider implements AgentOnlyProvider — this test would pass vacuously")
+	}
+
+	for _, info := range grantProviderInfos() {
+		if markers[info.Name] {
+			t.Errorf("provider %q implements AgentOnlyProvider but is still listed", info.Name)
+		}
+	}
+}
+
+// Companion direction: the marker must not swallow providers that do have a
+// credential of their own. Every agent provider that owns a grant stays listed.
+func TestGrantProviderInfosKeepsCredentialOwningAgents(t *testing.T) {
+	listed := make(map[string]bool)
+	for _, info := range grantProviderInfos() {
+		listed[info.Name] = true
+	}
+
+	// gemini owns its credential; claude and codex own theirs and are listed
+	// under the names users type (codex as its openai alias).
+	for _, name := range []string{"gemini", "claude", "openai"} {
+		p := provider.Get(name)
+		if p == nil {
+			t.Fatalf("provider %q is not registered — this test would pass vacuously", name)
+		}
+		if _, ok := p.(provider.AgentOnlyProvider); ok {
+			t.Errorf("provider %q owns a credential and must not be marked agent-only", name)
+		}
+		if !listed[name] {
+			t.Errorf("credential-owning provider %q should be listed", name)
 		}
 	}
 }

--- a/internal/provider/interfaces.go
+++ b/internal/provider/interfaces.go
@@ -130,6 +130,20 @@ type DescribableProvider interface {
 	Source() string // "builtin" or "custom"
 }
 
+// AgentOnlyProvider is an optional interface for providers that register as
+// CredentialProviders to carry agent runtime behavior but have no credential
+// of their own — they run on another provider's grant, and their Grant()
+// always errors pointing at it (see the pi and copilot providers).
+//
+// Credential listings such as 'moat grant providers' must exclude these, so
+// they never advertise a `moat grant <name>` that cannot work. Implement it on
+// any agent provider that borrows another grant, and say which one in the
+// method's doc comment.
+type AgentOnlyProvider interface {
+	// AgentOnly is a marker method; it does nothing.
+	AgentOnly()
+}
+
 // InitFileProvider is an optional interface for providers that need config
 // files written into the container at startup. The run manager collects
 // init files from all providers and passes them to moat-init.sh via the

--- a/internal/providers/copilot/provider.go
+++ b/internal/providers/copilot/provider.go
@@ -16,6 +16,7 @@ type Provider struct{}
 var (
 	_ provider.CredentialProvider = (*Provider)(nil)
 	_ provider.AgentProvider      = (*Provider)(nil)
+	_ provider.AgentOnlyProvider  = (*Provider)(nil)
 )
 
 func init() {
@@ -24,6 +25,10 @@ func init() {
 
 // Name returns the provider identifier.
 func (p *Provider) Name() string { return copilotProviderName }
+
+// AgentOnly marks Copilot as having no credential of its own: it runs on the
+// github grant, so credential listings exclude it.
+func (p *Provider) AgentOnly() {}
 
 // Grant intentionally does not acquire a separate credential. Copilot CLI uses
 // the github grant so there is one GitHub token to rotate and audit.

--- a/internal/providers/pi/provider.go
+++ b/internal/providers/pi/provider.go
@@ -20,6 +20,7 @@ type Provider struct{}
 var (
 	_ provider.CredentialProvider = (*Provider)(nil)
 	_ provider.AgentProvider      = (*Provider)(nil)
+	_ provider.AgentOnlyProvider  = (*Provider)(nil)
 )
 
 func init() {
@@ -28,6 +29,10 @@ func init() {
 
 // Name returns the provider identifier.
 func (p *Provider) Name() string { return "pi" }
+
+// AgentOnly marks Pi as having no credential of its own: it runs on the
+// anthropic or openai grant, so credential listings exclude it.
+func (p *Provider) AgentOnly() {}
 
 // Grant always errors: Pi has no credential of its own. Users grant a model
 // backend with `moat grant anthropic` or `moat grant openai` instead.


### PR DESCRIPTION
Follow-up to the non-blocking review note on [#447](https://github.com/majorcontext/moat/pull/447).

## Problem

`moat grant providers` excluded `pi` and `copilot` via a name list in the CLI:

```go
var agentOnlyProviders = map[string]bool{
	"copilot": true,
	"pi":      true,
}
```

Nothing tied that list to the property it encoded. A future agent runtime that borrows another provider's grant — the exact shape of `pi` and `copilot` — would compile, pass every existing test, and silently reappear in the listing advertising a `moat grant <name>` that can only error. That is the bug #447 fixed, re-openable by omission.

## Change

The declaration moves to the provider, next to the `Grant()` that errors because of it:

```go
// AgentOnlyProvider is an optional interface for providers that register as
// CredentialProviders to carry agent runtime behavior but have no credential
// of their own — they run on another provider's grant, and their Grant()
// always errors pointing at it.
type AgentOnlyProvider interface {
	AgentOnly()
}
```

`pi` and `copilot` implement it and carry the compile-time assertion alongside their existing ones (`_ provider.AgentOnlyProvider = (*Provider)(nil)`), and `grantProviderInfos()` filters on the interface instead of the map.

## Tests

- **Structural direction** — every registered provider implementing the marker is absent from the listing. This covers providers written after today, which the name list could not. It fails loudly if nothing implements the marker, so it cannot pass vacuously.
- **Literal direction** — `pi` and `copilot` are checked by name and asserted to implement the interface, so dropping a marker fails here rather than silently narrowing the structural test to whatever is left.
- **Companion direction** — `gemini`, `claude`, and `openai` own their credentials: asserted to be listed *and* to not carry the marker, so the exclusion can't over-reach.

Verified the guards bite: removing the marker from `pi` produces three failures (missing interface, `pi` listed again, `pi` undescribed). Restored, all seven tests pass.

`make lint` clean. `make test-unit` passes except the pre-existing network-dependent `TestRegistryGithubBinaryURLsExist`, which fails the same way on `main`.

## Scope

No user-visible change — the listing output is byte-identical, so there is no CHANGELOG entry. v0.7.0 already shipped the behavior; this only changes how it is enforced.

**What this does not solve:** an author who writes a new borrows-a-grant provider and never implements the interface still slips through. Fully automating that would mean calling `Grant()` on every registered provider to see if it always errors, which is not safe in a test — real providers prompt, hit the keychain, and make network calls. The marker plus the sibling examples in `pi`/`copilot` make it a visible convention instead of an invisible one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)