### PR TITLE
chore: drop legacy env and redundant grant from moat.yaml

### DIFF
--- a/moat.yaml
+++ b/moat.yaml
@@ -2,10 +2,6 @@ name: moat-dev
 agents: [claude, codex]
 interactive: true
 
-env:
-  ANTHROPIC_MODEL: opus
-  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: 1
-
 container:
   memory: 12192
   cpus: 16
@@ -24,7 +20,6 @@ dependencies:
   - docker:dind
 
 grants:
-  - claude
   - github
   - ssh:github.com
 


### PR DESCRIPTION
## Summary

Two leftovers in this repo's own dev `moat.yaml`.

**The `claude` grant is redundant.** `agents: [claude, codex]` already derives it via `ExpandAgents` → `CredentialGrant`, so the resolved grant set is identical either way. Verified with `moat run --dry-run --verbose`:

```
before: grants="[claude github ssh:github.com openai]"
after:  grants="[github ssh:github.com claude openai]"
```

Same set, different order. No behavior change.

**The `env:` block is a deliberate behavior change.** Pinning `ANTHROPIC_MODEL: opus` here forced every run in this repo onto opus regardless of how the operator configured their own credentials. That surfaced concretely while testing gateway support: a run against an Anthropic-compatible gateway inherited the pin, the gateway doesn't serve that model id, and Claude Code reported

> There's an issue with the selected model (claude-opus-5). It may not exist or you may not have access to it.

The project checkout is the wrong place to choose a model — that belongs to whoever is running the agent. `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` goes with it.

## Impact on other contributors

Anyone who wants the old behavior can set either variable per run (`-e ANTHROPIC_MODEL=opus`) or per identity in `~/.moat/config.yaml`. Runs with no explicit model now use whatever the operator's Claude Code defaults to.

## Relationship to #456–#458

Independent — cut from `main` deliberately, so it can land without waiting on that stack or forcing a re-review of it. The gateway work is what surfaced the model pin, but nothing here depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)